### PR TITLE
feat(console): worktree cards with live TodoWrite state (MVP-1, MVP-3)

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -39,5 +39,11 @@
   "engines": {
     "node": ">=22"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@10.33.2",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "electron",
+      "esbuild"
+    ]
+  }
 }

--- a/console/src/main/config.ts
+++ b/console/src/main/config.ts
@@ -7,6 +7,7 @@ import type {
   AgentConfig,
   ProjectConfig,
   RanchConfig,
+  WorktreePorts,
 } from '../shared/types.js';
 
 const RANCH_DIR = process.env.RANCH_HOME ?? join(homedir(), '.ranch');
@@ -16,6 +17,19 @@ const PROJECTS_PATH = join(RANCH_DIR, 'projects.toml');
 interface AgentSection {
   worktree?: unknown;
   description?: unknown;
+  ports?: unknown;
+}
+
+function parsePortsBlock(raw: unknown): WorktreePorts | undefined {
+  if (!isObject(raw)) return undefined;
+  const out: WorktreePorts = {};
+  for (const key of ['django', 'vite'] as const) {
+    const v = raw[key];
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0 && v < 65536) {
+      out[key] = v;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 interface ProjectSection {
@@ -45,6 +59,8 @@ function parseAgents(raw: unknown): AgentConfig[] {
     if (typeof section.description === 'string') {
       agent.description = section.description;
     }
+    const ports = parsePortsBlock(section.ports);
+    if (ports !== undefined) agent.ports = ports;
     agents.push(agent);
   }
   return agents;

--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -1,8 +1,24 @@
+/**
+ * IPC handler registration.
+ *
+ * One channel per typed RanchApi method. The channel string lives both
+ * here (registration) and in src/preload/index.ts (caller). They MUST
+ * stay in sync — easy to grep, easy to keep small.
+ *
+ * `ipcMain.handle(channel, fn)` registers a request/response handler.
+ * Renderer-side `ipcRenderer.invoke(channel, ...args)` returns a
+ * Promise resolving to whatever this handler returns.
+ */
+
 import { app, ipcMain } from 'electron';
 import { loadRanchConfig } from './config.js';
+import { listWorktrees } from './worktrees.js';
+import { getActiveSession } from './transcript.js';
 
 export const IPC_CHANNELS = {
   configGet: 'ranch:config:get',
+  worktreesList: 'ranch:worktrees:list',
+  worktreesSession: 'ranch:worktrees:session',
   appVersion: 'ranch:app:version',
 } as const;
 
@@ -10,6 +26,26 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.configGet, async () => {
     return loadRanchConfig();
   });
+
+  ipcMain.handle(IPC_CHANNELS.worktreesList, async () => {
+    return listWorktrees();
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.worktreesSession,
+    async (_event, agent: unknown) => {
+      if (typeof agent !== 'string' || !agent) {
+        throw new Error('worktrees.session requires an agent name');
+      }
+      // Re-read config on each call: it's tiny and rarely changes.
+      const config = await loadRanchConfig();
+      const match = config.agents.find((a) => a.name === agent);
+      if (!match) {
+        throw new Error(`Unknown agent: ${agent}`);
+      }
+      return getActiveSession(match.worktree);
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.appVersion, () => {
     return app.getVersion();

--- a/console/src/main/transcript.ts
+++ b/console/src/main/transcript.ts
@@ -1,0 +1,251 @@
+/**
+ * MVP-3 — find a worktree's most-recent CC session transcript and
+ * extract the live state we want to surface on the card:
+ *
+ *   - latest TodoWrite list (the killer feature)
+ *   - most recent user prompt text (for topic derivation)
+ *   - last-activity timestamp
+ *   - gitBranch CC last recorded
+ *
+ * Transcript layout (CC convention):
+ *   ~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl
+ *
+ * where `<encoded-cwd>` is the absolute worktree path with `/` replaced
+ * by `-`. Each line is one event. We walk the file backward to avoid
+ * loading megabytes when the only thing we need is the tail.
+ */
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { SessionState, TodoItem, TodoStatus } from '../shared/types.js';
+
+const PROJECTS_DIR = join(homedir(), '.claude', 'projects');
+
+export function encodeWorktreePath(worktreePath: string): string {
+  // Drop the leading slash so we don't end up with double dashes.
+  const trimmed = worktreePath.replace(/^\/+/, '');
+  return '-' + trimmed.replace(/\//g, '-');
+}
+
+/**
+ * The directory CC writes session JSONL to. Returns null if no
+ * directory exists yet (i.e. CC has never been run for this worktree).
+ */
+function projectsDirFor(worktreePath: string): string | null {
+  const dir = join(PROJECTS_DIR, encodeWorktreePath(worktreePath));
+  return existsSync(dir) ? dir : null;
+}
+
+interface SessionFileInfo {
+  sessionId: string;
+  path: string;
+  mtimeMs: number;
+}
+
+async function findMostRecentSession(
+  dir: string,
+): Promise<SessionFileInfo | null> {
+  const entries = await readdir(dir);
+  let newest: SessionFileInfo | null = null;
+  for (const name of entries) {
+    if (!name.endsWith('.jsonl')) continue;
+    const path = join(dir, name);
+    const s = await stat(path);
+    if (!s.isFile()) continue;
+    if (newest === null || s.mtimeMs > newest.mtimeMs) {
+      newest = {
+        sessionId: name.replace(/\.jsonl$/, ''),
+        path,
+        mtimeMs: s.mtimeMs,
+      };
+    }
+  }
+  return newest;
+}
+
+interface ParsedEntry {
+  raw: Record<string, unknown>;
+}
+
+/**
+ * Parse a single JSONL line. Real transcripts can have partial writes
+ * mid-stream, so we tolerate failure and let the caller skip.
+ */
+function parseLine(line: string): ParsedEntry | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    const raw: unknown = JSON.parse(trimmed);
+    if (typeof raw === 'object' && raw !== null && !Array.isArray(raw)) {
+      return { raw: raw as Record<string, unknown> };
+    }
+  } catch {
+    // Partial line during a concurrent write; skip.
+  }
+  return null;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined;
+}
+
+function asArray(v: unknown): unknown[] | undefined {
+  return Array.isArray(v) ? v : undefined;
+}
+
+function asObject(v: unknown): Record<string, unknown> | undefined {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined;
+}
+
+function getMessageContent(entry: Record<string, unknown>): unknown[] {
+  const message = asObject(entry['message']);
+  if (message) {
+    const c = asArray(message['content']);
+    if (c) return c;
+  }
+  const direct = asArray(entry['content']);
+  return direct ?? [];
+}
+
+function isTodoStatus(v: unknown): v is TodoStatus {
+  return v === 'pending' || v === 'in_progress' || v === 'completed';
+}
+
+function extractTodos(entry: Record<string, unknown>): TodoItem[] | null {
+  const content = getMessageContent(entry);
+  for (const block of content) {
+    const obj = asObject(block);
+    if (!obj) continue;
+    if (obj['type'] !== 'tool_use') continue;
+    if (obj['name'] !== 'TodoWrite') continue;
+    const input = asObject(obj['input']);
+    const todosRaw = asArray(input?.['todos']);
+    if (!todosRaw) continue;
+    const todos: TodoItem[] = [];
+    for (const t of todosRaw) {
+      const todoObj = asObject(t);
+      if (!todoObj) continue;
+      const content = asString(todoObj['content']);
+      const status = todoObj['status'];
+      if (!content || !isTodoStatus(status)) continue;
+      const item: TodoItem = { content, status };
+      const activeForm = asString(todoObj['activeForm']);
+      if (activeForm !== undefined) item.activeForm = activeForm;
+      todos.push(item);
+    }
+    return todos;
+  }
+  return null;
+}
+
+function extractUserPromptText(entry: Record<string, unknown>): string | null {
+  const t = entry['type'];
+  if (t !== 'user') return null;
+  const message = asObject(entry['message']);
+  if (!message) return null;
+  const content = message['content'];
+  if (typeof content === 'string') {
+    const trimmed = content.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  const arr = asArray(content);
+  if (!arr) return null;
+  for (const block of arr) {
+    const obj = asObject(block);
+    if (!obj) continue;
+    if (obj['type'] === 'text') {
+      const text = asString(obj['text']);
+      if (text && text.trim().length > 0) return text.trim();
+    }
+  }
+  return null;
+}
+
+interface TranscriptScan {
+  todos: TodoItem[];
+  lastUserPrompt?: string;
+  lastActivityAt?: string;
+  gitBranch?: string;
+}
+
+/**
+ * Walk entries newest → oldest. Stop early once we have everything.
+ */
+function scanEntries(entries: ParsedEntry[]): TranscriptScan {
+  const result: TranscriptScan = { todos: [] };
+  let foundTodos = false;
+  let foundPrompt = false;
+
+  // First pass: capture lastActivityAt + gitBranch from the newest entry
+  // that has them. Walk backward.
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i]!.raw;
+    if (result.lastActivityAt === undefined) {
+      const ts = asString(entry['timestamp']);
+      if (ts) result.lastActivityAt = ts;
+    }
+    if (result.gitBranch === undefined) {
+      const gb = asString(entry['gitBranch']);
+      if (gb) result.gitBranch = gb;
+    }
+    if (!foundTodos) {
+      const todos = extractTodos(entry);
+      if (todos) {
+        result.todos = todos;
+        foundTodos = true;
+      }
+    }
+    if (!foundPrompt) {
+      const prompt = extractUserPromptText(entry);
+      if (prompt) {
+        result.lastUserPrompt = prompt;
+        foundPrompt = true;
+      }
+    }
+    if (
+      foundTodos &&
+      foundPrompt &&
+      result.lastActivityAt !== undefined &&
+      result.gitBranch !== undefined
+    ) {
+      break;
+    }
+  }
+  return result;
+}
+
+export async function getActiveSession(
+  worktreePath: string,
+): Promise<SessionState> {
+  const dir = projectsDirFor(worktreePath);
+  if (!dir) {
+    return { status: 'none', todos: [] };
+  }
+  const newest = await findMostRecentSession(dir);
+  if (!newest) {
+    return { status: 'none', todos: [] };
+  }
+  const raw = await readFile(newest.path, 'utf8');
+  const entries: ParsedEntry[] = [];
+  for (const line of raw.split('\n')) {
+    const parsed = parseLine(line);
+    if (parsed) entries.push(parsed);
+  }
+  const scan = scanEntries(entries);
+  const state: SessionState = {
+    status: 'active',
+    sessionId: newest.sessionId,
+    transcriptPath: newest.path,
+    todos: scan.todos,
+  };
+  if (scan.lastActivityAt !== undefined)
+    state.lastActivityAt = scan.lastActivityAt;
+  if (scan.lastUserPrompt !== undefined)
+    state.lastUserPrompt = scan.lastUserPrompt;
+  if (scan.gitBranch !== undefined) state.gitBranch = scan.gitBranch;
+  return state;
+}

--- a/console/src/main/worktrees.ts
+++ b/console/src/main/worktrees.ts
@@ -51,8 +51,13 @@ function parsePort(raw: string | undefined): number | undefined {
   return Number.isFinite(n) && n > 0 && n < 65536 ? n : undefined;
 }
 
-async function readEnvAgent(envAgentPath: string): Promise<WorktreePorts> {
-  if (!existsSync(envAgentPath)) return {};
+interface EnvAgentRead {
+  ports: WorktreePorts;
+  envAgentName?: string;
+}
+
+async function readEnvAgent(envAgentPath: string): Promise<EnvAgentRead> {
+  if (!existsSync(envAgentPath)) return { ports: {} };
   const contents = await readFile(envAgentPath, 'utf8');
   const parsed = parseDotEnv(contents);
   const ports: WorktreePorts = {};
@@ -60,23 +65,49 @@ async function readEnvAgent(envAgentPath: string): Promise<WorktreePorts> {
   const vite = parsePort(parsed['VITE_PORT']);
   if (django !== undefined) ports.django = django;
   if (vite !== undefined) ports.vite = vite;
-  return ports;
+  const result: EnvAgentRead = { ports };
+  if (typeof parsed['AGENT_NAME'] === 'string' && parsed['AGENT_NAME']) {
+    result.envAgentName = parsed['AGENT_NAME'];
+  }
+  return result;
 }
 
 async function inspectAgent(agent: AgentConfig): Promise<WorktreeBasics> {
   const envAgentPath = join(agent.worktree, ENV_AGENT_FILENAME);
   const envAgentExists = existsSync(envAgentPath);
-  const ports = envAgentExists ? await readEnvAgent(envAgentPath) : {};
+  const env = envAgentExists
+    ? await readEnvAgent(envAgentPath)
+    : { ports: {} as WorktreePorts };
+  const envAgentMatches =
+    env.envAgentName === undefined || env.envAgentName === agent.name;
+
+  // Operator-canonical ports from ~/.ranch/config.toml win over .env.agent
+  // because the agents themselves can (and do) clobber the .env.agent file.
+  let ports: WorktreePorts;
+  let portsSource: WorktreeBasics['portsSource'];
+  if (agent.ports && (agent.ports.django || agent.ports.vite)) {
+    ports = { ...agent.ports };
+    portsSource = 'ranch-config';
+  } else if (env.ports.django !== undefined || env.ports.vite !== undefined) {
+    ports = env.ports;
+    portsSource = 'env-agent';
+  } else {
+    ports = {};
+    portsSource = 'unknown';
+  }
+
   const basics: WorktreeBasics = {
     agent: agent.name,
     worktreePath: agent.worktree,
     envAgentPath,
     envAgentExists,
+    envAgentMatches,
     ports,
+    portsSource,
+    envAgentPorts: env.ports,
   };
-  if (agent.description !== undefined) {
-    basics.description = agent.description;
-  }
+  if (agent.description !== undefined) basics.description = agent.description;
+  if (env.envAgentName !== undefined) basics.envAgentName = env.envAgentName;
   return basics;
 }
 

--- a/console/src/main/worktrees.ts
+++ b/console/src/main/worktrees.ts
@@ -1,0 +1,86 @@
+/**
+ * MVP-1 — read per-worktree basics from .env.agent.
+ *
+ * This module never writes. Source of truth is whatever
+ * citemed_web's `make init-agent` already produced; ranch
+ * just observes.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadRanchConfig } from './config.js';
+import type {
+  WorktreeBasics,
+  WorktreePorts,
+  AgentConfig,
+} from '../shared/types.js';
+
+const ENV_AGENT_FILENAME = '.env.agent';
+
+/**
+ * Parse a minimal subset of dotenv syntax: `KEY=VALUE` per line, ignoring
+ * comments and blank lines. We deliberately don't run shell expansion or
+ * variable substitution — `.env.agent` for the four hardcoded worktrees
+ * has flat literal values and we want a parser that can't surprise us.
+ */
+function parseDotEnv(contents: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    // Strip matching surrounding quotes if present.
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function parsePort(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 && n < 65536 ? n : undefined;
+}
+
+async function readEnvAgent(envAgentPath: string): Promise<WorktreePorts> {
+  if (!existsSync(envAgentPath)) return {};
+  const contents = await readFile(envAgentPath, 'utf8');
+  const parsed = parseDotEnv(contents);
+  const ports: WorktreePorts = {};
+  const django = parsePort(parsed['DJANGO_PORT']);
+  const vite = parsePort(parsed['VITE_PORT']);
+  if (django !== undefined) ports.django = django;
+  if (vite !== undefined) ports.vite = vite;
+  return ports;
+}
+
+async function inspectAgent(agent: AgentConfig): Promise<WorktreeBasics> {
+  const envAgentPath = join(agent.worktree, ENV_AGENT_FILENAME);
+  const envAgentExists = existsSync(envAgentPath);
+  const ports = envAgentExists ? await readEnvAgent(envAgentPath) : {};
+  const basics: WorktreeBasics = {
+    agent: agent.name,
+    worktreePath: agent.worktree,
+    envAgentPath,
+    envAgentExists,
+    ports,
+  };
+  if (agent.description !== undefined) {
+    basics.description = agent.description;
+  }
+  return basics;
+}
+
+export async function listWorktrees(): Promise<WorktreeBasics[]> {
+  const config = await loadRanchConfig();
+  return Promise.all(config.agents.map(inspectAgent));
+}

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -1,14 +1,32 @@
+/**
+ * Preload script — the bridge between renderer (sandboxed Chromium) and
+ * main (Node.js). Runs in the renderer's process but with elevated
+ * privileges before the page loads.
+ *
+ * `contextBridge.exposeInMainWorld('ranch', api)` injects a typed
+ * `window.ranch` into every page. The renderer can ONLY call methods
+ * we put on this object — everything else stays on the other side
+ * of the wall. That's the security guarantee.
+ */
+
 import { contextBridge, ipcRenderer } from 'electron';
 import type { RanchApi } from '../shared/types.js';
 
 const IPC_CHANNELS = {
   configGet: 'ranch:config:get',
+  worktreesList: 'ranch:worktrees:list',
+  worktreesSession: 'ranch:worktrees:session',
   appVersion: 'ranch:app:version',
 } as const;
 
 const api: RanchApi = {
   config: {
     get: () => ipcRenderer.invoke(IPC_CHANNELS.configGet),
+  },
+  worktrees: {
+    list: () => ipcRenderer.invoke(IPC_CHANNELS.worktreesList),
+    session: (agent) =>
+      ipcRenderer.invoke(IPC_CHANNELS.worktreesSession, agent),
   },
   app: {
     version: () => ipcRenderer.invoke(IPC_CHANNELS.appVersion),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -163,10 +163,11 @@ function WorktreeCard({ worktree }: WorktreeCardProps): JSX.Element {
       <BranchRow session={session} />
       <TopicLine session={session} />
       <TodoSummary todos={session?.todos ?? []} />
-      <PortsRow ports={worktree.ports} />
+      <PortsRow ports={worktree.ports} source={worktree.portsSource} />
+      <DriftWarnings worktree={worktree} />
       {!worktree.envAgentExists && (
         <p className="card__warn">
-          No <code>.env.agent</code> at this worktree — ports unknown.
+          No <code>.env.agent</code> at this worktree.
         </p>
       )}
     </article>
@@ -252,8 +253,10 @@ function TodoSummary({ todos }: { todos: TodoItem[] }): JSX.Element | null {
 
 function PortsRow({
   ports,
+  source,
 }: {
   ports: WorktreeBasics['ports'];
+  source: WorktreeBasics['portsSource'];
 }): JSX.Element | null {
   const buttons: { label: string; port: number }[] = [];
   if (ports.django !== undefined)
@@ -261,6 +264,12 @@ function PortsRow({
   if (ports.vite !== undefined)
     buttons.push({ label: 'Vite', port: ports.vite });
   if (buttons.length === 0) return null;
+  const sourceLabel =
+    source === 'ranch-config'
+      ? 'from ~/.ranch/config.toml'
+      : source === 'env-agent'
+        ? 'from .env.agent (may drift)'
+        : '';
   return (
     <div className="card__ports">
       {buttons.map((b) => (
@@ -270,9 +279,60 @@ function PortsRow({
           href={`http://localhost:${b.port}`}
           target="_blank"
           rel="noreferrer"
+          title={`${b.label} :${b.port} ${sourceLabel}`}
         >
           {b.label} <span className="port-button__num">:{b.port}</span>
         </a>
+      ))}
+    </div>
+  );
+}
+
+function DriftWarnings({
+  worktree,
+}: {
+  worktree: WorktreeBasics;
+}): JSX.Element | null {
+  const messages: string[] = [];
+
+  if (!worktree.envAgentMatches && worktree.envAgentName !== undefined) {
+    messages.push(
+      `.env.agent says AGENT_NAME=${worktree.envAgentName}, but this worktree is registered as ${worktree.agent}. Run \`make sync-env\` to repair.`,
+    );
+  }
+
+  if (worktree.portsSource === 'ranch-config') {
+    const drift: string[] = [];
+    if (
+      worktree.ports.django !== undefined &&
+      worktree.envAgentPorts.django !== undefined &&
+      worktree.ports.django !== worktree.envAgentPorts.django
+    ) {
+      drift.push(
+        `DJANGO_PORT (env: ${worktree.envAgentPorts.django}, config: ${worktree.ports.django})`,
+      );
+    }
+    if (
+      worktree.ports.vite !== undefined &&
+      worktree.envAgentPorts.vite !== undefined &&
+      worktree.ports.vite !== worktree.envAgentPorts.vite
+    ) {
+      drift.push(
+        `VITE_PORT (env: ${worktree.envAgentPorts.vite}, config: ${worktree.ports.vite})`,
+      );
+    }
+    if (drift.length > 0) {
+      messages.push(`.env.agent ports drift: ${drift.join(', ')}`);
+    }
+  }
+
+  if (messages.length === 0) return null;
+  return (
+    <div className="card__drift">
+      {messages.map((m, i) => (
+        <p key={i} className="card__warn">
+          ⚠ {m}
+        </p>
       ))}
     </div>
   );

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -1,38 +1,60 @@
 import { useEffect, useState } from 'react';
-import type { RanchConfig } from '../shared/types.js';
+import type {
+  SessionState,
+  TodoItem,
+  WorktreeBasics,
+} from '../shared/types.js';
 
-interface ConfigState {
+const SESSION_POLL_MS = 4000;
+const WORKTREE_POLL_MS = 30_000;
+
+interface AppState {
   status: 'loading' | 'ready' | 'error';
-  config?: RanchConfig;
+  worktrees: WorktreeBasics[];
   appVersion?: string;
   error?: string;
 }
 
 export function App(): JSX.Element {
-  const [state, setState] = useState<ConfigState>({ status: 'loading' });
+  const [state, setState] = useState<AppState>({
+    status: 'loading',
+    worktrees: [],
+  });
 
+  // Initial load + slow refresh of worktree basics (.env.agent rarely changes).
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
+
+    async function refreshWorktrees(initial = false): Promise<void> {
       try {
-        const [config, appVersion] = await Promise.all([
-          window.ranch.config.get(),
-          window.ranch.app.version(),
-        ]);
-        if (!cancelled) {
-          setState({ status: 'ready', config, appVersion });
+        const worktrees = await window.ranch.worktrees.list();
+        if (cancelled) return;
+        if (initial) {
+          const appVersion = await window.ranch.app.version();
+          if (cancelled) return;
+          setState({ status: 'ready', worktrees, appVersion });
+        } else {
+          setState((prev) => ({ ...prev, worktrees }));
         }
       } catch (err) {
         if (!cancelled) {
-          setState({
+          setState((prev) => ({
+            ...prev,
             status: 'error',
             error: err instanceof Error ? err.message : String(err),
-          });
+          }));
         }
       }
-    })();
+    }
+
+    void refreshWorktrees(true);
+    const handle = setInterval(() => {
+      void refreshWorktrees(false);
+    }, WORKTREE_POLL_MS);
+
     return () => {
       cancelled = true;
+      clearInterval(handle);
     };
   }, []);
 
@@ -47,11 +69,13 @@ export function App(): JSX.Element {
       <main className="app__layout">
         <section className="pane pane--grid">
           <h2>Worktree grid</h2>
-          <GridPlaceholder state={state} />
+          <Grid state={state} />
         </section>
         <section className="pane pane--terminal">
           <h2>Terminal</h2>
-          <p className="placeholder">No session selected.</p>
+          <p className="placeholder">
+            Embedded terminal coming in MVP-6 (tmux attach).
+          </p>
         </section>
         <section className="pane pane--inbox">
           <h2>Inbox</h2>
@@ -66,36 +90,226 @@ export function App(): JSX.Element {
   );
 }
 
-function GridPlaceholder({ state }: { state: ConfigState }): JSX.Element {
+function Grid({ state }: { state: AppState }): JSX.Element {
   if (state.status === 'loading') {
-    return <p className="placeholder">Loading config…</p>;
+    return <p className="placeholder">Loading worktrees…</p>;
   }
   if (state.status === 'error') {
     return (
       <p className="placeholder placeholder--error">Error: {state.error}</p>
     );
   }
-  const { agents, projects, configPath } = state.config!;
-  return (
-    <div>
-      <p className="config-summary">
-        Loaded <strong>{agents.length}</strong> agent
-        {agents.length === 1 ? '' : 's'} and <strong>{projects.length}</strong>{' '}
-        project{projects.length === 1 ? '' : 's'} from <code>{configPath}</code>
+  if (state.worktrees.length === 0) {
+    return (
+      <p className="placeholder">
+        No agents registered. Add some to <code>~/.ranch/config.toml</code>.
       </p>
-      {agents.length > 0 && (
-        <ul className="agent-list">
-          {agents.map((agent) => (
-            <li key={agent.name} className="agent-list__item">
-              <span className="agent-list__name">{agent.name}</span>
-              <span className="agent-list__path">{agent.worktree}</span>
-              {agent.description && (
-                <span className="agent-list__desc">{agent.description}</span>
-              )}
-            </li>
-          ))}
-        </ul>
-      )}
+    );
+  }
+  return (
+    <div className="grid">
+      {state.worktrees.map((wt) => (
+        <WorktreeCard key={wt.agent} worktree={wt} />
+      ))}
     </div>
   );
+}
+
+interface WorktreeCardProps {
+  worktree: WorktreeBasics;
+}
+
+function WorktreeCard({ worktree }: WorktreeCardProps): JSX.Element {
+  const [session, setSession] = useState<SessionState | null>(null);
+  const [sessionError, setSessionError] = useState<string | null>(null);
+
+  // Per-card transcript polling: cheap (file mtime + parse tail) and the
+  // freshness here is what makes the card actually useful.
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refresh(): Promise<void> {
+      try {
+        const next = await window.ranch.worktrees.session(worktree.agent);
+        if (!cancelled) {
+          setSession(next);
+          setSessionError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setSessionError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    }
+
+    void refresh();
+    const handle = setInterval(refresh, SESSION_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [worktree.agent]);
+
+  return (
+    <article className="card">
+      <header className="card__header">
+        <span className="card__name">{worktree.agent}</span>
+        <SessionPill session={session} error={sessionError} />
+      </header>
+      {worktree.description && (
+        <p className="card__desc">{worktree.description}</p>
+      )}
+      <p className="card__path">{worktree.worktreePath}</p>
+      <BranchRow session={session} />
+      <TopicLine session={session} />
+      <TodoSummary todos={session?.todos ?? []} />
+      <PortsRow ports={worktree.ports} />
+      {!worktree.envAgentExists && (
+        <p className="card__warn">
+          No <code>.env.agent</code> at this worktree — ports unknown.
+        </p>
+      )}
+    </article>
+  );
+}
+
+function SessionPill({
+  session,
+  error,
+}: {
+  session: SessionState | null;
+  error: string | null;
+}): JSX.Element {
+  if (error) return <span className="pill pill--error">err</span>;
+  if (!session) return <span className="pill">…</span>;
+  if (session.status === 'none') {
+    return <span className="pill pill--idle">no session</span>;
+  }
+  const age = relativeAge(session.lastActivityAt);
+  return <span className="pill pill--active">active · {age}</span>;
+}
+
+function BranchRow({
+  session,
+}: {
+  session: SessionState | null;
+}): JSX.Element | null {
+  const branch = session?.gitBranch;
+  if (!branch) return null;
+  const ticket = extractTicketId(branch);
+  return (
+    <p className="card__branch">
+      <span className="card__branch-name">{branch}</span>
+      {ticket && <span className="card__ticket">{ticket}</span>}
+    </p>
+  );
+}
+
+function TopicLine({
+  session,
+}: {
+  session: SessionState | null;
+}): JSX.Element | null {
+  if (!session || session.status === 'none') return null;
+  const inProgress = session.todos.find((t) => t.status === 'in_progress');
+  const topic =
+    inProgress?.activeForm ??
+    inProgress?.content ??
+    session.lastUserPrompt ??
+    null;
+  if (!topic) return null;
+  return <p className="card__topic">{truncate(topic, 140)}</p>;
+}
+
+function TodoSummary({ todos }: { todos: TodoItem[] }): JSX.Element | null {
+  if (todos.length === 0) return null;
+  const done = todos.filter((t) => t.status === 'completed').length;
+  const inProgress = todos.filter((t) => t.status === 'in_progress').length;
+  return (
+    <div className="card__todos">
+      <div className="card__todos-summary">
+        <strong>
+          {done} / {todos.length}
+        </strong>{' '}
+        complete
+        {inProgress > 0 && <span> · {inProgress} in progress</span>}
+      </div>
+      <ul className="todo-list">
+        {todos.map((t, i) => (
+          <li
+            key={i}
+            className={`todo todo--${t.status.replace('_', '-')}`}
+            title={t.content}
+          >
+            <span className="todo__icon">{todoIcon(t.status)}</span>
+            <span className="todo__text">{t.content}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PortsRow({
+  ports,
+}: {
+  ports: WorktreeBasics['ports'];
+}): JSX.Element | null {
+  const buttons: { label: string; port: number }[] = [];
+  if (ports.django !== undefined)
+    buttons.push({ label: 'Django', port: ports.django });
+  if (ports.vite !== undefined)
+    buttons.push({ label: 'Vite', port: ports.vite });
+  if (buttons.length === 0) return null;
+  return (
+    <div className="card__ports">
+      {buttons.map((b) => (
+        <a
+          key={b.label}
+          className="port-button"
+          href={`http://localhost:${b.port}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {b.label} <span className="port-button__num">:{b.port}</span>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+function todoIcon(status: TodoItem['status']): string {
+  switch (status) {
+    case 'completed':
+      return '✓';
+    case 'in_progress':
+      return '◐';
+    case 'pending':
+      return '○';
+  }
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}
+
+function extractTicketId(branch: string): string | null {
+  const m = /([A-Z]{2,}-\d+)/.exec(branch);
+  return m ? m[1]! : null;
+}
+
+function relativeAge(iso: string | undefined): string {
+  if (!iso) return '?';
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '?';
+  const sec = Math.max(0, Math.round((Date.now() - t) / 1000));
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  return `${day}d ago`;
 }

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -1,10 +1,15 @@
 :root {
   --bg: #0f1115;
   --bg-elevated: #161922;
+  --bg-card: #181c27;
   --border: #232838;
   --text: #e6e9ef;
   --text-muted: #9aa3b2;
+  --text-dim: #6b7384;
   --accent: #6aa2ff;
+  --green: #5cd47a;
+  --yellow: #f6c177;
+  --red: #ff6a6a;
   --error: #ff6a6a;
   font-family:
     -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto,
@@ -87,56 +92,233 @@ body,
   color: var(--error);
 }
 
-.config-summary {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-  margin: 0 0 0.75rem 0;
-}
-
-.config-summary code {
+.placeholder code {
   background: var(--bg-elevated);
   padding: 0.1rem 0.35rem;
   border-radius: 3px;
-  font-size: 0.8em;
+  font-size: 0.85em;
 }
 
-.agent-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+/* ─── Worktree grid ────────────────────────────────────────────── */
+
+.grid {
   display: grid;
-  gap: 0.4rem;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: 0.6rem;
 }
 
-.agent-list__item {
-  background: var(--bg-elevated);
+.card {
+  background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.5rem 0.75rem;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 0.75rem;
-  align-items: baseline;
+  border-radius: 6px;
+  padding: 0.75rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
   font-size: 0.85rem;
 }
 
-.agent-list__name {
-  font-weight: 600;
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.card__name {
+  font-weight: 700;
+  font-size: 0.95rem;
   color: var(--accent);
   font-family: 'SF Mono', Menlo, Consolas, monospace;
 }
 
-.agent-list__path {
-  color: var(--text-muted);
+.card__desc {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.card__path {
+  margin: 0;
   font-family: 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 0.78rem;
+  font-size: 0.72rem;
+  color: var(--text-dim);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.agent-list__desc {
-  color: var(--text-muted);
+.card__branch {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
   font-size: 0.78rem;
-  font-style: italic;
+}
+
+.card__branch-name {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  color: var(--text-muted);
+}
+
+.card__ticket {
+  background: rgba(106, 162, 255, 0.15);
+  color: var(--accent);
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.card__topic {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+
+.card__warn {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--yellow);
+}
+
+.card__warn code {
+  background: rgba(246, 193, 119, 0.1);
+  padding: 0.05rem 0.3rem;
+  border-radius: 2px;
+  font-size: 0.95em;
+}
+
+.pill {
+  font-size: 0.65rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--bg-elevated);
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.pill--active {
+  background: rgba(92, 212, 122, 0.12);
+  color: var(--green);
+  border-color: rgba(92, 212, 122, 0.3);
+}
+
+.pill--idle {
+  background: var(--bg-elevated);
+  color: var(--text-dim);
+}
+
+.pill--error {
+  background: rgba(255, 106, 106, 0.12);
+  color: var(--red);
+  border-color: rgba(255, 106, 106, 0.3);
+}
+
+/* ─── Todos ────────────────────────────────────────────────────── */
+
+.card__todos {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-top: 0.1rem;
+}
+
+.card__todos-summary {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.todo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  max-height: 8.5rem;
+  overflow-y: auto;
+}
+
+.todo {
+  display: grid;
+  grid-template-columns: 1.2rem 1fr;
+  gap: 0.35rem;
+  align-items: baseline;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.todo__icon {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.85em;
+  text-align: center;
+}
+
+.todo__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.todo--completed {
+  color: var(--text-dim);
+  text-decoration: line-through;
+  text-decoration-color: var(--text-dim);
+}
+.todo--completed .todo__icon {
+  color: var(--green);
+}
+
+.todo--in-progress {
+  color: var(--text);
+}
+.todo--in-progress .todo__icon {
+  color: var(--yellow);
+}
+
+.todo--pending .todo__icon {
+  color: var(--text-dim);
+}
+
+/* ─── Ports row ────────────────────────────────────────────────── */
+
+.card__ports {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.1rem;
+  flex-wrap: wrap;
+}
+
+.port-button {
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.74rem;
+  text-decoration: none;
+  font-family: -apple-system, sans-serif;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  transition: border-color 0.15s ease;
+}
+
+.port-button:hover {
+  border-color: var(--accent);
+}
+
+.port-button__num {
+  color: var(--accent);
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.95em;
 }

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -16,6 +16,12 @@ export interface AgentConfig {
   name: string;
   worktree: string;
   description?: string;
+  /**
+   * Operator-canonical ports for this agent (lives in ~/.ranch/config.toml,
+   * out of reach of the agents themselves). When set, the card displays
+   * these and warns if .env.agent disagrees.
+   */
+  ports?: WorktreePorts;
 }
 
 export interface ProjectConfig {
@@ -47,7 +53,20 @@ export interface WorktreeBasics {
   description?: string;
   envAgentPath: string;
   envAgentExists: boolean;
+  /** AGENT_NAME from .env.agent — useful for catching stale env files */
+  envAgentName?: string;
+  /** True if envAgentName matches the registered agent name */
+  envAgentMatches: boolean;
+  /**
+   * Ports surfaced on the card. Sourced from `agents.<name>.ports` in
+   * ~/.ranch/config.toml when present (operator-canonical), otherwise
+   * fall back to whatever `.env.agent` had (potentially stale).
+   */
   ports: WorktreePorts;
+  /** Where `ports` came from. */
+  portsSource: 'ranch-config' | 'env-agent' | 'unknown';
+  /** Ports as read directly from .env.agent — used to detect drift. */
+  envAgentPorts: WorktreePorts;
 }
 
 // ─── CC session state (MVP-3: from ~/.claude/projects/<encoded>/*.jsonl) ─

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -1,3 +1,17 @@
+/**
+ * Shared types — the IPC contract between main, preload, and renderer.
+ *
+ * Anything the renderer can call lives in `RanchApi`. Adding a capability
+ * is always a triangle:
+ *   1. Define types here
+ *   2. Implement in src/main/<module>.ts
+ *   3. Register the channel in src/main/ipc.ts
+ *   4. Expose via contextBridge in src/preload/index.ts
+ *   5. Consume from React via window.ranch.<namespace>.<method>()
+ */
+
+// ─── Agent registry (from ~/.ranch/config.toml) ──────────────────────────
+
 export interface AgentConfig {
   name: string;
   worktree: string;
@@ -20,9 +34,57 @@ export interface RanchConfig {
   ranchDir: string;
 }
 
+// ─── Worktree basics (MVP-1: from .env.agent) ────────────────────────────
+
+export interface WorktreePorts {
+  django?: number;
+  vite?: number;
+}
+
+export interface WorktreeBasics {
+  agent: string;
+  worktreePath: string;
+  description?: string;
+  envAgentPath: string;
+  envAgentExists: boolean;
+  ports: WorktreePorts;
+}
+
+// ─── CC session state (MVP-3: from ~/.claude/projects/<encoded>/*.jsonl) ─
+
+export type TodoStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface TodoItem {
+  content: string;
+  activeForm?: string;
+  status: TodoStatus;
+}
+
+export interface SessionState {
+  /** 'active' = transcript exists; 'none' = no transcript directory */
+  status: 'active' | 'none';
+  /** Newest .jsonl file discovered for this worktree */
+  sessionId?: string;
+  transcriptPath?: string;
+  /** ISO timestamp of the last entry */
+  lastActivityAt?: string;
+  /** Most recent user prompt text (for "topic" derivation in the card) */
+  lastUserPrompt?: string;
+  /** Most recent TodoWrite list — empty if the agent never used TodoWrite */
+  todos: TodoItem[];
+  /** Branch CC was on at the latest entry (assistant entries include `gitBranch`) */
+  gitBranch?: string;
+}
+
+// ─── IPC surface ─────────────────────────────────────────────────────────
+
 export interface RanchApi {
   config: {
     get: () => Promise<RanchConfig>;
+  };
+  worktrees: {
+    list: () => Promise<WorktreeBasics[]>;
+    session: (agent: string) => Promise<SessionState>;
   };
   app: {
     version: () => Promise<string>;


### PR DESCRIPTION
## Summary

- **MVP-1 (#36)** — \`window.ranch.worktrees.list()\` reads each agent's \`.env.agent\` and surfaces \`DJANGO_PORT\` + \`VITE_PORT\`
- **MVP-3 (#38)** — \`window.ranch.worktrees.session(agent)\` parses the most recent CC session JSONL for that worktree and returns the latest TodoWrite list, last user prompt, last-activity timestamp, and gitBranch
- Renderer replaces the placeholder list with a real worktree grid: per-agent card showing branch + ticket pill, in-progress todo as topic line, full todo list with status icons, port buttons (open in browser), active/idle pill driven by transcript freshness

## Architecture pattern

Every capability is a four-step triangle:

1. **Types** in \`src/shared/types.ts\` (the IPC contract)
2. **Implementation** in \`src/main/<module>.ts\` (Node-side, full system access)
3. **Handler registration** in \`src/main/ipc.ts\` (\`ipcMain.handle\`)
4. **Preload bridge** in \`src/preload/index.ts\` (\`contextBridge.exposeInMainWorld\`)

The renderer then calls \`window.ranch.<namespace>.<method>()\` and gets a \`Promise\` back. This PR adds two new triangles (worktrees.list, worktrees.session) to the existing config.get + app.version surface.

## Polling cadence

- Worktree basics: 30s (\`.env.agent\` rarely changes)
- Per-card session state: 4s (this is the freshness that makes the card useful)
- All polling lives in the renderer; main process is request/response only. (Live push via the event bus is Phase A2 — deferred.)

## Verification

- \`pnpm typecheck\` — clean
- \`pnpm lint\` — clean
- \`pnpm format:check\` — clean
- \`pnpm build\` — main 4.6 kB, preload 0.66 kB, renderer ~230 kB

## Test plan

- [ ] \`cd console && pnpm dev\`
- [ ] Window opens with four cards (max / jeffy / arnold / kesha)
- [ ] Each card shows the worktree path and \`Django :<port>\` + \`Vite :<port>\` buttons matching \`.env.agent\`
- [ ] Open a CC session in one of the four worktrees; within ~4s the card flips to active/<age>, branch + topic populate
- [ ] Run a TodoWrite update inside that session; the card's todo list reflects within ~4s
- [ ] Click a port button — opens \`http://localhost:<port>\` in default browser
- [ ] Card without an existing CC transcript shows \"no session\" pill (not an error)

## What's next

- **MVP-2** — git state observer (branch dirty/clean, ahead/behind, last commit)
- **MVP-4** — tmux + claude process detection (active / detached / idle / none)
- **MVP-5** — formalizes the card UI; with MVP-2/4 layered in, the card becomes complete
- **MVP-6** — embedded terminal pane (tmux attach)
- **MVP-7** — already done in this PR (port buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)