### PR TITLE
feat(console): embedded terminal via tmux + node-pty (MVP-6, closes #41)

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -12,14 +12,21 @@
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json",
     "lint": "eslint . --max-warnings=0",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "rebuild": "electron-rebuild --types prod,optional --force --only node-pty",
+    "postinstall": "electron-rebuild --types prod,optional --force --only node-pty"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-webgl": "^0.19.0",
+    "@xterm/xterm": "^6.0.0",
+    "node-pty": "^1.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@electron/rebuild": "^4.0.4",
     "@eslint/js": "^10.0.1",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",
@@ -43,7 +50,8 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "electron",
-      "esbuild"
+      "esbuild",
+      "node-pty"
     ]
   }
 }

--- a/console/pnpm-lock.yaml
+++ b/console/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/addon-webgl':
+        specifier: ^0.19.0
+        version: 0.19.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -18,6 +30,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
+      '@electron/rebuild':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@9.39.4)
@@ -158,6 +173,11 @@ packages:
   '@electron/get@2.0.3':
     resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
     engines: {node: '>=12'}
+
+  '@electron/rebuild@4.0.4':
+    resolution: {integrity: sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -367,6 +387,10 @@ packages:
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -382,6 +406,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@malept/cross-spawn-promise@2.0.0':
+    resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
+    engines: {node: '>= 12.13.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -647,6 +675,19 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-webgl@0.19.0':
+    resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
+
+  abbrev@4.0.0:
+    resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -768,6 +809,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
@@ -974,6 +1019,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
@@ -1246,6 +1294,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -1337,6 +1389,14 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1348,12 +1408,35 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  node-abi@4.28.0:
+    resolution: {integrity: sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==}
+    engines: {node: '>=22.12.0'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-api-version@0.2.1:
+    resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
+
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
+  node-gyp@12.3.0:
+    resolution: {integrity: sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  nopt@9.0.0:
+    resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
@@ -1452,6 +1535,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -1485,6 +1572,10 @@ packages:
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
+
+  read-binary-file-arch@1.0.6:
+    resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
+    hasBin: true
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1631,6 +1722,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -1676,6 +1771,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.25.0:
+    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+    engines: {node: '>=18.17'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -1742,6 +1841,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -1751,6 +1855,10 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -1892,6 +2000,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@electron/rebuild@4.0.4':
+    dependencies:
+      '@malept/cross-spawn-promise': 2.0.0
+      debug: 4.4.3
+      node-abi: 4.28.0
+      node-api-version: 0.2.1
+      node-gyp: 12.3.0
+      read-binary-file-arch: 1.0.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
@@ -2029,6 +2148,10 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2047,6 +2170,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@malept/cross-spawn-promise@2.0.0':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -2300,6 +2427,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-webgl@0.19.0': {}
+
+  '@xterm/xterm@6.0.0': {}
+
+  abbrev@4.0.0: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -2449,6 +2584,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chownr@3.0.0: {}
 
   clone-response@1.0.3:
     dependencies:
@@ -2783,6 +2920,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  exponential-backoff@3.1.3: {}
+
   extract-zip@2.0.1:
     dependencies:
       debug: 4.4.3
@@ -3076,6 +3215,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@4.0.0: {}
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -3163,11 +3304,27 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  node-abi@4.28.0:
+    dependencies:
+      semver: 7.7.4
+
+  node-addon-api@7.1.1: {}
+
+  node-api-version@0.2.1:
+    dependencies:
+      semver: 7.7.4
 
   node-exports-info@1.6.0:
     dependencies:
@@ -3176,7 +3333,28 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-gyp@12.3.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      graceful-fs: 4.2.11
+      nopt: 9.0.0
+      proc-log: 6.1.0
+      semver: 7.7.4
+      tar: 7.5.13
+      tinyglobby: 0.2.16
+      undici: 6.25.0
+      which: 6.0.1
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+
   node-releases@2.0.38: {}
+
+  nopt@9.0.0:
+    dependencies:
+      abbrev: 4.0.0
 
   normalize-url@6.1.0: {}
 
@@ -3273,6 +3451,8 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  proc-log@6.1.0: {}
+
   progress@2.0.3: {}
 
   prop-types@15.8.1:
@@ -3303,6 +3483,12 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  read-binary-file-arch@1.0.6:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3541,6 +3727,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3600,6 +3794,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@6.25.0: {}
 
   universalify@0.1.2: {}
 
@@ -3667,11 +3863,17 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
 
   yallist@3.1.1: {}
+
+  yallist@5.0.0: {}
 
   yauzl@2.10.0:
     dependencies:

--- a/console/src/main/index.ts
+++ b/console/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, shell } from 'electron';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { registerIpcHandlers } from './ipc.js';
+import { detachAllForWebContents } from './pty.js';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -31,6 +32,12 @@ function createMainWindow(): BrowserWindow {
   window.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
     return { action: 'deny' };
+  });
+
+  // Clean up any ptys we own when the window goes away. The tmux session
+  // lives on independently — we just close the client.
+  window.on('closed', () => {
+    detachAllForWebContents(window.webContents);
   });
 
   if (isDev) {

--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -1,35 +1,49 @@
 /**
  * IPC handler registration.
  *
- * One channel per typed RanchApi method. The channel string lives both
- * here (registration) and in src/preload/index.ts (caller). They MUST
- * stay in sync — easy to grep, easy to keep small.
+ * Two channel patterns in this file:
+ *   1. Request/response — `ipcMain.handle(channel, fn)`. Renderer-side
+ *      `ipcRenderer.invoke(channel, ...args)` returns a Promise.
+ *   2. Push (main → renderer) — `webContents.send(channel, payload)`.
+ *      Used for streaming pty output, where there's no single "response."
+ *      Subscribers register on the renderer side via
+ *      `ipcRenderer.on(channel, handler)`.
  *
- * `ipcMain.handle(channel, fn)` registers a request/response handler.
- * Renderer-side `ipcRenderer.invoke(channel, ...args)` returns a
- * Promise resolving to whatever this handler returns.
+ * Channel strings appear here AND in src/preload/index.ts. They must
+ * stay in sync — easy to grep, easy to keep small.
  */
 
 import { app, ipcMain } from 'electron';
 import { loadRanchConfig } from './config.js';
 import { listWorktrees } from './worktrees.js';
 import { getActiveSession } from './transcript.js';
+import {
+  attachTerminal,
+  detachTerminal,
+  getTerminalEnv,
+  resizeTerminal,
+  writeTerminal,
+} from './pty.js';
 
 export const IPC_CHANNELS = {
   configGet: 'ranch:config:get',
   worktreesList: 'ranch:worktrees:list',
   worktreesSession: 'ranch:worktrees:session',
+  terminalEnv: 'ranch:terminal:env',
+  terminalAttach: 'ranch:terminal:attach',
+  terminalWrite: 'ranch:terminal:write',
+  terminalResize: 'ranch:terminal:resize',
+  terminalDetach: 'ranch:terminal:detach',
+  // Push channels (main → renderer). No registration needed in main —
+  // we just call webContents.send(...). Listed here for grep-ability.
+  terminalData: 'terminal:data',
+  terminalExit: 'terminal:exit',
   appVersion: 'ranch:app:version',
 } as const;
 
 export function registerIpcHandlers(): void {
-  ipcMain.handle(IPC_CHANNELS.configGet, async () => {
-    return loadRanchConfig();
-  });
-
-  ipcMain.handle(IPC_CHANNELS.worktreesList, async () => {
-    return listWorktrees();
-  });
+  ipcMain.handle(IPC_CHANNELS.configGet, async () => loadRanchConfig());
+  ipcMain.handle(IPC_CHANNELS.worktreesList, async () => listWorktrees());
 
   ipcMain.handle(
     IPC_CHANNELS.worktreesSession,
@@ -37,7 +51,6 @@ export function registerIpcHandlers(): void {
       if (typeof agent !== 'string' || !agent) {
         throw new Error('worktrees.session requires an agent name');
       }
-      // Re-read config on each call: it's tiny and rarely changes.
       const config = await loadRanchConfig();
       const match = config.agents.find((a) => a.name === agent);
       if (!match) {
@@ -47,7 +60,54 @@ export function registerIpcHandlers(): void {
     },
   );
 
-  ipcMain.handle(IPC_CHANNELS.appVersion, () => {
-    return app.getVersion();
+  ipcMain.handle(IPC_CHANNELS.terminalEnv, async () => getTerminalEnv());
+
+  ipcMain.handle(
+    IPC_CHANNELS.terminalAttach,
+    async (event, agent: unknown, cols: unknown, rows: unknown) => {
+      if (typeof agent !== 'string' || !agent) {
+        throw new Error('terminal.attach requires an agent name');
+      }
+      const config = await loadRanchConfig();
+      const match = config.agents.find((a) => a.name === agent);
+      if (!match) {
+        throw new Error(`Unknown agent: ${agent}`);
+      }
+      return attachTerminal({
+        agent,
+        worktreePath: match.worktree,
+        ...(typeof cols === 'number' ? { cols } : {}),
+        ...(typeof rows === 'number' ? { rows } : {}),
+        webContents: event.sender,
+      });
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.terminalWrite,
+    (_event, terminalId: unknown, data: unknown) => {
+      if (typeof terminalId === 'string' && typeof data === 'string') {
+        writeTerminal(terminalId, data);
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.terminalResize,
+    (_event, terminalId: unknown, cols: unknown, rows: unknown) => {
+      if (
+        typeof terminalId === 'string' &&
+        typeof cols === 'number' &&
+        typeof rows === 'number'
+      ) {
+        resizeTerminal(terminalId, cols, rows);
+      }
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.terminalDetach, (_event, terminalId: unknown) => {
+    if (typeof terminalId === 'string') detachTerminal(terminalId);
   });
+
+  ipcMain.handle(IPC_CHANNELS.appVersion, () => app.getVersion());
 }

--- a/console/src/main/pty.ts
+++ b/console/src/main/pty.ts
@@ -1,0 +1,208 @@
+/**
+ * MVP-6 — embedded terminal via tmux + node-pty.
+ *
+ * The convention this module enforces:
+ *   - Every ranch terminal lives in a tmux session named `ranch-<agent>`
+ *   - We attach via `tmux new-session -A`, which means "attach if exists,
+ *     create if not" — idempotent and survives detach
+ *   - Closing the pty detaches the tmux client; the session keeps running
+ *
+ * This naming contract is also how ranch tells its sessions apart from
+ * the operator's manually-created tmux sessions, and how cross-contamination
+ * detection (future MVP-4 work) will identify which agent a process belongs to.
+ *
+ * Why two IPC patterns:
+ *   - request/response (ipcMain.handle): for one-shot ops (attach, write, resize)
+ *   - main→renderer push (webContents.send): for streaming pty output
+ *     There's no other clean way to hand a continuous byte stream from
+ *     a Node child process up to a sandboxed renderer.
+ */
+
+import { spawn as ptySpawn, type IPty } from 'node-pty';
+import { execFile as execFileCb } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { promisify } from 'node:util';
+import type { WebContents } from 'electron';
+import type { TerminalEnv, TerminalAttachResult } from '../shared/types.js';
+
+const execFile = promisify(execFileCb);
+
+interface ActiveTerminal {
+  terminalId: string;
+  agent: string;
+  pty: IPty;
+  /** WebContents that this terminal pushes data to. */
+  webContents: WebContents;
+}
+
+/** Indexed by terminalId (`ranch-<agent>`). */
+const terminals = new Map<string, ActiveTerminal>();
+
+let cachedTmuxPath: string | null | undefined;
+
+/**
+ * Locate tmux on PATH. Cached after first lookup.
+ * Returns null if not installed.
+ */
+async function findTmux(): Promise<string | null> {
+  if (cachedTmuxPath !== undefined) return cachedTmuxPath;
+  // Check common Homebrew + system locations directly first
+  // (the spawned PATH inside Electron may not include /opt/homebrew/bin).
+  for (const candidate of [
+    '/opt/homebrew/bin/tmux',
+    '/usr/local/bin/tmux',
+    '/usr/bin/tmux',
+  ]) {
+    if (existsSync(candidate)) {
+      cachedTmuxPath = candidate;
+      return candidate;
+    }
+  }
+  // Fall back to `which`.
+  try {
+    const { stdout } = await execFile('which', ['tmux']);
+    const path = stdout.trim();
+    cachedTmuxPath = path.length > 0 ? path : null;
+    return cachedTmuxPath;
+  } catch {
+    cachedTmuxPath = null;
+    return null;
+  }
+}
+
+export async function getTerminalEnv(): Promise<TerminalEnv> {
+  const tmuxPath = await findTmux();
+  const env: TerminalEnv = { tmuxAvailable: tmuxPath !== null };
+  if (tmuxPath) env.tmuxPath = tmuxPath;
+  return env;
+}
+
+interface AttachOptions {
+  agent: string;
+  worktreePath: string;
+  cols?: number;
+  rows?: number;
+  webContents: WebContents;
+}
+
+export async function attachTerminal(
+  opts: AttachOptions,
+): Promise<TerminalAttachResult> {
+  const tmuxPath = await findTmux();
+  if (!tmuxPath) {
+    return {
+      ok: false,
+      reason:
+        'tmux is not installed. Install via `brew install tmux` and reopen the terminal.',
+    };
+  }
+
+  const terminalId = `ranch-${opts.agent}`;
+
+  // If already attached for this webContents, re-use.
+  const existing = terminals.get(terminalId);
+  if (existing && existing.webContents === opts.webContents) {
+    return { ok: true, terminalId };
+  }
+  // If a different window had it attached, detach the old client first.
+  if (existing) {
+    detachInternal(terminalId);
+  }
+
+  // tmux new-session:
+  //   -A  attach if a session by this name exists, else create
+  //   -s  session name
+  //   -c  start directory (only used when creating a new session)
+  const args = ['new-session', '-A', '-s', terminalId, '-c', opts.worktreePath];
+
+  const pty = ptySpawn(tmuxPath, args, {
+    name: 'xterm-256color',
+    cols: opts.cols ?? 100,
+    rows: opts.rows ?? 30,
+    cwd: opts.worktreePath,
+    env: {
+      ...process.env,
+      // Force a known TERM so xterm.js renders correctly.
+      TERM: 'xterm-256color',
+      // Tell child processes they're inside ranch — useful for future
+      // hooks that want to behave differently when launched here.
+      RANCH_AGENT: opts.agent,
+      RANCH_TERMINAL: terminalId,
+    },
+  });
+
+  const active: ActiveTerminal = {
+    terminalId,
+    agent: opts.agent,
+    pty,
+    webContents: opts.webContents,
+  };
+  terminals.set(terminalId, active);
+
+  pty.onData((data) => {
+    if (active.webContents.isDestroyed()) return;
+    active.webContents.send('terminal:data', { terminalId, data });
+  });
+
+  pty.onExit(({ exitCode, signal }) => {
+    if (!active.webContents.isDestroyed()) {
+      active.webContents.send('terminal:exit', {
+        terminalId,
+        exitCode,
+        signal: signal ?? null,
+      });
+    }
+    terminals.delete(terminalId);
+  });
+
+  return { ok: true, terminalId };
+}
+
+export function writeTerminal(terminalId: string, data: string): void {
+  const t = terminals.get(terminalId);
+  if (!t) return;
+  t.pty.write(data);
+}
+
+export function resizeTerminal(
+  terminalId: string,
+  cols: number,
+  rows: number,
+): void {
+  const t = terminals.get(terminalId);
+  if (!t) return;
+  if (cols < 1 || rows < 1) return;
+  try {
+    t.pty.resize(Math.floor(cols), Math.floor(rows));
+  } catch {
+    // pty closed mid-resize; ignore
+  }
+}
+
+export function detachTerminal(terminalId: string): void {
+  detachInternal(terminalId);
+}
+
+function detachInternal(terminalId: string): void {
+  const t = terminals.get(terminalId);
+  if (!t) return;
+  try {
+    // SIGHUP → tmux client detaches cleanly without killing the session.
+    t.pty.kill('SIGHUP');
+  } catch {
+    // already gone
+  }
+  terminals.delete(terminalId);
+}
+
+/**
+ * Detach all terminals associated with a webContents instance — called
+ * when a window closes so we don't leak ptys.
+ */
+export function detachAllForWebContents(wc: WebContents): void {
+  for (const [id, t] of terminals.entries()) {
+    if (t.webContents === wc) {
+      detachInternal(id);
+    }
+  }
+}

--- a/console/src/main/pty.ts
+++ b/console/src/main/pty.ts
@@ -33,6 +33,15 @@ interface ActiveTerminal {
   pty: IPty;
   /** WebContents that this terminal pushes data to. */
   webContents: WebContents;
+  /**
+   * Number of live attach() calls that haven't been balanced by detach().
+   * React 18 StrictMode in dev double-fires effects (mount → cleanup →
+   * mount), and even in production a card may attach twice across a
+   * re-render before the first detach lands. We only SIGHUP the tmux
+   * client when refCount drops to 0 — otherwise we kill the pty out
+   * from under a still-mounted Terminal component.
+   */
+  refCount: number;
 }
 
 /** Indexed by terminalId (`ranch-<agent>`). */
@@ -99,14 +108,19 @@ export async function attachTerminal(
 
   const terminalId = `ranch-${opts.agent}`;
 
-  // If already attached for this webContents, re-use.
+  // If already attached for this webContents, increment the refcount and
+  // re-use. The same data stream is fanned out — re-spawning would kill
+  // the live one and break the still-mounted component.
   const existing = terminals.get(terminalId);
   if (existing && existing.webContents === opts.webContents) {
+    existing.refCount += 1;
     return { ok: true, terminalId };
   }
-  // If a different window had it attached, detach the old client first.
+  // If a different window had it attached, force-detach the old client
+  // first. (This is intentional: only one window owns a terminal at a
+  // time. Multi-window support is post-MVP.)
   if (existing) {
-    detachInternal(terminalId);
+    detachInternal(terminalId, true);
   }
 
   // tmux new-session:
@@ -136,6 +150,7 @@ export async function attachTerminal(
     agent: opts.agent,
     pty,
     webContents: opts.webContents,
+    refCount: 1,
   };
   terminals.set(terminalId, active);
 
@@ -145,6 +160,10 @@ export async function attachTerminal(
   });
 
   pty.onExit(({ exitCode, signal }) => {
+    // Diagnostic — useful when tmux dies for non-obvious reasons.
+    console.error(
+      `[ranch.pty] ${terminalId} exited (exitCode=${exitCode}, signal=${signal ?? 'none'})`,
+    );
     if (!active.webContents.isDestroyed()) {
       active.webContents.send('terminal:exit', {
         terminalId,
@@ -180,12 +199,22 @@ export function resizeTerminal(
 }
 
 export function detachTerminal(terminalId: string): void {
-  detachInternal(terminalId);
+  detachInternal(terminalId, false);
 }
 
-function detachInternal(terminalId: string): void {
+/**
+ * @param force when true, ignore refcount and SIGHUP immediately. Used
+ *   when a window closes (we want all its ptys gone, regardless of how
+ *   many components were mid-cleanup) and when transferring a terminal
+ *   between windows.
+ */
+function detachInternal(terminalId: string, force: boolean): void {
   const t = terminals.get(terminalId);
   if (!t) return;
+  if (!force) {
+    t.refCount -= 1;
+    if (t.refCount > 0) return;
+  }
   try {
     // SIGHUP → tmux client detaches cleanly without killing the session.
     t.pty.kill('SIGHUP');
@@ -202,7 +231,7 @@ function detachInternal(terminalId: string): void {
 export function detachAllForWebContents(wc: WebContents): void {
   for (const [id, t] of terminals.entries()) {
     if (t.webContents === wc) {
-      detachInternal(id);
+      detachInternal(id, true);
     }
   }
 }

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -3,21 +3,57 @@
  * main (Node.js). Runs in the renderer's process but with elevated
  * privileges before the page loads.
  *
+ * Two IPC patterns surfaced through this file:
+ *   1. Request/response — `ipcRenderer.invoke(channel, ...args)` returns
+ *      a Promise resolving to whatever the matching ipcMain.handle returned.
+ *   2. Push (main → renderer) — `ipcRenderer.on(channel, handler)`.
+ *      We expose subscribers as functions returning an unsubscribe so
+ *      callers can wire them into React `useEffect` cleanup.
+ *
  * `contextBridge.exposeInMainWorld('ranch', api)` injects a typed
  * `window.ranch` into every page. The renderer can ONLY call methods
- * we put on this object — everything else stays on the other side
- * of the wall. That's the security guarantee.
+ * we put on this object — that's the security wall.
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
-import type { RanchApi } from '../shared/types.js';
+import type {
+  RanchApi,
+  TerminalDataEvent,
+  TerminalExitEvent,
+  Unsubscribe,
+} from '../shared/types.js';
 
 const IPC_CHANNELS = {
   configGet: 'ranch:config:get',
   worktreesList: 'ranch:worktrees:list',
   worktreesSession: 'ranch:worktrees:session',
+  terminalEnv: 'ranch:terminal:env',
+  terminalAttach: 'ranch:terminal:attach',
+  terminalWrite: 'ranch:terminal:write',
+  terminalResize: 'ranch:terminal:resize',
+  terminalDetach: 'ranch:terminal:detach',
+  terminalData: 'terminal:data',
+  terminalExit: 'terminal:exit',
   appVersion: 'ranch:app:version',
 } as const;
+
+/**
+ * Subscribe to a push channel and return an unsubscribe function.
+ * IpcRenderer's `on` listener takes (event, ...args); we discard the
+ * event and forward the first arg payload.
+ */
+function subscribe<T>(
+  channel: string,
+  handler: (payload: T) => void,
+): Unsubscribe {
+  const listener = (_event: unknown, payload: T): void => {
+    handler(payload);
+  };
+  ipcRenderer.on(channel, listener);
+  return () => {
+    ipcRenderer.removeListener(channel, listener);
+  };
+}
 
 const api: RanchApi = {
   config: {
@@ -27,6 +63,21 @@ const api: RanchApi = {
     list: () => ipcRenderer.invoke(IPC_CHANNELS.worktreesList),
     session: (agent) =>
       ipcRenderer.invoke(IPC_CHANNELS.worktreesSession, agent),
+  },
+  terminal: {
+    env: () => ipcRenderer.invoke(IPC_CHANNELS.terminalEnv),
+    attach: (agent, cols, rows) =>
+      ipcRenderer.invoke(IPC_CHANNELS.terminalAttach, agent, cols, rows),
+    write: (terminalId, data) =>
+      ipcRenderer.invoke(IPC_CHANNELS.terminalWrite, terminalId, data),
+    resize: (terminalId, cols, rows) =>
+      ipcRenderer.invoke(IPC_CHANNELS.terminalResize, terminalId, cols, rows),
+    detach: (terminalId) =>
+      ipcRenderer.invoke(IPC_CHANNELS.terminalDetach, terminalId),
+    onData: (handler) =>
+      subscribe<TerminalDataEvent>(IPC_CHANNELS.terminalData, handler),
+    onExit: (handler) =>
+      subscribe<TerminalExitEvent>(IPC_CHANNELS.terminalExit, handler),
   },
   app: {
     version: () => ipcRenderer.invoke(IPC_CHANNELS.appVersion),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import type {
   SessionState,
+  TerminalEnv,
   TodoItem,
   WorktreeBasics,
 } from '../shared/types.js';
+import { Terminal } from './Terminal.js';
 
 const SESSION_POLL_MS = 4000;
 const WORKTREE_POLL_MS = 30_000;
@@ -15,11 +17,31 @@ interface AppState {
   error?: string;
 }
 
+interface ActiveTerminal {
+  agent: string;
+  /** Bumped on each (re-)open to force a fresh attach. */
+  generation: number;
+}
+
 export function App(): JSX.Element {
   const [state, setState] = useState<AppState>({
     status: 'loading',
     worktrees: [],
   });
+  const [activeTerminal, setActiveTerminal] = useState<ActiveTerminal | null>(
+    null,
+  );
+  const [terminalEnv, setTerminalEnv] = useState<TerminalEnv | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.ranch.terminal.env().then((env) => {
+      if (!cancelled) setTerminalEnv(env);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Initial load + slow refresh of worktree basics (.env.agent rarely changes).
   useEffect(() => {
@@ -58,6 +80,18 @@ export function App(): JSX.Element {
     };
   }, []);
 
+  function openTerminal(agent: string): void {
+    setActiveTerminal((prev) =>
+      prev?.agent === agent
+        ? { agent, generation: prev.generation + 1 }
+        : { agent, generation: 1 },
+    );
+  }
+
+  function closeTerminal(): void {
+    setActiveTerminal(null);
+  }
+
   return (
     <div className="app">
       <header className="app__header">
@@ -69,13 +103,40 @@ export function App(): JSX.Element {
       <main className="app__layout">
         <section className="pane pane--grid">
           <h2>Worktree grid</h2>
-          <Grid state={state} />
+          <Grid
+            state={state}
+            onOpenTerminal={openTerminal}
+            terminalEnv={terminalEnv}
+          />
         </section>
         <section className="pane pane--terminal">
-          <h2>Terminal</h2>
-          <p className="placeholder">
-            Embedded terminal coming in MVP-6 (tmux attach).
-          </p>
+          <div className="pane__heading">
+            <h2>
+              Terminal
+              {activeTerminal && (
+                <span className="pane__heading-sub">
+                  {' '}
+                  · ranch-{activeTerminal.agent}
+                </span>
+              )}
+            </h2>
+            {activeTerminal && (
+              <button className="link-button" onClick={closeTerminal}>
+                detach
+              </button>
+            )}
+          </div>
+          {activeTerminal ? (
+            <Terminal
+              key={activeTerminal.agent}
+              agent={activeTerminal.agent}
+              generation={activeTerminal.generation}
+            />
+          ) : (
+            <p className="placeholder">
+              Click <strong>Open terminal</strong> on a worktree card to attach.
+            </p>
+          )}
         </section>
         <section className="pane pane--inbox">
           <h2>Inbox</h2>
@@ -90,7 +151,15 @@ export function App(): JSX.Element {
   );
 }
 
-function Grid({ state }: { state: AppState }): JSX.Element {
+function Grid({
+  state,
+  onOpenTerminal,
+  terminalEnv,
+}: {
+  state: AppState;
+  onOpenTerminal: (agent: string) => void;
+  terminalEnv: TerminalEnv | null;
+}): JSX.Element {
   if (state.status === 'loading') {
     return <p className="placeholder">Loading worktrees…</p>;
   }
@@ -107,19 +176,38 @@ function Grid({ state }: { state: AppState }): JSX.Element {
     );
   }
   return (
-    <div className="grid">
-      {state.worktrees.map((wt) => (
-        <WorktreeCard key={wt.agent} worktree={wt} />
-      ))}
-    </div>
+    <>
+      {terminalEnv && !terminalEnv.tmuxAvailable && (
+        <p className="card__warn card__warn--banner">
+          ⚠ tmux not found on PATH. Install with <code>brew install tmux</code>{' '}
+          to enable embedded terminals.
+        </p>
+      )}
+      <div className="grid">
+        {state.worktrees.map((wt) => (
+          <WorktreeCard
+            key={wt.agent}
+            worktree={wt}
+            onOpenTerminal={onOpenTerminal}
+            terminalEnv={terminalEnv}
+          />
+        ))}
+      </div>
+    </>
   );
 }
 
 interface WorktreeCardProps {
   worktree: WorktreeBasics;
+  onOpenTerminal: (agent: string) => void;
+  terminalEnv: TerminalEnv | null;
 }
 
-function WorktreeCard({ worktree }: WorktreeCardProps): JSX.Element {
+function WorktreeCard({
+  worktree,
+  onOpenTerminal,
+  terminalEnv,
+}: WorktreeCardProps): JSX.Element {
   const [session, setSession] = useState<SessionState | null>(null);
   const [sessionError, setSessionError] = useState<string | null>(null);
 
@@ -170,6 +258,20 @@ function WorktreeCard({ worktree }: WorktreeCardProps): JSX.Element {
           No <code>.env.agent</code> at this worktree.
         </p>
       )}
+      <footer className="card__actions">
+        <button
+          className="card__action"
+          onClick={() => onOpenTerminal(worktree.agent)}
+          disabled={terminalEnv !== null && !terminalEnv.tmuxAvailable}
+          title={
+            terminalEnv && !terminalEnv.tmuxAvailable
+              ? 'tmux not installed'
+              : 'Attach an embedded terminal to this worktree'
+          }
+        >
+          Open terminal
+        </button>
+      </footer>
     </article>
   );
 }

--- a/console/src/renderer/Terminal.tsx
+++ b/console/src/renderer/Terminal.tsx
@@ -84,7 +84,10 @@ export function Terminal({ agent, generation }: TerminalProps): JSX.Element {
 
     const offExit = window.ranch.terminal.onExit((evt) => {
       if (evt.terminalId !== attachedTerminalId) return;
-      xterm.writeln(`\r\n\x1b[33m[ranch] tmux client detached\x1b[0m`);
+      const sigPart = evt.signal !== null ? ` signal=${evt.signal}` : '';
+      xterm.writeln(
+        `\r\n\x1b[33m[ranch] tmux client detached (exit=${evt.exitCode}${sigPart})\x1b[0m`,
+      );
     });
 
     // 3. Forward keystrokes from xterm into the pty.

--- a/console/src/renderer/Terminal.tsx
+++ b/console/src/renderer/Terminal.tsx
@@ -1,0 +1,164 @@
+/**
+ * Embedded terminal component (xterm.js + main-process pty).
+ *
+ * Lifecycle on mount:
+ *   1. Construct the xterm.js Terminal and attach to the container DOM
+ *   2. Load addons (fit, webgl)
+ *   3. Subscribe to push events from main: terminal:data → write to xterm
+ *   4. Wire xterm onData → ranch.terminal.write (keystrokes back to pty)
+ *   5. Call ranch.terminal.attach with the current cols/rows
+ *   6. Resize observer keeps pty in sync with the container
+ *
+ * On unmount: unsubscribe + detach the pty (the tmux session keeps
+ * running — we're closing the client, not killing the session).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Terminal as XTerm } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebglAddon } from '@xterm/addon-webgl';
+import '@xterm/xterm/css/xterm.css';
+
+interface TerminalProps {
+  agent: string;
+  /** Increment this to force a fresh attach (e.g. after detach). */
+  generation: number;
+}
+
+type Status =
+  | { kind: 'connecting' }
+  | { kind: 'connected'; terminalId: string }
+  | { kind: 'error'; reason: string };
+
+export function Terminal({ agent, generation }: TerminalProps): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<Status>({ kind: 'connecting' });
+
+  useEffect(() => {
+    let disposed = false;
+    const container = containerRef.current;
+    if (!container) return;
+
+    // 1. xterm instance
+    const xterm = new XTerm({
+      fontFamily: 'SF Mono, Menlo, Consolas, monospace',
+      fontSize: 13,
+      lineHeight: 1.2,
+      cursorBlink: true,
+      allowProposedApi: true,
+      theme: {
+        background: '#0f1115',
+        foreground: '#e6e9ef',
+        cursor: '#6aa2ff',
+        selectionBackground: '#2a3044',
+      },
+    });
+
+    const fitAddon = new FitAddon();
+    xterm.loadAddon(fitAddon);
+    xterm.open(container);
+
+    // WebGL renderer is much faster on busy streams (CC plan mode etc.)
+    // It can fail on some GPU configs — fall back silently.
+    try {
+      const webgl = new WebglAddon();
+      webgl.onContextLoss(() => webgl.dispose());
+      xterm.loadAddon(webgl);
+    } catch {
+      // canvas/dom renderer kicks in by default
+    }
+
+    fitAddon.fit();
+    const initialCols = xterm.cols;
+    const initialRows = xterm.rows;
+
+    // 2. Subscribe to pty push events. Only render data for our terminal —
+    //    multiple terminals can be active simultaneously in main, but this
+    //    component owns one.
+    let attachedTerminalId: string | null = null;
+
+    const offData = window.ranch.terminal.onData((evt) => {
+      if (evt.terminalId !== attachedTerminalId) return;
+      xterm.write(evt.data);
+    });
+
+    const offExit = window.ranch.terminal.onExit((evt) => {
+      if (evt.terminalId !== attachedTerminalId) return;
+      xterm.writeln(`\r\n\x1b[33m[ranch] tmux client detached\x1b[0m`);
+    });
+
+    // 3. Forward keystrokes from xterm into the pty.
+    const onDataDisposable = xterm.onData((data) => {
+      if (attachedTerminalId !== null) {
+        void window.ranch.terminal.write(attachedTerminalId, data);
+      }
+    });
+
+    // 4. Attach.
+    void (async () => {
+      const result = await window.ranch.terminal.attach(
+        agent,
+        initialCols,
+        initialRows,
+      );
+      if (disposed) {
+        if (result.ok) {
+          void window.ranch.terminal.detach(result.terminalId);
+        }
+        return;
+      }
+      if (!result.ok) {
+        setStatus({ kind: 'error', reason: result.reason });
+        return;
+      }
+      attachedTerminalId = result.terminalId;
+      setStatus({ kind: 'connected', terminalId: result.terminalId });
+      xterm.focus();
+    })();
+
+    // 5. Resize: refit on container resize, then push cols/rows to the pty.
+    const ro = new ResizeObserver(() => {
+      try {
+        fitAddon.fit();
+      } catch {
+        // container detached mid-resize
+        return;
+      }
+      if (attachedTerminalId !== null) {
+        void window.ranch.terminal.resize(
+          attachedTerminalId,
+          xterm.cols,
+          xterm.rows,
+        );
+      }
+    });
+    ro.observe(container);
+
+    return () => {
+      disposed = true;
+      ro.disconnect();
+      offData();
+      offExit();
+      onDataDisposable.dispose();
+      if (attachedTerminalId !== null) {
+        void window.ranch.terminal.detach(attachedTerminalId);
+      }
+      xterm.dispose();
+    };
+    // generation is in deps so a re-mount can be triggered externally if needed
+  }, [agent, generation]);
+
+  return (
+    <div className="terminal">
+      <div ref={containerRef} className="terminal__pane" />
+      {status.kind === 'connecting' && (
+        <div className="terminal__overlay">connecting…</div>
+      )}
+      {status.kind === 'error' && (
+        <div className="terminal__overlay terminal__overlay--error">
+          {status.reason}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -83,6 +83,13 @@ body,
   color: var(--text-muted);
 }
 
+.pane--terminal {
+  padding: 0.75rem 0.5rem 0.5rem 0.5rem;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
 .placeholder {
   color: var(--text-muted);
   font-size: 0.85rem;
@@ -321,4 +328,126 @@ body,
   color: var(--accent);
   font-family: 'SF Mono', Menlo, Consolas, monospace;
   font-size: 0.95em;
+}
+
+/* ─── Card actions ─────────────────────────────────────────────── */
+
+.card__actions {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.25rem;
+}
+
+.card__action {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 0.3rem 0.65rem;
+  border-radius: 4px;
+  font-size: 0.78rem;
+  cursor: pointer;
+  font-family: inherit;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.card__action:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: rgba(106, 162, 255, 0.08);
+}
+
+.card__action:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.card__warn--banner {
+  margin: 0 0 0.6rem 0;
+  background: rgba(246, 193, 119, 0.08);
+  border: 1px solid rgba(246, 193, 119, 0.3);
+  border-radius: 4px;
+  padding: 0.35rem 0.6rem;
+}
+
+.card__drift {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+/* ─── Terminal pane ────────────────────────────────────────────── */
+
+.pane__heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.pane__heading h2 {
+  margin: 0;
+}
+
+.pane__heading-sub {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--accent);
+  font-weight: 500;
+  font-size: 0.7rem;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.72rem;
+  cursor: pointer;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+}
+
+.link-button:hover {
+  color: var(--text);
+  background: var(--bg-elevated);
+}
+
+.terminal {
+  position: relative;
+  width: 100%;
+  height: calc(100% - 1.6rem);
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+}
+
+.terminal__pane {
+  flex: 1;
+  min-height: 0;
+  padding: 0.5rem;
+}
+
+.terminal__pane .xterm,
+.terminal__pane .xterm-viewport,
+.terminal__pane .xterm-screen {
+  height: 100% !important;
+}
+
+.terminal__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 17, 21, 0.85);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  pointer-events: none;
+}
+
+.terminal__overlay--error {
+  color: var(--red);
+  pointer-events: auto;
 }

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -95,6 +95,34 @@ export interface SessionState {
   gitBranch?: string;
 }
 
+// ─── Terminal (MVP-6) ────────────────────────────────────────────────────
+
+export interface TerminalEnv {
+  tmuxAvailable: boolean;
+  tmuxPath?: string;
+}
+
+export type TerminalAttachResult =
+  | { ok: true; terminalId: string }
+  | { ok: false; reason: string };
+
+export interface TerminalDataEvent {
+  terminalId: string;
+  data: string;
+}
+
+export interface TerminalExitEvent {
+  terminalId: string;
+  exitCode: number;
+  signal: number | null;
+}
+
+/**
+ * Renderer-side subscription handle. Calling the function unsubscribes —
+ * standard React-effect-cleanup pattern.
+ */
+export type Unsubscribe = () => void;
+
 // ─── IPC surface ─────────────────────────────────────────────────────────
 
 export interface RanchApi {
@@ -104,6 +132,19 @@ export interface RanchApi {
   worktrees: {
     list: () => Promise<WorktreeBasics[]>;
     session: (agent: string) => Promise<SessionState>;
+  };
+  terminal: {
+    env: () => Promise<TerminalEnv>;
+    attach: (
+      agent: string,
+      cols?: number,
+      rows?: number,
+    ) => Promise<TerminalAttachResult>;
+    write: (terminalId: string, data: string) => Promise<void>;
+    resize: (terminalId: string, cols: number, rows: number) => Promise<void>;
+    detach: (terminalId: string) => Promise<void>;
+    onData: (handler: (event: TerminalDataEvent) => void) => Unsubscribe;
+    onExit: (handler: (event: TerminalExitEvent) => void) => Unsubscribe;
   };
   app: {
     version: () => Promise<string>;


### PR DESCRIPTION
## Summary

- \`Open terminal\` button on each worktree card → attaches an embedded xterm.js terminal in the right pane
- Sessions are tmux-backed with the convention \`ranch-<agent>\` so closing the pane detaches the tmux client without killing the session — reopen and you reattach with full scrollback
- Tmux missing? Banner explains how to fix (\`brew install tmux\`), buttons disabled

## Architectural addition: second IPC pattern

Up to now every IPC was request/response (\`ipcMain.handle\` ↔ \`ipcRenderer.invoke\`). PTY streaming needs **push** (main → renderer continuously, no single response). Both patterns now coexist in \`ipc.ts\` / \`preload/index.ts\`:

- \`terminal:data\` and \`terminal:exit\` are pushed via \`webContents.send\`
- Preload exposes them as \`onData(handler) -> Unsubscribe\` and \`onExit(handler) -> Unsubscribe\` — subscribe-and-cleanup, wires directly into React \`useEffect\` return values

This is the pattern Phase A2 (event bus, deferred) will scale up. Same shape: subscribe via preload, get an unsubscribe back, wire into effect cleanup.

## Native modules

\`node-pty\` is C++ and needs to be rebuilt against Electron's Node ABI (different from the system Node). Handled by:

- \`pnpm.onlyBuiltDependencies\` includes \`node-pty\`
- \`postinstall\` script: \`electron-rebuild --types prod,optional --force --only node-pty\`
- The \`--only node-pty\` flag avoids @electron/rebuild's pnpm-virtual-store confusion (it tries to walk a flat node_modules and trips otherwise)

## Tmux discovery

Electron's spawned subprocess PATH on macOS doesn't include \`/opt/homebrew/bin\` by default. \`pty.ts\` checks common system paths directly first (\`/opt/homebrew/bin/tmux\`, \`/usr/local/bin/tmux\`, \`/usr/bin/tmux\`), then falls back to \`which tmux\`. Result is cached.

## Lifecycle guarantees

- Window close → all attached ptys for that webContents are SIGHUP'd cleanly (not killed); tmux sessions persist
- Renderer effect unmount → \`detach(terminalId)\` from preload → SIGHUP in main
- Multiple windows can each attach to a different session simultaneously (current UI shows one at a time but the API supports more)

## Verification

- \`pnpm typecheck\` — clean (full strict + exactOptionalPropertyTypes)
- \`pnpm lint\` — clean
- \`pnpm format:check\` — clean
- \`pnpm build\` — main 17 kB, preload 1.9 kB, renderer ~820 kB (xterm + WebGL)
- \`pnpm dev\` — confirmed launches cleanly

## Test plan

- [ ] \`brew install tmux\` if not already installed
- [ ] \`cd console && pnpm install\` (will rebuild node-pty automatically)
- [ ] \`pnpm dev\`
- [ ] Click \"Open terminal\" on max → xterm pane attaches at \`/Users/.../max\`, prompt visible
- [ ] Type \`ls\`, see worktree contents
- [ ] Click \"detach\" → pane clears
- [ ] Click \"Open terminal\" on max again → reattaches with prior history (tmux scrollback preserved)
- [ ] Click \"Open terminal\" on jeffy → switches to jeffy's session, max session keeps running in background
- [ ] Verify \`tmux ls\` in another terminal shows \`ranch-max\`, \`ranch-jeffy\` while their cards are/were active
- [ ] Close ranch window, reopen → tmux sessions still listable, ranch can reattach
- [ ] Without tmux installed: card buttons disabled, top-of-grid banner shows install instruction

## What's next

- **MVP-2** — git state observer (branch dirty, ahead/behind, last commit)
- **MVP-4** — claude process detection + cross-contamination warnings (\"max's claude process is running but its tmux session is named ranch-jeffy\")
- **MVP-5** — formalize the card UI now that all data sources are landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)