### PR TITLE
feat(console): git state + tmux/claude process detection (MVP-2 + MVP-4, closes #37 #39)

### DIFF
--- a/console/src/main/git.ts
+++ b/console/src/main/git.ts
@@ -1,0 +1,106 @@
+/**
+ * MVP-2 — per-worktree git state.
+ *
+ * We shell out to `git` rather than pull in a library. A handful of
+ * commands and we don't have to worry about libgit2 native rebuild
+ * across Electron versions.
+ *
+ * The `git -C <path>` form runs as if cwd were <path>, without changing
+ * our process's actual cwd — important when polling four worktrees in
+ * parallel.
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import type { GitLastCommit, WorktreeGitState } from '../shared/types.js';
+
+const execFile = promisify(execFileCb);
+
+const COMPARE_BRANCH = 'origin/develop';
+
+async function git(
+  cwd: string,
+  args: string[],
+): Promise<{ stdout: string; stderr: string; ok: boolean }> {
+  try {
+    const { stdout, stderr } = await execFile('git', ['-C', cwd, ...args], {
+      // 1 MB is plenty for everything we run here
+      maxBuffer: 1024 * 1024,
+    });
+    return { stdout, stderr, ok: true };
+  } catch (err) {
+    const stderr =
+      err && typeof err === 'object' && 'stderr' in err
+        ? String((err as { stderr: unknown }).stderr ?? '')
+        : '';
+    return { stdout: '', stderr, ok: false };
+  }
+}
+
+export async function getWorktreeGitState(
+  worktreePath: string,
+): Promise<WorktreeGitState> {
+  // Cheap precheck. `.git` may be a directory (regular repo) or a file
+  // (linked worktree, points at .git/worktrees/<name>).
+  if (!existsSync(join(worktreePath, '.git'))) {
+    return { status: 'no-git' };
+  }
+
+  const branchRes = await git(worktreePath, [
+    'rev-parse',
+    '--abbrev-ref',
+    'HEAD',
+  ]);
+  if (!branchRes.ok) {
+    return { status: 'no-git' };
+  }
+  const branch = branchRes.stdout.trim();
+
+  // Run the rest in parallel — they're all independent reads.
+  const [statusRes, aheadBehindRes, lastCommitRes] = await Promise.all([
+    git(worktreePath, ['status', '--porcelain']),
+    git(worktreePath, [
+      'rev-list',
+      '--left-right',
+      '--count',
+      `${COMPARE_BRANCH}...HEAD`,
+    ]),
+    git(worktreePath, ['log', '-1', '--format=%h%x09%s%x09%cr']),
+  ]);
+
+  const dirty =
+    statusRes.ok && statusRes.stdout.split(/\r?\n/).some((l) => l.length > 0);
+
+  let behind: number | undefined;
+  let ahead: number | undefined;
+  if (aheadBehindRes.ok) {
+    // Output: "<behind>\t<ahead>"
+    const parts = aheadBehindRes.stdout.trim().split(/\s+/);
+    if (parts.length === 2) {
+      const b = Number.parseInt(parts[0]!, 10);
+      const a = Number.parseInt(parts[1]!, 10);
+      if (Number.isFinite(b)) behind = b;
+      if (Number.isFinite(a)) ahead = a;
+    }
+  }
+
+  let lastCommit: GitLastCommit | undefined;
+  if (lastCommitRes.ok) {
+    const [sha, message, age] = lastCommitRes.stdout.split('\t');
+    if (sha && message && age) {
+      lastCommit = {
+        sha: sha.trim(),
+        message: message.trim(),
+        age: age.trim(),
+      };
+    }
+  }
+
+  const result: WorktreeGitState = { status: 'ok', branch, dirty };
+  if (ahead !== undefined) result.ahead = ahead;
+  if (behind !== undefined) result.behind = behind;
+  if (lastCommit) result.lastCommit = lastCommit;
+  return result;
+}

--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -17,6 +17,8 @@ import { app, ipcMain } from 'electron';
 import { loadRanchConfig } from './config.js';
 import { listWorktrees } from './worktrees.js';
 import { getActiveSession } from './transcript.js';
+import { getWorktreeGitState } from './git.js';
+import { snapshotProcessState } from './process.js';
 import {
   attachTerminal,
   detachTerminal,
@@ -29,6 +31,8 @@ export const IPC_CHANNELS = {
   configGet: 'ranch:config:get',
   worktreesList: 'ranch:worktrees:list',
   worktreesSession: 'ranch:worktrees:session',
+  worktreesGit: 'ranch:worktrees:git',
+  worktreesProcessSnapshot: 'ranch:worktrees:processSnapshot',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -59,6 +63,23 @@ export function registerIpcHandlers(): void {
       return getActiveSession(match.worktree);
     },
   );
+
+  ipcMain.handle(IPC_CHANNELS.worktreesGit, async (_event, agent: unknown) => {
+    if (typeof agent !== 'string' || !agent) {
+      throw new Error('worktrees.git requires an agent name');
+    }
+    const config = await loadRanchConfig();
+    const match = config.agents.find((a) => a.name === agent);
+    if (!match) throw new Error(`Unknown agent: ${agent}`);
+    return getWorktreeGitState(match.worktree);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.worktreesProcessSnapshot, async () => {
+    const config = await loadRanchConfig();
+    const agents: Record<string, string> = {};
+    for (const a of config.agents) agents[a.name] = a.worktree;
+    return snapshotProcessState({ agents });
+  });
 
   ipcMain.handle(IPC_CHANNELS.terminalEnv, async () => getTerminalEnv());
 

--- a/console/src/main/process.ts
+++ b/console/src/main/process.ts
@@ -1,0 +1,200 @@
+/**
+ * MVP-4 — detect tmux sessions and `claude` processes for each worktree.
+ *
+ * Two parallel signals per worktree:
+ *
+ *   1. tmux session named `ranch-<agent>`
+ *      - exists / attached-clients / created-at
+ *      - Lifted from `tmux list-sessions -F '...'`. We don't error if
+ *        tmux is missing — that's surfaced separately by pty.ts.
+ *
+ *   2. `claude` processes whose cwd is inside the worktree path
+ *      - We list all claude processes via `ps`, then resolve each one's
+ *        cwd via `lsof`. We do this once per fleet refresh (not once per
+ *        worktree) so four cards polling at 5s = 4 ps + ~N lsof, not
+ *        16 ps invocations.
+ *      - The cwd-based attribution is what makes cross-contamination
+ *        detectable later: a claude with cwd in jeffy/ but parent shell
+ *        rooted in max/'s tmux session is a smell.
+ *
+ * macOS-only for now. Linux would swap `lsof -a -p X -d cwd -F n` for
+ * reading `/proc/X/cwd` symlink.
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+import type {
+  CCProcessState,
+  ClaudeProcess,
+  TmuxSessionState,
+} from '../shared/types.js';
+
+const execFile = promisify(execFileCb);
+
+interface SnapshotInput {
+  /** Agents to surface state for; keyed by agent name → worktree path. */
+  agents: Record<string, string>;
+}
+
+/** ─── tmux ──────────────────────────────────────────────────── */
+
+async function listRanchTmuxSessions(): Promise<Map<string, TmuxSessionState>> {
+  const out = new Map<string, TmuxSessionState>();
+  try {
+    const { stdout } = await execFile('tmux', [
+      'list-sessions',
+      '-F',
+      '#{session_name}|#{session_attached}|#{session_created}',
+    ]);
+    for (const line of stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const [name, attached, created] = trimmed.split('|');
+      if (!name || !name.startsWith('ranch-')) continue;
+      const agent = name.slice('ranch-'.length);
+      const attachedClients = Number.parseInt(attached ?? '0', 10);
+      const createdAtSec = Number.parseInt(created ?? '0', 10);
+      const session: TmuxSessionState = {
+        sessionName: name,
+        exists: true,
+        attachedClients: Number.isFinite(attachedClients) ? attachedClients : 0,
+      };
+      if (Number.isFinite(createdAtSec)) {
+        session.createdAt = new Date(createdAtSec * 1000).toISOString();
+      }
+      out.set(agent, session);
+    }
+  } catch {
+    // tmux missing, no server running, or it errored — return empty map.
+    // pty.ts already surfaces "tmux not installed" as a separate signal.
+  }
+  return out;
+}
+
+/** ─── claude processes ─────────────────────────────────────── */
+
+interface RawProcess {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+async function listClaudeProcesses(): Promise<RawProcess[]> {
+  // ps -axo pid=,ppid=,command=  (= suppresses headers)
+  const { stdout } = await execFile('ps', ['-axo', 'pid=,ppid=,command=']);
+  const processes: RawProcess[] = [];
+  for (const line of stdout.split('\n')) {
+    const m = /^\s*(\d+)\s+(\d+)\s+(.+)$/.exec(line);
+    if (!m) continue;
+    const command = m[3]!.trim();
+    if (!isClaudeCommand(command)) continue;
+    processes.push({
+      pid: Number.parseInt(m[1]!, 10),
+      ppid: Number.parseInt(m[2]!, 10),
+      command,
+    });
+  }
+  return processes;
+}
+
+/**
+ * Match the `claude` CLI but reject lookalikes like
+ *   `/bin/zsh -c "... claude foo ..."` (a shell calling claude),
+ *   `claude --chrome` (Claude Desktop's helper).
+ *
+ * The CLI command line is either bare `claude` (or `claude <subcmd>`)
+ * or its absolute path ending in `/claude`. We tolerate flags but
+ * reject anything where `claude` isn't the first token.
+ */
+function isClaudeCommand(command: string): boolean {
+  const first = command.split(/\s+/, 1)[0] ?? '';
+  if (first.endsWith('/claude') || first === 'claude') {
+    // Reject Claude Desktop helper.
+    if (command.includes('--chrome')) return false;
+    return true;
+  }
+  return false;
+}
+
+/** Returns the cwd of a process, or null if it can't be resolved. */
+async function getProcessCwd(pid: number): Promise<string | null> {
+  try {
+    // -a ANDs the filters; without it lsof ORs them and dumps everything.
+    const { stdout } = await execFile('lsof', [
+      '-a',
+      '-p',
+      String(pid),
+      '-d',
+      'cwd',
+      '-F',
+      'n',
+    ]);
+    // Format:
+    //   p<pid>
+    //   fcwd
+    //   n<path>
+    for (const line of stdout.split('\n')) {
+      if (line.startsWith('n')) return line.slice(1);
+    }
+  } catch {
+    // process gone, or no permission
+  }
+  return null;
+}
+
+async function resolveClaudeCwds(
+  procs: RawProcess[],
+): Promise<ClaudeProcess[]> {
+  return Promise.all(
+    procs.map(async (p) => {
+      const cwd = await getProcessCwd(p.pid);
+      const result: ClaudeProcess = {
+        pid: p.pid,
+        ppid: p.ppid,
+        command: p.command,
+      };
+      if (cwd !== null) result.cwd = cwd;
+      return result;
+    }),
+  );
+}
+
+/** ─── snapshot (fleet-wide) ─────────────────────────────────── */
+
+/**
+ * One ps + one tmux-list-sessions per snapshot, regardless of how many
+ * worktrees we're attributing. Cards consume the resulting per-agent
+ * slice. Caller decides cadence.
+ */
+export async function snapshotProcessState(
+  input: SnapshotInput,
+): Promise<Record<string, CCProcessState>> {
+  const [tmuxByAgent, rawClaudes] = await Promise.all([
+    listRanchTmuxSessions(),
+    listClaudeProcesses(),
+  ]);
+  const claudes = await resolveClaudeCwds(rawClaudes);
+
+  // Bucket claude processes by worktree (string-prefix match: a claude
+  // started inside a subdirectory of the worktree still attributes
+  // back to the worktree).
+  const out: Record<string, CCProcessState> = {};
+  for (const [agent, worktreePath] of Object.entries(input.agents)) {
+    const tmux = tmuxByAgent.get(agent) ?? null;
+    const inWorktree = claudes.filter(
+      (c) => c.cwd !== undefined && isWithin(c.cwd, worktreePath),
+    );
+    out[agent] = {
+      tmux,
+      claudeRunning: inWorktree.length > 0,
+      claudeProcesses: inWorktree,
+    };
+  }
+  return out;
+}
+
+function isWithin(path: string, base: string): boolean {
+  if (path === base) return true;
+  const baseSlash = base.endsWith('/') ? base : base + '/';
+  return path.startsWith(baseSlash);
+}

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -27,6 +27,8 @@ const IPC_CHANNELS = {
   configGet: 'ranch:config:get',
   worktreesList: 'ranch:worktrees:list',
   worktreesSession: 'ranch:worktrees:session',
+  worktreesGit: 'ranch:worktrees:git',
+  worktreesProcessSnapshot: 'ranch:worktrees:processSnapshot',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -63,6 +65,9 @@ const api: RanchApi = {
     list: () => ipcRenderer.invoke(IPC_CHANNELS.worktreesList),
     session: (agent) =>
       ipcRenderer.invoke(IPC_CHANNELS.worktreesSession, agent),
+    git: (agent) => ipcRenderer.invoke(IPC_CHANNELS.worktreesGit, agent),
+    processSnapshot: () =>
+      ipcRenderer.invoke(IPC_CHANNELS.worktreesProcessSnapshot),
   },
   terminal: {
     env: () => ipcRenderer.invoke(IPC_CHANNELS.terminalEnv),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -1,13 +1,17 @@
 import { useEffect, useState } from 'react';
 import type {
+  CCProcessState,
   SessionState,
   TerminalEnv,
   TodoItem,
   WorktreeBasics,
+  WorktreeGitState,
 } from '../shared/types.js';
 import { Terminal } from './Terminal.js';
 
 const SESSION_POLL_MS = 4000;
+const PROCESS_POLL_MS = 5000;
+const GIT_POLL_MS = 8000;
 const WORKTREE_POLL_MS = 30_000;
 
 interface AppState {
@@ -32,6 +36,9 @@ export function App(): JSX.Element {
     null,
   );
   const [terminalEnv, setTerminalEnv] = useState<TerminalEnv | null>(null);
+  const [processSnapshot, setProcessSnapshot] = useState<
+    Record<string, CCProcessState>
+  >({});
 
   useEffect(() => {
     let cancelled = false;
@@ -40,6 +47,26 @@ export function App(): JSX.Element {
     });
     return () => {
       cancelled = true;
+    };
+  }, []);
+
+  // Fleet-wide process snapshot (one ps + one tmux-list per tick, all agents).
+  // Cheaper than per-card polling and gives us cross-worktree consistency.
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      try {
+        const snap = await window.ranch.worktrees.processSnapshot();
+        if (!cancelled) setProcessSnapshot(snap);
+      } catch {
+        // tmux/ps errors are surfaced indirectly (empty snapshot)
+      }
+    }
+    void refresh();
+    const handle = setInterval(refresh, PROCESS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
     };
   }, []);
 
@@ -107,6 +134,7 @@ export function App(): JSX.Element {
             state={state}
             onOpenTerminal={openTerminal}
             terminalEnv={terminalEnv}
+            processSnapshot={processSnapshot}
           />
         </section>
         <section className="pane pane--terminal">
@@ -155,10 +183,12 @@ function Grid({
   state,
   onOpenTerminal,
   terminalEnv,
+  processSnapshot,
 }: {
   state: AppState;
   onOpenTerminal: (agent: string) => void;
   terminalEnv: TerminalEnv | null;
+  processSnapshot: Record<string, CCProcessState>;
 }): JSX.Element {
   if (state.status === 'loading') {
     return <p className="placeholder">Loading worktrees…</p>;
@@ -190,6 +220,7 @@ function Grid({
             worktree={wt}
             onOpenTerminal={onOpenTerminal}
             terminalEnv={terminalEnv}
+            processState={processSnapshot[wt.agent] ?? null}
           />
         ))}
       </div>
@@ -201,15 +232,18 @@ interface WorktreeCardProps {
   worktree: WorktreeBasics;
   onOpenTerminal: (agent: string) => void;
   terminalEnv: TerminalEnv | null;
+  processState: CCProcessState | null;
 }
 
 function WorktreeCard({
   worktree,
   onOpenTerminal,
   terminalEnv,
+  processState,
 }: WorktreeCardProps): JSX.Element {
   const [session, setSession] = useState<SessionState | null>(null);
   const [sessionError, setSessionError] = useState<string | null>(null);
+  const [git, setGit] = useState<WorktreeGitState | null>(null);
 
   // Per-card transcript polling: cheap (file mtime + parse tail) and the
   // freshness here is what makes the card actually useful.
@@ -238,19 +272,44 @@ function WorktreeCard({
     };
   }, [worktree.agent]);
 
+  // Per-card git state polling. Slower than transcript — branch + last
+  // commit only change when the operator does something.
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      try {
+        const next = await window.ranch.worktrees.git(worktree.agent);
+        if (!cancelled) setGit(next);
+      } catch {
+        // ignore — card just won't show git row
+      }
+    }
+    void refresh();
+    const handle = setInterval(refresh, GIT_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [worktree.agent]);
+
   return (
     <article className="card">
       <header className="card__header">
         <span className="card__name">{worktree.agent}</span>
-        <SessionPill session={session} error={sessionError} />
+        <SessionPill
+          session={session}
+          processState={processState}
+          error={sessionError}
+        />
       </header>
       {worktree.description && (
         <p className="card__desc">{worktree.description}</p>
       )}
       <p className="card__path">{worktree.worktreePath}</p>
-      <BranchRow session={session} />
+      <GitRow git={git} session={session} />
       <TopicLine session={session} />
       <TodoSummary todos={session?.todos ?? []} />
+      <ProcessRow processState={processState} />
       <PortsRow ports={worktree.ports} source={worktree.portsSource} />
       <DriftWarnings worktree={worktree} />
       {!worktree.envAgentExists && (
@@ -278,33 +337,126 @@ function WorktreeCard({
 
 function SessionPill({
   session,
+  processState,
   error,
 }: {
   session: SessionState | null;
+  processState: CCProcessState | null;
   error: string | null;
 }): JSX.Element {
   if (error) return <span className="pill pill--error">err</span>;
+  // Process state is the strongest signal — claude is or isn't running now.
+  if (processState?.claudeRunning) {
+    return <span className="pill pill--running">claude running</span>;
+  }
   if (!session) return <span className="pill">…</span>;
   if (session.status === 'none') {
     return <span className="pill pill--idle">no session</span>;
   }
   const age = relativeAge(session.lastActivityAt);
-  return <span className="pill pill--active">active · {age}</span>;
+  return <span className="pill pill--active">last · {age}</span>;
 }
 
-function BranchRow({
+function GitRow({
+  git,
   session,
 }: {
+  git: WorktreeGitState | null;
   session: SessionState | null;
 }): JSX.Element | null {
-  const branch = session?.gitBranch;
-  if (!branch) return null;
-  const ticket = extractTicketId(branch);
+  // git observer is authoritative; transcript branch is fallback while
+  // git poll is in flight on first paint.
+  let branch: string | undefined;
+  if (git?.status === 'ok') branch = git.branch;
+  else if (session?.gitBranch) branch = session.gitBranch;
+
+  if (!branch && (!git || git.status !== 'ok')) return null;
+
+  const ticket = branch ? extractTicketId(branch) : null;
+  const dirty = git?.status === 'ok' && git.dirty;
+  const ahead = git?.status === 'ok' ? (git.ahead ?? 0) : 0;
+  const behind = git?.status === 'ok' ? (git.behind ?? 0) : 0;
+  const lastCommit = git?.status === 'ok' ? git.lastCommit : undefined;
+
   return (
-    <p className="card__branch">
-      <span className="card__branch-name">{branch}</span>
-      {ticket && <span className="card__ticket">{ticket}</span>}
-    </p>
+    <div className="card__git">
+      <div className="card__git-line">
+        {branch && <span className="card__branch-name">{branch}</span>}
+        {ticket && <span className="card__ticket">{ticket}</span>}
+        {dirty && (
+          <span
+            className="card__git-dirty"
+            title="Uncommitted changes in working tree"
+          >
+            ●
+          </span>
+        )}
+        {(ahead > 0 || behind > 0) && (
+          <span
+            className="card__git-ahead-behind"
+            title={`${ahead} ahead, ${behind} behind origin/develop`}
+          >
+            {ahead > 0 && `↑${ahead}`}
+            {behind > 0 && `↓${behind}`}
+          </span>
+        )}
+      </div>
+      {lastCommit && (
+        <div
+          className="card__git-commit"
+          title={`${lastCommit.sha} · ${lastCommit.age}`}
+        >
+          <code>{lastCommit.sha}</code> {truncate(lastCommit.message, 60)}{' '}
+          <span className="card__git-age">· {lastCommit.age}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProcessRow({
+  processState,
+}: {
+  processState: CCProcessState | null;
+}): JSX.Element | null {
+  if (!processState) return null;
+  const tmuxBadge = processState.tmux ? (
+    <span
+      className="proc-badge proc-badge--ok"
+      title={
+        processState.tmux.attachedClients > 0
+          ? `tmux session with ${processState.tmux.attachedClients} client(s)`
+          : 'tmux session detached but alive'
+      }
+    >
+      tmux ✓ {processState.tmux.attachedClients > 0 ? '· attached' : ''}
+    </span>
+  ) : (
+    <span className="proc-badge proc-badge--off" title="No ranch- tmux session">
+      tmux —
+    </span>
+  );
+  const claudePids = processState.claudeProcesses.map((p) => p.pid).join(', ');
+  const claudeBadge = processState.claudeRunning ? (
+    <span
+      className="proc-badge proc-badge--ok"
+      title={`claude PID(s): ${claudePids}`}
+    >
+      claude · {processState.claudeProcesses.length}
+    </span>
+  ) : (
+    <span
+      className="proc-badge proc-badge--off"
+      title="No claude process in this worktree"
+    >
+      claude —
+    </span>
+  );
+  return (
+    <div className="card__procs">
+      {tmuxBadge}
+      {claudeBadge}
+    </div>
   );
 }
 

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -169,6 +169,53 @@ body,
   color: var(--text-muted);
 }
 
+.card__git {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.78rem;
+}
+
+.card__git-line {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.card__git-dirty {
+  color: var(--yellow);
+  font-size: 0.85em;
+}
+
+.card__git-ahead-behind {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  color: var(--text-muted);
+  font-size: 0.85em;
+  letter-spacing: -0.02em;
+}
+
+.card__git-commit {
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.card__git-commit code {
+  background: var(--bg-elevated);
+  padding: 0.05rem 0.3rem;
+  border-radius: 2px;
+  font-size: 0.95em;
+  color: var(--accent);
+}
+
+.card__git-age {
+  color: var(--text-dim);
+  font-style: italic;
+}
+
 .card__ticket {
   background: rgba(106, 162, 255, 0.15);
   color: var(--accent);
@@ -213,10 +260,16 @@ body,
   white-space: nowrap;
 }
 
-.pill--active {
-  background: rgba(92, 212, 122, 0.12);
+.pill--running {
+  background: rgba(92, 212, 122, 0.18);
   color: var(--green);
-  border-color: rgba(92, 212, 122, 0.3);
+  border-color: rgba(92, 212, 122, 0.45);
+}
+
+.pill--active {
+  background: rgba(106, 162, 255, 0.12);
+  color: var(--accent);
+  border-color: rgba(106, 162, 255, 0.3);
 }
 
 .pill--idle {
@@ -293,6 +346,35 @@ body,
 }
 
 .todo--pending .todo__icon {
+  color: var(--text-dim);
+}
+
+/* ─── Process badges ───────────────────────────────────────────── */
+
+.card__procs {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  margin-top: 0.05rem;
+}
+
+.proc-badge {
+  font-size: 0.68rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 3px;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  letter-spacing: 0;
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+}
+
+.proc-badge--ok {
+  color: var(--green);
+  border-color: rgba(92, 212, 122, 0.3);
+  background: rgba(92, 212, 122, 0.06);
+}
+
+.proc-badge--off {
   color: var(--text-dim);
 }
 

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -69,6 +69,47 @@ export interface WorktreeBasics {
   envAgentPorts: WorktreePorts;
 }
 
+// ─── Git state (MVP-2) ──────────────────────────────────────────────────
+
+export interface GitLastCommit {
+  sha: string;
+  message: string;
+  age: string;
+}
+
+export type WorktreeGitState =
+  | { status: 'no-git' }
+  | {
+      status: 'ok';
+      branch: string;
+      dirty: boolean;
+      ahead?: number;
+      behind?: number;
+      lastCommit?: GitLastCommit;
+    };
+
+// ─── Process state (MVP-4) ──────────────────────────────────────────────
+
+export interface TmuxSessionState {
+  sessionName: string;
+  exists: boolean;
+  attachedClients: number;
+  createdAt?: string;
+}
+
+export interface ClaudeProcess {
+  pid: number;
+  ppid: number;
+  command: string;
+  cwd?: string;
+}
+
+export interface CCProcessState {
+  tmux: TmuxSessionState | null;
+  claudeRunning: boolean;
+  claudeProcesses: ClaudeProcess[];
+}
+
 // ─── CC session state (MVP-3: from ~/.claude/projects/<encoded>/*.jsonl) ─
 
 export type TodoStatus = 'pending' | 'in_progress' | 'completed';
@@ -132,6 +173,9 @@ export interface RanchApi {
   worktrees: {
     list: () => Promise<WorktreeBasics[]>;
     session: (agent: string) => Promise<SessionState>;
+    git: (agent: string) => Promise<WorktreeGitState>;
+    /** Fleet snapshot — one ps + one tmux-list per call, all agents. */
+    processSnapshot: () => Promise<Record<string, CCProcessState>>;
   };
   terminal: {
     env: () => Promise<TerminalEnv>;


### PR DESCRIPTION
## Summary

Two new triangles built on the existing IPC pattern, both feeding the worktree card.

**MVP-2 (#37) — git state observer.** \`src/main/git.ts\` shells out to git for: branch name, dirty/clean, commits ahead/behind \`origin/develop\`, and last commit (sha + message + relative age). Card replaces the transcript-derived branch row with a richer git row: branch, ticket pill, yellow dirty dot, \`↑3 ↓1\` ahead/behind counters, last commit summary.

**MVP-4 (#39) — tmux + claude process detection.** \`src/main/process.ts\` does one fleet-wide snapshot per tick (one \`ps\`, one \`tmux list-sessions\`, plus one \`lsof\` per claude process) and buckets the results by worktree. Card gains two badges: \`tmux ✓\` (or \`—\`) and \`claude · N\` showing how many claude processes are running with cwd in this worktree. The session pill becomes \`claude running\` (green) when a process is detected, falling back to transcript freshness otherwise.

## Architectural choice: fleet snapshot vs per-card polling

Each card could call its own \`process(agent)\` IPC every 5s — but that's 4 \`ps\` invocations per tick, 4 \`tmux ls\`, and N \`lsof\` calls. Wasteful. Instead, App-level state polls \`processSnapshot()\` once and passes per-agent slices down via prop. One round trip, all four cards rendered consistently.

This is the same pattern Phase A2 (event bus) will scale up: aggregate at the source, fan out at the renderer.

## Cross-contamination groundwork

The \`cwd\` attribution from \`lsof\` is the load-bearing primitive. A card whose worktree is jeffy/ but reports a claude process running there with PPID rooted in ranch-max's tmux is the exact scenario you described — agents killing each other's sessions. We're not detecting that yet (MVP-5 polish), but every claude process's cwd is now known to ranch.

## Verification

- \`pnpm typecheck\` — clean (full strict + exactOptionalPropertyTypes)
- \`pnpm lint\` — clean
- \`pnpm format:check\` — clean
- \`pnpm build\` — main 18 kB, preload 2 kB, renderer ~810 kB

## Test plan

- [ ] Pull, \`pnpm install\`, \`pnpm dev\`
- [ ] Each card shows current branch + last commit info
- [ ] Make a dirty change in one worktree (\`echo > foo\`); within ~8s the card shows the dirty yellow dot
- [ ] Run \`claude\` in a worktree (via the embedded terminal); within ~5s the pill flips to \`claude running\` (green) and the \`claude · 1\` badge lights up
- [ ] Quit claude; pill falls back to last-activity, badge dims to \`claude —\`
- [ ] Open the embedded terminal on max → \`tmux\` badge shows \`tmux ✓ · attached\`; close the terminal pane → badge stays \`tmux ✓\` (no \`attached\`)
- [ ] Hover the \`claude · N\` badge → tooltip shows the PIDs
- [ ] Hover \`↑3 ↓1\` → tooltip explains the counts

## What's next

- **MVP-5** — polish the card layout now that all six data sources are landing; add cross-contamination warnings (claude process where it shouldn't be)
- **Phase A2 (deferred)** — replace polling with the event bus; the React card code stays nearly identical, the data just arrives via push

🤖 Generated with [Claude Code](https://claude.com/claude-code)