### PR TITLE
feat(console): cross-contamination warnings + card polish (MVP-5, closes #40)

### DIFF
--- a/console/src/main/process.ts
+++ b/console/src/main/process.ts
@@ -26,6 +26,7 @@ import { promisify } from 'node:util';
 import type {
   CCProcessState,
   ClaudeProcess,
+  ProcessSnapshot,
   TmuxSessionState,
 } from '../shared/types.js';
 
@@ -168,7 +169,7 @@ async function resolveClaudeCwds(
  */
 export async function snapshotProcessState(
   input: SnapshotInput,
-): Promise<Record<string, CCProcessState>> {
+): Promise<ProcessSnapshot> {
   const [tmuxByAgent, rawClaudes] = await Promise.all([
     listRanchTmuxSessions(),
     listClaudeProcesses(),
@@ -178,19 +179,32 @@ export async function snapshotProcessState(
   // Bucket claude processes by worktree (string-prefix match: a claude
   // started inside a subdirectory of the worktree still attributes
   // back to the worktree).
-  const out: Record<string, CCProcessState> = {};
+  const perAgent: Record<string, CCProcessState> = {};
+  const claimed = new Set<number>();
   for (const [agent, worktreePath] of Object.entries(input.agents)) {
     const tmux = tmuxByAgent.get(agent) ?? null;
     const inWorktree = claudes.filter(
       (c) => c.cwd !== undefined && isWithin(c.cwd, worktreePath),
     );
-    out[agent] = {
+    for (const p of inWorktree) claimed.add(p.pid);
+    perAgent[agent] = {
       tmux,
       claudeRunning: inWorktree.length > 0,
       claudeProcesses: inWorktree,
     };
   }
-  return out;
+
+  // Orphans: claudes that didn't attribute to any registered worktree.
+  // Could be an operator running claude in a non-tracked dir (Documents/,
+  // a one-off scratch repo) or, more concerningly, a claude inside one
+  // of our worktrees that we somehow missed. The cwd will tell.
+  const orphanClaudes = claudes.filter((c) => !claimed.has(c.pid));
+
+  return {
+    perAgent,
+    orphanClaudes,
+    totalClaudes: claudes.length,
+  };
 }
 
 function isWithin(path: string, base: string): boolean {

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useState } from 'react';
 import type {
   CCProcessState,
+  ProcessSnapshot,
   SessionState,
   TerminalEnv,
   TodoItem,
   WorktreeBasics,
   WorktreeGitState,
 } from '../shared/types.js';
+
+const EMPTY_SNAPSHOT: ProcessSnapshot = {
+  perAgent: {},
+  orphanClaudes: [],
+  totalClaudes: 0,
+};
 import { Terminal } from './Terminal.js';
 
 const SESSION_POLL_MS = 4000;
@@ -36,9 +43,8 @@ export function App(): JSX.Element {
     null,
   );
   const [terminalEnv, setTerminalEnv] = useState<TerminalEnv | null>(null);
-  const [processSnapshot, setProcessSnapshot] = useState<
-    Record<string, CCProcessState>
-  >({});
+  const [processSnapshot, setProcessSnapshot] =
+    useState<ProcessSnapshot>(EMPTY_SNAPSHOT);
 
   useEffect(() => {
     let cancelled = false;
@@ -188,7 +194,7 @@ function Grid({
   state: AppState;
   onOpenTerminal: (agent: string) => void;
   terminalEnv: TerminalEnv | null;
-  processSnapshot: Record<string, CCProcessState>;
+  processSnapshot: ProcessSnapshot;
 }): JSX.Element {
   if (state.status === 'loading') {
     return <p className="placeholder">Loading worktrees…</p>;
@@ -213,6 +219,7 @@ function Grid({
           to enable embedded terminals.
         </p>
       )}
+      <FleetWarnings snapshot={processSnapshot} />
       <div className="grid">
         {state.worktrees.map((wt) => (
           <WorktreeCard
@@ -220,11 +227,36 @@ function Grid({
             worktree={wt}
             onOpenTerminal={onOpenTerminal}
             terminalEnv={terminalEnv}
-            processState={processSnapshot[wt.agent] ?? null}
+            processState={processSnapshot.perAgent[wt.agent] ?? null}
           />
         ))}
       </div>
     </>
+  );
+}
+
+function FleetWarnings({
+  snapshot,
+}: {
+  snapshot: ProcessSnapshot;
+}): JSX.Element | null {
+  if (snapshot.orphanClaudes.length === 0) return null;
+  return (
+    <div className="fleet-warnings">
+      <p className="fleet-warnings__heading">
+        ⚠ {snapshot.orphanClaudes.length} claude process
+        {snapshot.orphanClaudes.length === 1 ? '' : 'es'} running outside any
+        registered worktree
+      </p>
+      <ul className="fleet-warnings__list">
+        {snapshot.orphanClaudes.map((p) => (
+          <li key={p.pid} className="fleet-warnings__item">
+            <code>PID {p.pid}</code>
+            {p.cwd && <span className="fleet-warnings__path">{p.cwd}</span>}
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 
@@ -294,29 +326,45 @@ function WorktreeCard({
 
   return (
     <article className="card">
+      {/* Identity */}
       <header className="card__header">
-        <span className="card__name">{worktree.agent}</span>
+        <div className="card__identity">
+          <span className="card__name">{worktree.agent}</span>
+          {worktree.description && (
+            <span className="card__desc">{worktree.description}</span>
+          )}
+        </div>
         <SessionPill
           session={session}
           processState={processState}
           error={sessionError}
         />
       </header>
-      {worktree.description && (
-        <p className="card__desc">{worktree.description}</p>
-      )}
       <p className="card__path">{worktree.worktreePath}</p>
+
+      <div className="card__divider" />
+
+      {/* Live work */}
       <GitRow git={git} session={session} />
       <TopicLine session={session} />
       <TodoSummary todos={session?.todos ?? []} />
+
+      <div className="card__divider" />
+
+      {/* Infrastructure */}
       <ProcessRow processState={processState} />
       <PortsRow ports={worktree.ports} source={worktree.portsSource} />
+
+      {/* Warnings */}
+      <ProcessWarnings processState={processState} />
       <DriftWarnings worktree={worktree} />
       {!worktree.envAgentExists && (
         <p className="card__warn">
           No <code>.env.agent</code> at this worktree.
         </p>
       )}
+
+      {/* Actions */}
       <footer className="card__actions">
         <button
           className="card__action"
@@ -332,6 +380,36 @@ function WorktreeCard({
         </button>
       </footer>
     </article>
+  );
+}
+
+function ProcessWarnings({
+  processState,
+}: {
+  processState: CCProcessState | null;
+}): JSX.Element | null {
+  if (!processState || !processState.claudeRunning) return null;
+  const warnings: string[] = [];
+  if (!processState.tmux) {
+    warnings.push(
+      'claude is running here but no ranch- tmux session exists. It was likely started outside ranch — closing it from a stray terminal could surprise you. Use Open terminal to bring it under ranch.',
+    );
+  }
+  if (processState.claudeProcesses.length > 1) {
+    const pids = processState.claudeProcesses.map((p) => p.pid).join(', ');
+    warnings.push(
+      `${processState.claudeProcesses.length} claude processes here (PIDs ${pids}). Possible duplicate session — pick the right one before sending input.`,
+    );
+  }
+  if (warnings.length === 0) return null;
+  return (
+    <div className="card__drift">
+      {warnings.map((m, i) => (
+        <p key={i} className="card__warn">
+          ⚠ {m}
+        </p>
+      ))}
+    </div>
   );
 }
 

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -127,9 +127,16 @@ body,
 
 .card__header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.6rem;
+}
+
+.card__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  min-width: 0;
 }
 
 .card__name {
@@ -140,10 +147,15 @@ body,
 }
 
 .card__desc {
-  margin: 0;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   color: var(--text-dim);
   font-style: italic;
+}
+
+.card__divider {
+  height: 1px;
+  background: var(--border);
+  margin: 0.15rem 0;
 }
 
 .card__path {
@@ -450,6 +462,61 @@ body,
   border: 1px solid rgba(246, 193, 119, 0.3);
   border-radius: 4px;
   padding: 0.35rem 0.6rem;
+}
+
+/* ─── Fleet warnings ───────────────────────────────────────────── */
+
+.fleet-warnings {
+  margin: 0 0 0.6rem 0;
+  background: rgba(246, 193, 119, 0.06);
+  border: 1px solid rgba(246, 193, 119, 0.3);
+  border-radius: 4px;
+  padding: 0.45rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.fleet-warnings__heading {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--yellow);
+  font-weight: 600;
+}
+
+.fleet-warnings__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.fleet-warnings__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  align-items: baseline;
+}
+
+.fleet-warnings__item code {
+  background: var(--bg-elevated);
+  padding: 0.05rem 0.35rem;
+  border-radius: 2px;
+  font-size: 0.95em;
+  color: var(--accent);
+}
+
+.fleet-warnings__path {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .card__drift {

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -110,6 +110,19 @@ export interface CCProcessState {
   claudeProcesses: ClaudeProcess[];
 }
 
+export interface ProcessSnapshot {
+  /** Per-registered-agent process state. */
+  perAgent: Record<string, CCProcessState>;
+  /**
+   * Claude processes whose cwd doesn't match any registered worktree —
+   * either truly outside the agent fleet (e.g. a manual `claude` in
+   * Documents/) or in an unregistered subproject.
+   */
+  orphanClaudes: ClaudeProcess[];
+  /** Total number of claude processes seen across all categories. */
+  totalClaudes: number;
+}
+
 // ─── CC session state (MVP-3: from ~/.claude/projects/<encoded>/*.jsonl) ─
 
 export type TodoStatus = 'pending' | 'in_progress' | 'completed';
@@ -175,7 +188,7 @@ export interface RanchApi {
     session: (agent: string) => Promise<SessionState>;
     git: (agent: string) => Promise<WorktreeGitState>;
     /** Fleet snapshot — one ps + one tmux-list per call, all agents. */
-    processSnapshot: () => Promise<Record<string, CCProcessState>>;
+    processSnapshot: () => Promise<ProcessSnapshot>;
   };
   terminal: {
     env: () => Promise<TerminalEnv>;


### PR DESCRIPTION
## Summary

Closes the MVP set. Renders the cross-contamination signals the data has been carrying and tightens the card visual hierarchy.

### Fleet warnings banner

Process snapshot now returns \`orphanClaudes\` — claude processes whose cwd doesn't match any registered worktree. Surfaced as a yellow banner above the grid:

> ⚠ 1 claude process running outside any registered worktree
> PID 67632  /Users/.../citemed/citemed_web

This catches \"I started claude in the wrong dir\" — a setup that, per your earlier note, contributes to agents stomping each other.

### Per-card cross-contamination warnings

Two new yellow warnings on a card when present:

1. **\"claude running but no ranch- tmux session\"** — operator started claude in iTerm directly. Closing it from a stray window could surprise them; the warning nudges them to bring it under ranch via Open terminal.
2. **\"N claude processes here\"** — duplicate-session smell. Lists all PIDs.

### Card visual hierarchy

Reads top-to-bottom as four bands separated by subtle dividers:

| Band | Purpose |
|---|---|
| **Identity** | name + description + status pill |
| **Live work** | branch + ticket, topic, todo list — \"what is this agent doing right now?\" |
| **Infrastructure** | tmux/claude badges + port buttons — \"how is it wired?\" |
| **Warnings + Actions** | drift, contamination warnings, env-agent gaps, then Open terminal |

Description moved into the identity block (it was floating awkwardly above the path before).

## Verification

- \`pnpm typecheck\` — clean
- \`pnpm lint\` — clean
- \`pnpm format:check\` — clean
- \`pnpm build\` — main 18 kB, preload 2 kB, renderer ~820 kB

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Each card reads as four clear bands with dividers
- [ ] Run \`claude\` in a non-tracked dir (e.g. \`cd ~/Documents && claude\`) → fleet banner above grid lists it as an orphan with cwd
- [ ] Run \`claude\` in max's worktree but from iTerm directly (not via Open terminal) → max's card shows \"claude is running here but no ranch- tmux session\" warning
- [ ] Open the embedded terminal on max → warning clears within ~5s as ranch-max session appears
- [ ] (If reproducible) Have two claude processes in the same worktree → card warns about duplicate sessions with both PIDs

## What's next

The MVP set is complete. Suggested next:

- **Tighten any rough edges from real usage** — let's see what falls out after a day of using this in anger
- **A2 (event bus, deferred)** — replace polling with push when polling cost becomes annoying
- **Phase B (project externalization, deferred)** — when adding a fifth agent or second project becomes a real ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)