### PR TITLE
feat(console): auto-launch Claude on first open + Reveal/Copy

### DIFF
--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -13,7 +13,7 @@
  * stay in sync — easy to grep, easy to keep small.
  */
 
-import { app, ipcMain } from 'electron';
+import { app, ipcMain, shell } from 'electron';
 import { loadRanchConfig } from './config.js';
 import { listWorktrees } from './worktrees.js';
 import { getActiveSession } from './transcript.js';
@@ -43,6 +43,7 @@ export const IPC_CHANNELS = {
   terminalData: 'terminal:data',
   terminalExit: 'terminal:exit',
   appVersion: 'ranch:app:version',
+  appRevealInFinder: 'ranch:app:revealInFinder',
 } as const;
 
 export function registerIpcHandlers(): void {
@@ -85,7 +86,7 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(
     IPC_CHANNELS.terminalAttach,
-    async (event, agent: unknown, cols: unknown, rows: unknown) => {
+    async (event, agent: unknown, opts: unknown) => {
       if (typeof agent !== 'string' || !agent) {
         throw new Error('terminal.attach requires an agent name');
       }
@@ -94,11 +95,15 @@ export function registerIpcHandlers(): void {
       if (!match) {
         throw new Error(`Unknown agent: ${agent}`);
       }
+      const o = (opts as Record<string, unknown> | undefined) ?? {};
       return attachTerminal({
         agent,
         worktreePath: match.worktree,
-        ...(typeof cols === 'number' ? { cols } : {}),
-        ...(typeof rows === 'number' ? { rows } : {}),
+        ...(typeof o['cols'] === 'number' ? { cols: o['cols'] as number } : {}),
+        ...(typeof o['rows'] === 'number' ? { rows: o['rows'] as number } : {}),
+        ...(typeof o['command'] === 'string' && o['command']
+          ? { command: o['command'] as string }
+          : {}),
         webContents: event.sender,
       });
     },
@@ -131,4 +136,12 @@ export function registerIpcHandlers(): void {
   });
 
   ipcMain.handle(IPC_CHANNELS.appVersion, () => app.getVersion());
+
+  ipcMain.handle(IPC_CHANNELS.appRevealInFinder, (_event, path: unknown) => {
+    if (typeof path !== 'string' || !path) return;
+    // showItemInFolder reveals the path in Finder (selecting the item itself
+    // if it's a file, or showing the directory). Safer than openPath which
+    // would try to "open" the directory in whatever the default handler is.
+    shell.showItemInFolder(path);
+  });
 }

--- a/console/src/main/pty.ts
+++ b/console/src/main/pty.ts
@@ -92,6 +92,13 @@ interface AttachOptions {
   cols?: number;
   rows?: number;
   webContents: WebContents;
+  /**
+   * Command to run inside the tmux session if it doesn't already exist.
+   * tmux's `-A` flag (attach-or-create) ignores command args when the
+   * session is already running, so this only affects fresh sessions —
+   * exactly what we want.
+   */
+  command?: string;
 }
 
 export async function attachTerminal(
@@ -127,7 +134,10 @@ export async function attachTerminal(
   //   -A  attach if a session by this name exists, else create
   //   -s  session name
   //   -c  start directory (only used when creating a new session)
+  //   final positional COMMAND (if given) only runs when creating;
+  //   ignored when attaching to existing session
   const args = ['new-session', '-A', '-s', terminalId, '-c', opts.worktreePath];
+  if (opts.command) args.push(opts.command);
 
   const pty = ptySpawn(tmuxPath, args, {
     name: 'xterm-256color',

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -37,6 +37,7 @@ const IPC_CHANNELS = {
   terminalData: 'terminal:data',
   terminalExit: 'terminal:exit',
   appVersion: 'ranch:app:version',
+  appRevealInFinder: 'ranch:app:revealInFinder',
 } as const;
 
 /**
@@ -71,8 +72,8 @@ const api: RanchApi = {
   },
   terminal: {
     env: () => ipcRenderer.invoke(IPC_CHANNELS.terminalEnv),
-    attach: (agent, cols, rows) =>
-      ipcRenderer.invoke(IPC_CHANNELS.terminalAttach, agent, cols, rows),
+    attach: (agent, opts) =>
+      ipcRenderer.invoke(IPC_CHANNELS.terminalAttach, agent, opts ?? {}),
     write: (terminalId, data) =>
       ipcRenderer.invoke(IPC_CHANNELS.terminalWrite, terminalId, data),
     resize: (terminalId, cols, rows) =>
@@ -86,6 +87,8 @@ const api: RanchApi = {
   },
   app: {
     version: () => ipcRenderer.invoke(IPC_CHANNELS.appVersion),
+    revealInFinder: (path) =>
+      ipcRenderer.invoke(IPC_CHANNELS.appRevealInFinder, path),
   },
 };
 

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -340,7 +340,16 @@ function WorktreeCard({
           error={sessionError}
         />
       </header>
-      <p className="card__path">{worktree.worktreePath}</p>
+      <button
+        className="card__path"
+        onClick={() => {
+          void navigator.clipboard.writeText(worktree.worktreePath);
+        }}
+        title="Copy path"
+        type="button"
+      >
+        {worktree.worktreePath}
+      </button>
 
       <div className="card__divider" />
 
@@ -367,16 +376,25 @@ function WorktreeCard({
       {/* Actions */}
       <footer className="card__actions">
         <button
-          className="card__action"
+          className="card__action card__action--primary"
           onClick={() => onOpenTerminal(worktree.agent)}
           disabled={terminalEnv !== null && !terminalEnv.tmuxAvailable}
           title={
             terminalEnv && !terminalEnv.tmuxAvailable
               ? 'tmux not installed'
-              : 'Attach an embedded terminal to this worktree'
+              : `Open ${worktree.agent}'s embedded terminal — launches Claude on first open, attaches afterward`
           }
         >
-          Open terminal
+          Open Claude
+        </button>
+        <button
+          className="card__action"
+          onClick={() => {
+            void window.ranch.app.revealInFinder(worktree.worktreePath);
+          }}
+          title="Reveal worktree in Finder"
+        >
+          Reveal
         </button>
       </footer>
     </article>

--- a/console/src/renderer/Terminal.tsx
+++ b/console/src/renderer/Terminal.tsx
@@ -97,13 +97,16 @@ export function Terminal({ agent, generation }: TerminalProps): JSX.Element {
       }
     });
 
-    // 4. Attach.
+    // 4. Attach. We pass `command: 'claude'` so that if the tmux session
+    //    is being newly created (no existing ranch-<agent>), it launches
+    //    straight into claude. tmux's -A flag ignores the command when
+    //    attaching to an existing session, so this is no-op for re-attach.
     void (async () => {
-      const result = await window.ranch.terminal.attach(
-        agent,
-        initialCols,
-        initialRows,
-      );
+      const result = await window.ranch.terminal.attach(agent, {
+        cols: initialCols,
+        rows: initialRows,
+        command: 'claude',
+      });
       if (disposed) {
         if (result.ok) {
           void window.ranch.terminal.detach(result.terminalId);

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -166,6 +166,22 @@ body,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: copy;
+  font-family-: inherit;
+}
+
+.card__path:hover {
+  color: var(--text-muted);
+}
+
+.card__path:active {
+  color: var(--accent);
 }
 
 .card__branch {
@@ -454,6 +470,18 @@ body,
 .card__action:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.card__action--primary {
+  background: rgba(106, 162, 255, 0.12);
+  border-color: rgba(106, 162, 255, 0.4);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.card__action--primary:hover:not(:disabled) {
+  background: rgba(106, 162, 255, 0.2);
+  border-color: var(--accent);
 }
 
 .card__warn--banner {

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -160,6 +160,19 @@ export type TerminalAttachResult =
   | { ok: true; terminalId: string }
   | { ok: false; reason: string };
 
+/** Renderer-side options for ranch.terminal.attach. */
+export interface TerminalAttachOptions {
+  cols?: number;
+  rows?: number;
+  /**
+   * Command to run inside the tmux session if it's being newly created.
+   * Ignored if the session already exists (tmux -A semantics). Use this
+   * to launch `claude` immediately on first open, while still attaching
+   * cleanly on subsequent opens.
+   */
+  command?: string;
+}
+
 export interface TerminalDataEvent {
   terminalId: string;
   data: string;
@@ -194,8 +207,7 @@ export interface RanchApi {
     env: () => Promise<TerminalEnv>;
     attach: (
       agent: string,
-      cols?: number,
-      rows?: number,
+      opts?: TerminalAttachOptions,
     ) => Promise<TerminalAttachResult>;
     write: (terminalId: string, data: string) => Promise<void>;
     resize: (terminalId: string, cols: number, rows: number) => Promise<void>;
@@ -205,6 +217,8 @@ export interface RanchApi {
   };
   app: {
     version: () => Promise<string>;
+    /** Open a path in the OS file manager. */
+    revealInFinder: (path: string) => Promise<void>;
   };
 }
 


### PR DESCRIPTION
## Summary

Three small UX wins that compound into a much smoother flow:

- **Auto-launch Claude.** \"Open Claude\" (renamed from \"Open terminal\") now passes \`command: 'claude'\` to \`tmux new-session\`. First click → claude is running. Subsequent clicks → tmux's \`-A\` semantics attach to whatever's there (claude, shell, vim, anything).
- **Reveal in Finder.** Secondary button per card, uses Electron's \`shell.showItemInFolder\` so worktrees pop in Finder without leaving ranch.
- **Click worktree path → copy.** The grey path strip is now a button; click copies to clipboard. Useful for pasting into other terminals or browser bars.

## Details

### Why it's safe to always pass \`command: 'claude'\`

tmux's \`new-session -A\` is \"attach if exists, else create.\" The trailing positional command argument is **only used when creating** — ignored when attaching. So:

- No \`ranch-max\` session yet → tmux creates one running \`claude\` directly. User lands in a live claude REPL.
- \`ranch-max\` already exists (any state — claude running, shell at prompt, vim open) → tmux attaches to it as-is.

That means a user can quit claude inside the session, do shell work, and the next \"Open Claude\" click drops them back into the shell prompt where they left it. Not into a fresh claude. Predictable.

### Path is now a button

\`<button class=\"card__path\">\` styled to look like the previous text but supports \`onClick\` and proper a11y. Cursor flips to \`copy\` on hover.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Restart \`pnpm dev\`
- [ ] Click \"Open Claude\" on a worktree with no existing tmux session → claude REPL appears immediately at the worktree path
- [ ] Quit claude (Ctrl-C twice) inside the session → drops to shell prompt at worktree
- [ ] Click \"Open Claude\" on the same card again → reattaches to the shell (NOT a fresh claude — predictable)
- [ ] \`tmux kill-session -t ranch-<agent>\` from external terminal, click \"Open Claude\" again → fresh session with claude running
- [ ] Click \"Reveal\" → Finder opens at the worktree
- [ ] Click the grey path string → it's copied to clipboard (try pasting into another terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)