### PR TITLE
feat(console): awaiting-input detection — never miss a paused agent

### DIFF
--- a/console/src/main/transcript.ts
+++ b/console/src/main/transcript.ts
@@ -19,7 +19,15 @@ import { readdir, readFile, stat } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { SessionState, TodoItem, TodoStatus } from '../shared/types.js';
+import type {
+  SessionRunState,
+  SessionState,
+  TodoItem,
+  TodoStatus,
+} from '../shared/types.js';
+
+const ACTIVE_WINDOW_MS = 5_000;
+const IDLE_THRESHOLD_MS = 5 * 60_000;
 
 const PROJECTS_DIR = join(homedir(), '.claude', 'projects');
 
@@ -170,13 +178,102 @@ interface TranscriptScan {
   lastUserPrompt?: string;
   lastActivityAt?: string;
   gitBranch?: string;
+  runState: SessionRunState;
+}
+
+/**
+ * Pull the tool_use IDs from an assistant entry's content blocks.
+ */
+function extractAssistantToolUseIds(entry: Record<string, unknown>): string[] {
+  if (entry['type'] !== 'assistant') return [];
+  const ids: string[] = [];
+  for (const block of getMessageContent(entry)) {
+    const obj = asObject(block);
+    if (!obj) continue;
+    if (obj['type'] !== 'tool_use') continue;
+    const id = asString(obj['id']);
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Pull tool_result IDs that this user entry is responding to. CC writes
+ * these as `type: user` with a `content` array containing tool_result
+ * blocks (each carrying `tool_use_id`).
+ */
+function extractToolResultIds(entry: Record<string, unknown>): string[] {
+  if (entry['type'] !== 'user') return [];
+  const ids: string[] = [];
+  for (const block of getMessageContent(entry)) {
+    const obj = asObject(block);
+    if (!obj) continue;
+    if (obj['type'] !== 'tool_result') continue;
+    const id = asString(obj['tool_use_id']);
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Decide what state the session is in based on the latest assistant turn,
+ * subsequent tool results, and how long ago the last entry was written.
+ */
+function inferRunState(
+  entries: ParsedEntry[],
+  lastActivityAt: string | undefined,
+  now: number,
+): SessionRunState {
+  if (entries.length === 0) return 'unknown';
+
+  const lastTs = lastActivityAt ? Date.parse(lastActivityAt) : NaN;
+  const ageMs = Number.isFinite(lastTs) ? now - lastTs : Infinity;
+
+  // Find the latest assistant entry.
+  let latestAssistantIdx = -1;
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i]!.raw['type'] === 'assistant') {
+      latestAssistantIdx = i;
+      break;
+    }
+  }
+  if (latestAssistantIdx < 0) {
+    // No assistant entries seen — typically means user just opened a session.
+    return ageMs < ACTIVE_WINDOW_MS ? 'active' : 'idle';
+  }
+
+  // Tool uses requested in the latest assistant turn.
+  const toolUseIds = extractAssistantToolUseIds(
+    entries[latestAssistantIdx]!.raw,
+  );
+
+  if (toolUseIds.length > 0) {
+    // Walk forward looking for matching tool_results.
+    const responded = new Set<string>();
+    for (let i = latestAssistantIdx + 1; i < entries.length; i++) {
+      for (const id of extractToolResultIds(entries[i]!.raw)) {
+        responded.add(id);
+      }
+    }
+    const allAnswered = toolUseIds.every((id) => responded.has(id));
+    if (!allAnswered) {
+      // Tool call queued without a result yet — claude is mid-work
+      // (or the tool's hung; either way, not "awaiting input").
+      return 'tool_in_flight';
+    }
+  }
+
+  // Latest assistant turn either had no tools or all tools resolved.
+  if (ageMs < ACTIVE_WINDOW_MS) return 'active';
+  if (ageMs < IDLE_THRESHOLD_MS) return 'awaiting_input';
+  return 'idle';
 }
 
 /**
  * Walk entries newest → oldest. Stop early once we have everything.
  */
 function scanEntries(entries: ParsedEntry[]): TranscriptScan {
-  const result: TranscriptScan = { todos: [] };
+  const result: TranscriptScan = { todos: [], runState: 'unknown' };
   let foundTodos = false;
   let foundPrompt = false;
 
@@ -215,6 +312,8 @@ function scanEntries(entries: ParsedEntry[]): TranscriptScan {
       break;
     }
   }
+
+  result.runState = inferRunState(entries, result.lastActivityAt, Date.now());
   return result;
 }
 
@@ -223,11 +322,11 @@ export async function getActiveSession(
 ): Promise<SessionState> {
   const dir = projectsDirFor(worktreePath);
   if (!dir) {
-    return { status: 'none', todos: [] };
+    return { status: 'none', todos: [], runState: 'unknown' };
   }
   const newest = await findMostRecentSession(dir);
   if (!newest) {
-    return { status: 'none', todos: [] };
+    return { status: 'none', todos: [], runState: 'unknown' };
   }
   const raw = await readFile(newest.path, 'utf8');
   const entries: ParsedEntry[] = [];
@@ -241,6 +340,7 @@ export async function getActiveSession(
     sessionId: newest.sessionId,
     transcriptPath: newest.path,
     todos: scan.todos,
+    runState: scan.runState,
   };
   if (scan.lastActivityAt !== undefined)
     state.lastActivityAt = scan.lastActivityAt;

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -8,13 +8,13 @@ import type {
   WorktreeBasics,
   WorktreeGitState,
 } from '../shared/types.js';
+import { Terminal } from './Terminal.js';
 
 const EMPTY_SNAPSHOT: ProcessSnapshot = {
   perAgent: {},
   orphanClaudes: [],
   totalClaudes: 0,
 };
-import { Terminal } from './Terminal.js';
 
 const SESSION_POLL_MS = 4000;
 const PROCESS_POLL_MS = 5000;
@@ -324,8 +324,12 @@ function WorktreeCard({
     };
   }, [worktree.agent]);
 
+  const needsInput =
+    (processState?.claudeRunning ?? false) &&
+    session?.runState === 'awaiting_input';
+
   return (
-    <article className="card">
+    <article className={`card${needsInput ? ' card--needs-input' : ''}`}>
       {/* Identity */}
       <header className="card__header">
         <div className="card__identity">
@@ -441,8 +445,31 @@ function SessionPill({
   error: string | null;
 }): JSX.Element {
   if (error) return <span className="pill pill--error">err</span>;
-  // Process state is the strongest signal — claude is or isn't running now.
-  if (processState?.claudeRunning) {
+
+  // Combine process detection with transcript-derived run state for the
+  // strongest possible "what's claude doing right now" signal.
+  const claudeAlive = processState?.claudeRunning ?? false;
+  const runState = session?.runState ?? 'unknown';
+
+  if (claudeAlive && runState === 'awaiting_input') {
+    const age = relativeAge(session?.lastActivityAt);
+    return (
+      <span
+        className="pill pill--awaiting"
+        title="Claude is waiting on a human reply"
+      >
+        needs input · {age}
+      </span>
+    );
+  }
+  if (claudeAlive && runState === 'tool_in_flight') {
+    return (
+      <span className="pill pill--running" title="Claude is mid-tool-call">
+        working
+      </span>
+    );
+  }
+  if (claudeAlive) {
     return <span className="pill pill--running">claude running</span>;
   }
   if (!session) return <span className="pill">…</span>;

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -123,6 +123,24 @@ body,
   flex-direction: column;
   gap: 0.4rem;
   font-size: 0.85rem;
+  position: relative;
+  transition: border-color 0.2s ease;
+}
+
+.card--needs-input {
+  border-color: rgba(246, 193, 119, 0.55);
+  box-shadow: 0 0 0 1px rgba(246, 193, 119, 0.2);
+}
+
+.card--needs-input::before {
+  content: '';
+  position: absolute;
+  left: -1px;
+  top: -1px;
+  bottom: -1px;
+  width: 3px;
+  background: var(--yellow);
+  border-radius: 6px 0 0 6px;
 }
 
 .card__header {
@@ -292,6 +310,13 @@ body,
   background: rgba(92, 212, 122, 0.18);
   color: var(--green);
   border-color: rgba(92, 212, 122, 0.45);
+}
+
+.pill--awaiting {
+  background: rgba(246, 193, 119, 0.18);
+  color: var(--yellow);
+  border-color: rgba(246, 193, 119, 0.5);
+  font-weight: 600;
 }
 
 .pill--active {

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -133,6 +133,25 @@ export interface TodoItem {
   status: TodoStatus;
 }
 
+/**
+ * Inferred state of the latest CC session, derived from the transcript tail:
+ *
+ *   - 'active'         very recent activity (assistant just spoke, < ~5s)
+ *   - 'tool_in_flight' assistant kicked off a tool call and we haven't seen
+ *                      its result yet — claude is doing work
+ *   - 'awaiting_input' assistant has spoken (text-only or all tools resolved)
+ *                      and the transcript has been quiet — claude is waiting
+ *                      on a human reply
+ *   - 'idle'           nothing recent at all (transcript stale > ~5min)
+ *   - 'unknown'        couldn't determine (parse failures, no entries)
+ */
+export type SessionRunState =
+  | 'active'
+  | 'tool_in_flight'
+  | 'awaiting_input'
+  | 'idle'
+  | 'unknown';
+
 export interface SessionState {
   /** 'active' = transcript exists; 'none' = no transcript directory */
   status: 'active' | 'none';
@@ -147,6 +166,8 @@ export interface SessionState {
   todos: TodoItem[];
   /** Branch CC was on at the latest entry (assistant entries include `gitBranch`) */
   gitBranch?: string;
+  /** Inferred run state — see SessionRunState */
+  runState: SessionRunState;
 }
 
 // ─── Terminal (MVP-6) ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The card now tells you when a Claude session is **waiting on you** vs **doing work** vs **idle** — not just whether claude is running. Combines transcript tail analysis (which tool calls are unanswered) with process detection.

## Heuristic

\`SessionRunState\` derived per transcript:

| Latest assistant turn | Tool results pending? | Age | State |
|---|---|---|---|
| Has tool_use | Some unanswered | any | \`tool_in_flight\` |
| No tools / all answered | — | <5s | \`active\` |
| No tools / all answered | — | 5s–5min | \`awaiting_input\` |
| Anything | — | >5min | \`idle\` |

Combined with \`processState.claudeRunning\`, the renderer chooses the strongest signal:

- claude alive + awaiting_input → **\"needs input\"** yellow pill, card gets a left border + soft yellow ring
- claude alive + tool_in_flight → **\"working\"** green pill
- claude alive otherwise → existing **\"claude running\"** pill
- claude not alive → existing fallbacks (last activity / no session)

## Why this matters

Today you'd only know an agent was paused if you clicked into the terminal. Now the card lights up across the grid — glance at the four cards and the one demanding attention is unmistakable.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Find/create a session that's currently in mid-tool-call (e.g. a long Bash) → card pill reads \"working\"
- [ ] Let claude finish and sit at a prompt for >5s → pill flips to \"needs input\" (yellow), card gets the yellow left border
- [ ] Reply to claude → activity → pill flips back to \"working\" or \"claude running\"
- [ ] Quit claude entirely → pill returns to \"last · Xm ago\"

## What's next

Suggested:
- **Inbox panel populated** — the \"needs input\" cards plus orphan claudes are exactly the items that belong in an inbox stream with click-to-route
- **Cross-tmux contamination** — walk PPID tree to detect \"claude in jeffy/ but tmux parent is ranch-max\" cases that today's heuristic misses
- **Multiple terminals visible at once** — split or tab the terminal pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)