### PR TITLE
feat(console): 4-up live terminal grid + editable per-agent notes

### DIFF
--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -19,6 +19,7 @@ import { listWorktrees } from './worktrees.js';
 import { getActiveSession } from './transcript.js';
 import { getWorktreeGitState } from './git.js';
 import { snapshotProcessState } from './process.js';
+import { getAllNotes, setNote } from './notes.js';
 import {
   attachTerminal,
   detachTerminal,
@@ -33,6 +34,8 @@ export const IPC_CHANNELS = {
   worktreesSession: 'ranch:worktrees:session',
   worktreesGit: 'ranch:worktrees:git',
   worktreesProcessSnapshot: 'ranch:worktrees:processSnapshot',
+  notesGetAll: 'ranch:notes:getAll',
+  notesSet: 'ranch:notes:set',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -81,6 +84,21 @@ export function registerIpcHandlers(): void {
     for (const a of config.agents) agents[a.name] = a.worktree;
     return snapshotProcessState({ agents });
   });
+
+  ipcMain.handle(IPC_CHANNELS.notesGetAll, async () => getAllNotes());
+
+  ipcMain.handle(
+    IPC_CHANNELS.notesSet,
+    async (_event, agent: unknown, label: unknown) => {
+      if (typeof agent !== 'string' || !agent) {
+        throw new Error('notes.set requires an agent name');
+      }
+      if (typeof label !== 'string') {
+        throw new Error('notes.set requires a string label');
+      }
+      return setNote(agent, label);
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.terminalEnv, async () => getTerminalEnv());
 

--- a/console/src/main/notes.ts
+++ b/console/src/main/notes.ts
@@ -1,0 +1,93 @@
+/**
+ * Operator-owned per-agent notes — free-form labels like
+ * "max will work on scrapers tickets today".
+ *
+ * Lives at ~/.ranch/notes.json (operator's home dir, intentionally
+ * out of every agent's worktree so a stray rm/edit can't blow them
+ * away). Writes are atomic: write to a tmp file, rename onto target.
+ */
+
+import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import type { AgentNote } from '../shared/types.js';
+
+const RANCH_DIR = process.env.RANCH_HOME ?? join(homedir(), '.ranch');
+const NOTES_PATH = join(RANCH_DIR, 'notes.json');
+
+interface NotesFile {
+  agents: Record<string, AgentNote>;
+}
+
+function emptyFile(): NotesFile {
+  return { agents: {} };
+}
+
+async function readFileSafe(): Promise<NotesFile> {
+  if (!existsSync(NOTES_PATH)) return emptyFile();
+  try {
+    const raw = await readFile(NOTES_PATH, 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      'agents' in parsed &&
+      typeof (parsed as { agents: unknown }).agents === 'object' &&
+      (parsed as { agents: unknown }).agents !== null
+    ) {
+      const agents = (parsed as { agents: Record<string, unknown> }).agents;
+      const out: Record<string, AgentNote> = {};
+      for (const [k, v] of Object.entries(agents)) {
+        if (
+          typeof v === 'object' &&
+          v !== null &&
+          typeof (v as AgentNote).label === 'string' &&
+          typeof (v as AgentNote).updatedAt === 'string'
+        ) {
+          out[k] = {
+            label: (v as AgentNote).label,
+            updatedAt: (v as AgentNote).updatedAt,
+          };
+        }
+      }
+      return { agents: out };
+    }
+  } catch {
+    // corrupt file — fall through to empty
+  }
+  return emptyFile();
+}
+
+async function writeFileAtomic(data: NotesFile): Promise<void> {
+  const dir = dirname(NOTES_PATH);
+  if (!existsSync(dir)) await mkdir(dir, { recursive: true });
+  const tmp = `${NOTES_PATH}.${process.pid}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2), 'utf8');
+  await rename(tmp, NOTES_PATH);
+}
+
+export async function getAllNotes(): Promise<Record<string, AgentNote>> {
+  const file = await readFileSafe();
+  return file.agents;
+}
+
+export async function setNote(
+  agent: string,
+  label: string,
+): Promise<AgentNote | null> {
+  const file = await readFileSafe();
+  const trimmed = label.trim();
+  if (trimmed.length === 0) {
+    delete file.agents[agent];
+    await writeFileAtomic(file);
+    return null;
+  }
+  const note: AgentNote = {
+    label: trimmed,
+    updatedAt: new Date().toISOString(),
+  };
+  file.agents[agent] = note;
+  await writeFileAtomic(file);
+  return note;
+}

--- a/console/src/main/transcript.ts
+++ b/console/src/main/transcript.ts
@@ -20,6 +20,7 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type {
+  InFlightTool,
   SessionRunState,
   SessionState,
   TodoItem,
@@ -150,32 +151,51 @@ function extractTodos(entry: Record<string, unknown>): TodoItem[] | null {
   return null;
 }
 
-function extractUserPromptText(entry: Record<string, unknown>): string | null {
-  const t = entry['type'];
-  if (t !== 'user') return null;
-  const message = asObject(entry['message']);
-  if (!message) return null;
-  const content = message['content'];
-  if (typeof content === 'string') {
-    const trimmed = content.trim();
-    return trimmed.length > 0 ? trimmed : null;
-  }
-  const arr = asArray(content);
-  if (!arr) return null;
-  for (const block of arr) {
+/**
+ * Pull the trailing text from an assistant turn — claude usually wraps
+ * up with a "here's what I did" summary, which is what we want on the
+ * card header.
+ */
+function extractAssistantText(entry: Record<string, unknown>): string | null {
+  if (entry['type'] !== 'assistant') return null;
+  const parts: string[] = [];
+  for (const block of getMessageContent(entry)) {
     const obj = asObject(block);
     if (!obj) continue;
     if (obj['type'] === 'text') {
       const text = asString(obj['text']);
-      if (text && text.trim().length > 0) return text.trim();
+      if (text && text.trim().length > 0) parts.push(text.trim());
     }
   }
-  return null;
+  return parts.length === 0 ? null : parts.join('\n\n');
+}
+
+/**
+ * One-line summary of a tool's input. Conventions:
+ *   Bash: first line of the command, truncated
+ *   Edit/Write/Read/Glob/Grep/Notebook*: file path / pattern
+ *   anything else: empty (caller falls back to tool name only)
+ */
+function summarizeToolInput(name: string, input: unknown): string {
+  const obj = asObject(input);
+  if (!obj) return '';
+  if (name === 'Bash') {
+    const cmd = asString(obj['command']);
+    if (cmd) return cmd.split('\n')[0]!.slice(0, 120);
+    return '';
+  }
+  const path =
+    asString(obj['file_path']) ??
+    asString(obj['path']) ??
+    asString(obj['notebook_path']) ??
+    asString(obj['pattern']);
+  return path ?? '';
 }
 
 interface TranscriptScan {
   todos: TodoItem[];
-  lastUserPrompt?: string;
+  lastAssistantText?: string;
+  currentTool?: InFlightTool;
   lastActivityAt?: string;
   gitBranch?: string;
   runState: SessionRunState;
@@ -275,10 +295,9 @@ function inferRunState(
 function scanEntries(entries: ParsedEntry[]): TranscriptScan {
   const result: TranscriptScan = { todos: [], runState: 'unknown' };
   let foundTodos = false;
-  let foundPrompt = false;
+  let foundAssistantText = false;
 
-  // First pass: capture lastActivityAt + gitBranch from the newest entry
-  // that has them. Walk backward.
+  // Walk backward; capture the newest signals we care about.
   for (let i = entries.length - 1; i >= 0; i--) {
     const entry = entries[i]!.raw;
     if (result.lastActivityAt === undefined) {
@@ -296,16 +315,16 @@ function scanEntries(entries: ParsedEntry[]): TranscriptScan {
         foundTodos = true;
       }
     }
-    if (!foundPrompt) {
-      const prompt = extractUserPromptText(entry);
-      if (prompt) {
-        result.lastUserPrompt = prompt;
-        foundPrompt = true;
+    if (!foundAssistantText) {
+      const text = extractAssistantText(entry);
+      if (text) {
+        result.lastAssistantText = text;
+        foundAssistantText = true;
       }
     }
     if (
       foundTodos &&
-      foundPrompt &&
+      foundAssistantText &&
       result.lastActivityAt !== undefined &&
       result.gitBranch !== undefined
     ) {
@@ -314,6 +333,43 @@ function scanEntries(entries: ParsedEntry[]): TranscriptScan {
   }
 
   result.runState = inferRunState(entries, result.lastActivityAt, Date.now());
+
+  // If a tool is mid-flight, surface its name + input summary.
+  if (result.runState === 'tool_in_flight') {
+    let latestAssistantIdx = -1;
+    for (let i = entries.length - 1; i >= 0; i--) {
+      if (entries[i]!.raw['type'] === 'assistant') {
+        latestAssistantIdx = i;
+        break;
+      }
+    }
+    if (latestAssistantIdx >= 0) {
+      const assistantEntry = entries[latestAssistantIdx]!.raw;
+      const toolUses: Array<{ id: string; name: string; input: unknown }> = [];
+      for (const block of getMessageContent(assistantEntry)) {
+        const obj = asObject(block);
+        if (!obj) continue;
+        if (obj['type'] !== 'tool_use') continue;
+        const id = asString(obj['id']);
+        const name = asString(obj['name']);
+        if (id && name) toolUses.push({ id, name, input: obj['input'] });
+      }
+      const responded = new Set<string>();
+      for (let i = latestAssistantIdx + 1; i < entries.length; i++) {
+        for (const id of extractToolResultIds(entries[i]!.raw)) {
+          responded.add(id);
+        }
+      }
+      const pending = toolUses.find((t) => !responded.has(t.id));
+      if (pending) {
+        result.currentTool = {
+          name: pending.name,
+          summary: summarizeToolInput(pending.name, pending.input),
+        };
+      }
+    }
+  }
+
   return result;
 }
 
@@ -344,8 +400,9 @@ export async function getActiveSession(
   };
   if (scan.lastActivityAt !== undefined)
     state.lastActivityAt = scan.lastActivityAt;
-  if (scan.lastUserPrompt !== undefined)
-    state.lastUserPrompt = scan.lastUserPrompt;
+  if (scan.lastAssistantText !== undefined)
+    state.lastAssistantText = scan.lastAssistantText;
+  if (scan.currentTool !== undefined) state.currentTool = scan.currentTool;
   if (scan.gitBranch !== undefined) state.gitBranch = scan.gitBranch;
   return state;
 }

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -29,6 +29,8 @@ const IPC_CHANNELS = {
   worktreesSession: 'ranch:worktrees:session',
   worktreesGit: 'ranch:worktrees:git',
   worktreesProcessSnapshot: 'ranch:worktrees:processSnapshot',
+  notesGetAll: 'ranch:notes:getAll',
+  notesSet: 'ranch:notes:set',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -69,6 +71,11 @@ const api: RanchApi = {
     git: (agent) => ipcRenderer.invoke(IPC_CHANNELS.worktreesGit, agent),
     processSnapshot: () =>
       ipcRenderer.invoke(IPC_CHANNELS.worktreesProcessSnapshot),
+  },
+  notes: {
+    getAll: () => ipcRenderer.invoke(IPC_CHANNELS.notesGetAll),
+    set: (agent, label) =>
+      ipcRenderer.invoke(IPC_CHANNELS.notesSet, agent, label),
   },
   terminal: {
     env: () => ipcRenderer.invoke(IPC_CHANNELS.terminalEnv),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
+  AgentNote,
   CCProcessState,
   ProcessSnapshot,
   SessionState,
   TerminalEnv,
-  TodoItem,
   WorktreeBasics,
   WorktreeGitState,
 } from '../shared/types.js';
@@ -20,6 +20,7 @@ const SESSION_POLL_MS = 4000;
 const PROCESS_POLL_MS = 5000;
 const GIT_POLL_MS = 8000;
 const WORKTREE_POLL_MS = 30_000;
+const NOTES_POLL_MS = 15_000;
 
 interface AppState {
   status: 'loading' | 'ready' | 'error';
@@ -28,24 +29,18 @@ interface AppState {
   error?: string;
 }
 
-interface ActiveTerminal {
-  agent: string;
-  /** Bumped on each (re-)open to force a fresh attach. */
-  generation: number;
-}
-
 export function App(): JSX.Element {
   const [state, setState] = useState<AppState>({
     status: 'loading',
     worktrees: [],
   });
-  const [activeTerminal, setActiveTerminal] = useState<ActiveTerminal | null>(
-    null,
-  );
   const [terminalEnv, setTerminalEnv] = useState<TerminalEnv | null>(null);
   const [processSnapshot, setProcessSnapshot] =
     useState<ProcessSnapshot>(EMPTY_SNAPSHOT);
+  const [notes, setNotes] = useState<Record<string, AgentNote>>({});
+  const [focusedAgent, setFocusedAgent] = useState<string | null>(null);
 
+  // ─── one-shot loads ────────────────────────────────────────
   useEffect(() => {
     let cancelled = false;
     void window.ranch.terminal.env().then((env) => {
@@ -56,31 +51,10 @@ export function App(): JSX.Element {
     };
   }, []);
 
-  // Fleet-wide process snapshot (one ps + one tmux-list per tick, all agents).
-  // Cheaper than per-card polling and gives us cross-worktree consistency.
+  // ─── worktree list (slow refresh) ──────────────────────────
   useEffect(() => {
     let cancelled = false;
-    async function refresh(): Promise<void> {
-      try {
-        const snap = await window.ranch.worktrees.processSnapshot();
-        if (!cancelled) setProcessSnapshot(snap);
-      } catch {
-        // tmux/ps errors are surfaced indirectly (empty snapshot)
-      }
-    }
-    void refresh();
-    const handle = setInterval(refresh, PROCESS_POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(handle);
-    };
-  }, []);
-
-  // Initial load + slow refresh of worktree basics (.env.agent rarely changes).
-  useEffect(() => {
-    let cancelled = false;
-
-    async function refreshWorktrees(initial = false): Promise<void> {
+    async function refresh(initial = false): Promise<void> {
       try {
         const worktrees = await window.ranch.worktrees.list();
         if (cancelled) return;
@@ -101,29 +75,74 @@ export function App(): JSX.Element {
         }
       }
     }
-
-    void refreshWorktrees(true);
-    const handle = setInterval(() => {
-      void refreshWorktrees(false);
-    }, WORKTREE_POLL_MS);
-
+    void refresh(true);
+    const handle = setInterval(() => void refresh(false), WORKTREE_POLL_MS);
     return () => {
       cancelled = true;
       clearInterval(handle);
     };
   }, []);
 
-  function openTerminal(agent: string): void {
-    setActiveTerminal((prev) =>
-      prev?.agent === agent
-        ? { agent, generation: prev.generation + 1 }
-        : { agent, generation: 1 },
-    );
-  }
+  // ─── process snapshot (fleet-wide) ─────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      try {
+        const snap = await window.ranch.worktrees.processSnapshot();
+        if (!cancelled) setProcessSnapshot(snap);
+      } catch {
+        // tmux/ps errors are surfaced indirectly (empty snapshot)
+      }
+    }
+    void refresh();
+    const handle = setInterval(refresh, PROCESS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, []);
 
-  function closeTerminal(): void {
-    setActiveTerminal(null);
-  }
+  // ─── notes (slow refresh — operator edits are intentional) ──
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      try {
+        const all = await window.ranch.notes.getAll();
+        if (!cancelled) setNotes(all);
+      } catch {
+        // ignore
+      }
+    }
+    void refresh();
+    const handle = setInterval(refresh, NOTES_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, []);
+
+  // Save a note locally + persist. Optimistic — if the persist fails
+  // we'll see it on the next refresh tick.
+  const saveNote = useCallback(async (agent: string, label: string) => {
+    const trimmed = label.trim();
+    setNotes((prev) => {
+      const next = { ...prev };
+      if (trimmed.length === 0) {
+        delete next[agent];
+      } else {
+        next[agent] = {
+          label: trimmed,
+          updatedAt: new Date().toISOString(),
+        };
+      }
+      return next;
+    });
+    try {
+      await window.ranch.notes.set(agent, trimmed);
+    } catch {
+      // server-side fail; next poll will reconcile
+    }
+  }, []);
 
   return (
     <div className="app">
@@ -132,108 +151,39 @@ export function App(): JSX.Element {
         <span className="app__version">
           {state.appVersion ? `v${state.appVersion}` : ''}
         </span>
+        <FleetWarnings snapshot={processSnapshot} />
+        {terminalEnv && !terminalEnv.tmuxAvailable && (
+          <span className="app__warn">
+            ⚠ tmux not found — install with <code>brew install tmux</code>
+          </span>
+        )}
       </header>
-      <main className="app__layout">
-        <section className="pane pane--grid">
-          <h2>Worktree grid</h2>
-          <Grid
-            state={state}
-            onOpenTerminal={openTerminal}
-            terminalEnv={terminalEnv}
-            processSnapshot={processSnapshot}
-          />
-        </section>
-        <section className="pane pane--terminal">
-          <div className="pane__heading">
-            <h2>
-              Terminal
-              {activeTerminal && (
-                <span className="pane__heading-sub">
-                  {' '}
-                  · ranch-{activeTerminal.agent}
-                </span>
-              )}
-            </h2>
-            {activeTerminal && (
-              <button className="link-button" onClick={closeTerminal}>
-                detach
-              </button>
-            )}
-          </div>
-          {activeTerminal ? (
-            <Terminal
-              key={activeTerminal.agent}
-              agent={activeTerminal.agent}
-              generation={activeTerminal.generation}
+      <main className="app__grid">
+        {state.status === 'loading' && (
+          <p className="placeholder">Loading worktrees…</p>
+        )}
+        {state.status === 'error' && (
+          <p className="placeholder placeholder--error">Error: {state.error}</p>
+        )}
+        {state.status === 'ready' &&
+          state.worktrees.map((wt) => (
+            <AgentCell
+              key={wt.agent}
+              worktree={wt}
+              processState={processSnapshot.perAgent[wt.agent] ?? null}
+              note={notes[wt.agent] ?? null}
+              terminalEnv={terminalEnv}
+              focused={focusedAgent === wt.agent}
+              onFocus={() => setFocusedAgent(wt.agent)}
+              onSaveNote={(label) => saveNote(wt.agent, label)}
             />
-          ) : (
-            <p className="placeholder">
-              Click <strong>Open terminal</strong> on a worktree card to attach.
-            </p>
-          )}
-        </section>
-        <section className="pane pane--inbox">
-          <h2>Inbox</h2>
-          <p className="placeholder">Empty.</p>
-        </section>
-        <section className="pane pane--memory">
-          <h2>Memory</h2>
-          <p className="placeholder">Lessons panel coming in Phase F.</p>
-        </section>
+          ))}
       </main>
     </div>
   );
 }
 
-function Grid({
-  state,
-  onOpenTerminal,
-  terminalEnv,
-  processSnapshot,
-}: {
-  state: AppState;
-  onOpenTerminal: (agent: string) => void;
-  terminalEnv: TerminalEnv | null;
-  processSnapshot: ProcessSnapshot;
-}): JSX.Element {
-  if (state.status === 'loading') {
-    return <p className="placeholder">Loading worktrees…</p>;
-  }
-  if (state.status === 'error') {
-    return (
-      <p className="placeholder placeholder--error">Error: {state.error}</p>
-    );
-  }
-  if (state.worktrees.length === 0) {
-    return (
-      <p className="placeholder">
-        No agents registered. Add some to <code>~/.ranch/config.toml</code>.
-      </p>
-    );
-  }
-  return (
-    <>
-      {terminalEnv && !terminalEnv.tmuxAvailable && (
-        <p className="card__warn card__warn--banner">
-          ⚠ tmux not found on PATH. Install with <code>brew install tmux</code>{' '}
-          to enable embedded terminals.
-        </p>
-      )}
-      <FleetWarnings snapshot={processSnapshot} />
-      <div className="grid">
-        {state.worktrees.map((wt) => (
-          <WorktreeCard
-            key={wt.agent}
-            worktree={wt}
-            onOpenTerminal={onOpenTerminal}
-            terminalEnv={terminalEnv}
-            processState={processSnapshot.perAgent[wt.agent] ?? null}
-          />
-        ))}
-      </div>
-    </>
-  );
-}
+// ─── Fleet warnings (orphans) ─────────────────────────────────
 
 function FleetWarnings({
   snapshot,
@@ -242,60 +192,54 @@ function FleetWarnings({
 }): JSX.Element | null {
   if (snapshot.orphanClaudes.length === 0) return null;
   return (
-    <div className="fleet-warnings">
-      <p className="fleet-warnings__heading">
-        ⚠ {snapshot.orphanClaudes.length} claude process
-        {snapshot.orphanClaudes.length === 1 ? '' : 'es'} running outside any
-        registered worktree
-      </p>
-      <ul className="fleet-warnings__list">
-        {snapshot.orphanClaudes.map((p) => (
-          <li key={p.pid} className="fleet-warnings__item">
-            <code>PID {p.pid}</code>
-            {p.cwd && <span className="fleet-warnings__path">{p.cwd}</span>}
-          </li>
-        ))}
-      </ul>
-    </div>
+    <span className="app__warn" title={orphanTooltip(snapshot)}>
+      ⚠ {snapshot.orphanClaudes.length} orphan claude
+      {snapshot.orphanClaudes.length === 1 ? '' : 's'}
+    </span>
   );
 }
 
-interface WorktreeCardProps {
-  worktree: WorktreeBasics;
-  onOpenTerminal: (agent: string) => void;
-  terminalEnv: TerminalEnv | null;
-  processState: CCProcessState | null;
+function orphanTooltip(snap: ProcessSnapshot): string {
+  return snap.orphanClaudes
+    .map((p) => `PID ${p.pid}${p.cwd ? ` · ${p.cwd}` : ''}`)
+    .join('\n');
 }
 
-function WorktreeCard({
+// ─── AgentCell — one per worktree, embeds the live terminal ───
+
+interface AgentCellProps {
+  worktree: WorktreeBasics;
+  processState: CCProcessState | null;
+  note: AgentNote | null;
+  terminalEnv: TerminalEnv | null;
+  focused: boolean;
+  onFocus: () => void;
+  onSaveNote: (label: string) => void;
+}
+
+function AgentCell({
   worktree,
-  onOpenTerminal,
-  terminalEnv,
   processState,
-}: WorktreeCardProps): JSX.Element {
+  note,
+  terminalEnv,
+  focused,
+  onFocus,
+  onSaveNote,
+}: AgentCellProps): JSX.Element {
   const [session, setSession] = useState<SessionState | null>(null);
-  const [sessionError, setSessionError] = useState<string | null>(null);
   const [git, setGit] = useState<WorktreeGitState | null>(null);
 
-  // Per-card transcript polling: cheap (file mtime + parse tail) and the
-  // freshness here is what makes the card actually useful.
+  // Per-cell transcript polling.
   useEffect(() => {
     let cancelled = false;
-
     async function refresh(): Promise<void> {
       try {
         const next = await window.ranch.worktrees.session(worktree.agent);
-        if (!cancelled) {
-          setSession(next);
-          setSessionError(null);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setSessionError(err instanceof Error ? err.message : String(err));
-        }
+        if (!cancelled) setSession(next);
+      } catch {
+        // ignore
       }
     }
-
     void refresh();
     const handle = setInterval(refresh, SESSION_POLL_MS);
     return () => {
@@ -304,8 +248,7 @@ function WorktreeCard({
     };
   }, [worktree.agent]);
 
-  // Per-card git state polling. Slower than transcript — branch + last
-  // commit only change when the operator does something.
+  // Per-cell git polling.
   useEffect(() => {
     let cancelled = false;
     async function refresh(): Promise<void> {
@@ -313,7 +256,7 @@ function WorktreeCard({
         const next = await window.ranch.worktrees.git(worktree.agent);
         if (!cancelled) setGit(next);
       } catch {
-        // ignore — card just won't show git row
+        // ignore
       }
     }
     void refresh();
@@ -328,137 +271,219 @@ function WorktreeCard({
     (processState?.claudeRunning ?? false) &&
     session?.runState === 'awaiting_input';
 
+  const cellClass = useMemo(() => {
+    const c = ['cell'];
+    if (focused) c.push('cell--focused');
+    if (needsInput) c.push('cell--needs-input');
+    return c.join(' ');
+  }, [focused, needsInput]);
+
   return (
-    <article className={`card${needsInput ? ' card--needs-input' : ''}`}>
-      {/* Identity */}
-      <header className="card__header">
-        <div className="card__identity">
-          <span className="card__name">{worktree.agent}</span>
-          {worktree.description && (
-            <span className="card__desc">{worktree.description}</span>
-          )}
-        </div>
-        <SessionPill
-          session={session}
-          processState={processState}
-          error={sessionError}
-        />
-      </header>
-      <button
-        className="card__path"
-        onClick={() => {
-          void navigator.clipboard.writeText(worktree.worktreePath);
-        }}
-        title="Copy path"
-        type="button"
-      >
-        {worktree.worktreePath}
-      </button>
-
-      <div className="card__divider" />
-
-      {/* Live work */}
-      <GitRow git={git} session={session} />
-      <TopicLine session={session} />
-      <TodoSummary todos={session?.todos ?? []} />
-
-      <div className="card__divider" />
-
-      {/* Infrastructure */}
-      <ProcessRow processState={processState} />
-      <PortsRow ports={worktree.ports} source={worktree.portsSource} />
-
-      {/* Warnings */}
-      <ProcessWarnings processState={processState} />
-      <DriftWarnings worktree={worktree} />
-      {!worktree.envAgentExists && (
-        <p className="card__warn">
-          No <code>.env.agent</code> at this worktree.
-        </p>
-      )}
-
-      {/* Actions */}
-      <footer className="card__actions">
-        <button
-          className="card__action card__action--primary"
-          onClick={() => onOpenTerminal(worktree.agent)}
-          disabled={terminalEnv !== null && !terminalEnv.tmuxAvailable}
-          title={
-            terminalEnv && !terminalEnv.tmuxAvailable
-              ? 'tmux not installed'
-              : `Open ${worktree.agent}'s embedded terminal — launches Claude on first open, attaches afterward`
-          }
-        >
-          Open Claude
-        </button>
-        <button
-          className="card__action"
-          onClick={() => {
-            void window.ranch.app.revealInFinder(worktree.worktreePath);
-          }}
-          title="Reveal worktree in Finder"
-        >
-          Reveal
-        </button>
-      </footer>
+    <article
+      className={cellClass}
+      onMouseDown={onFocus}
+      onFocusCapture={onFocus}
+    >
+      <CellHeader
+        worktree={worktree}
+        session={session}
+        processState={processState}
+        git={git}
+        note={note}
+        onSaveNote={onSaveNote}
+      />
+      <div className="cell__terminal">
+        {terminalEnv && terminalEnv.tmuxAvailable ? (
+          <Terminal agent={worktree.agent} generation={1} />
+        ) : (
+          <p className="placeholder placeholder--center">
+            tmux not installed — terminals unavailable
+          </p>
+        )}
+      </div>
     </article>
   );
 }
 
-function ProcessWarnings({
+// ─── Cell header ──────────────────────────────────────────────
+
+function CellHeader({
+  worktree,
+  session,
   processState,
+  git,
+  note,
+  onSaveNote,
 }: {
+  worktree: WorktreeBasics;
+  session: SessionState | null;
   processState: CCProcessState | null;
-}): JSX.Element | null {
-  if (!processState || !processState.claudeRunning) return null;
-  const warnings: string[] = [];
-  if (!processState.tmux) {
-    warnings.push(
-      'claude is running here but no ranch- tmux session exists. It was likely started outside ranch — closing it from a stray terminal could surprise you. Use Open terminal to bring it under ranch.',
-    );
-  }
-  if (processState.claudeProcesses.length > 1) {
-    const pids = processState.claudeProcesses.map((p) => p.pid).join(', ');
-    warnings.push(
-      `${processState.claudeProcesses.length} claude processes here (PIDs ${pids}). Possible duplicate session — pick the right one before sending input.`,
-    );
-  }
-  if (warnings.length === 0) return null;
+  git: WorktreeGitState | null;
+  note: AgentNote | null;
+  onSaveNote: (label: string) => void;
+}): JSX.Element {
   return (
-    <div className="card__drift">
-      {warnings.map((m, i) => (
-        <p key={i} className="card__warn">
-          ⚠ {m}
-        </p>
-      ))}
-    </div>
+    <header className="cell__header">
+      <div className="cell__top">
+        <span className="cell__name">{worktree.agent}</span>
+        <SessionPill session={session} processState={processState} />
+        <GitInline git={git} session={session} />
+        <PortsInline ports={worktree.ports} />
+      </div>
+      <div className="cell__notes">
+        <EditableNote
+          agent={worktree.agent}
+          note={note}
+          onSaveNote={onSaveNote}
+        />
+        <ActivityLine session={session} />
+      </div>
+    </header>
   );
 }
+
+// ─── Editable note ────────────────────────────────────────────
+
+function EditableNote({
+  agent,
+  note,
+  onSaveNote,
+}: {
+  agent: string;
+  note: AgentNote | null;
+  onSaveNote: (label: string) => void;
+}): JSX.Element {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function startEdit(): void {
+    setDraft(note?.label ?? '');
+    setEditing(true);
+  }
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  function commit(): void {
+    onSaveNote(draft);
+    setEditing(false);
+  }
+
+  function cancel(): void {
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        className="note__input"
+        value={draft}
+        placeholder={`What is ${agent} working on?`}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') commit();
+          if (e.key === 'Escape') cancel();
+        }}
+        // Don't let the cell's onMouseDown steal focus.
+        onMouseDown={(e) => e.stopPropagation()}
+      />
+    );
+  }
+
+  if (note?.label) {
+    return (
+      <button
+        className="note__display"
+        onClick={(e) => {
+          e.stopPropagation();
+          startEdit();
+        }}
+        title="Click to edit"
+        type="button"
+      >
+        {note.label}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      className="note__display note__display--empty"
+      onClick={(e) => {
+        e.stopPropagation();
+        startEdit();
+      }}
+      type="button"
+    >
+      + add a note (e.g. {`"working on scrapers tickets"`})
+    </button>
+  );
+}
+
+// ─── Activity line — current tool OR last assistant text ──────
+
+function ActivityLine({
+  session,
+}: {
+  session: SessionState | null;
+}): JSX.Element | null {
+  if (!session || session.status === 'none') return null;
+
+  if (session.runState === 'tool_in_flight' && session.currentTool) {
+    const t = session.currentTool;
+    return (
+      <p className="cell__activity cell__activity--tool">
+        <span className="cell__activity-label">running</span>{' '}
+        <code>{t.name}</code>
+        {t.summary && <span className="cell__activity-arg">: {t.summary}</span>}
+      </p>
+    );
+  }
+
+  if (session.lastAssistantText) {
+    return (
+      <p className="cell__activity" title={session.lastAssistantText}>
+        {truncate(session.lastAssistantText, 240)}
+      </p>
+    );
+  }
+
+  // Fallback: in-progress todo
+  const inProgress = session.todos.find((t) => t.status === 'in_progress');
+  if (inProgress) {
+    return (
+      <p className="cell__activity">
+        {truncate(inProgress.activeForm ?? inProgress.content, 240)}
+      </p>
+    );
+  }
+
+  return null;
+}
+
+// ─── Compact pieces for the header strip ─────────────────────
 
 function SessionPill({
   session,
   processState,
-  error,
 }: {
   session: SessionState | null;
   processState: CCProcessState | null;
-  error: string | null;
 }): JSX.Element {
-  if (error) return <span className="pill pill--error">err</span>;
-
-  // Combine process detection with transcript-derived run state for the
-  // strongest possible "what's claude doing right now" signal.
   const claudeAlive = processState?.claudeRunning ?? false;
   const runState = session?.runState ?? 'unknown';
 
   if (claudeAlive && runState === 'awaiting_input') {
-    const age = relativeAge(session?.lastActivityAt);
     return (
       <span
         className="pill pill--awaiting"
         title="Claude is waiting on a human reply"
       >
-        needs input · {age}
+        needs input
       </span>
     );
   }
@@ -470,7 +495,7 @@ function SessionPill({
     );
   }
   if (claudeAlive) {
-    return <span className="pill pill--running">claude running</span>;
+    return <span className="pill pill--running">claude</span>;
   }
   if (!session) return <span className="pill">…</span>;
   if (session.status === 'none') {
@@ -480,253 +505,75 @@ function SessionPill({
   return <span className="pill pill--active">last · {age}</span>;
 }
 
-function GitRow({
+function GitInline({
   git,
   session,
 }: {
   git: WorktreeGitState | null;
   session: SessionState | null;
 }): JSX.Element | null {
-  // git observer is authoritative; transcript branch is fallback while
-  // git poll is in flight on first paint.
   let branch: string | undefined;
   if (git?.status === 'ok') branch = git.branch;
   else if (session?.gitBranch) branch = session.gitBranch;
+  if (!branch) return null;
 
-  if (!branch && (!git || git.status !== 'ok')) return null;
-
-  const ticket = branch ? extractTicketId(branch) : null;
+  const ticket = extractTicketId(branch);
   const dirty = git?.status === 'ok' && git.dirty;
   const ahead = git?.status === 'ok' ? (git.ahead ?? 0) : 0;
   const behind = git?.status === 'ok' ? (git.behind ?? 0) : 0;
-  const lastCommit = git?.status === 'ok' ? git.lastCommit : undefined;
 
   return (
-    <div className="card__git">
-      <div className="card__git-line">
-        {branch && <span className="card__branch-name">{branch}</span>}
-        {ticket && <span className="card__ticket">{ticket}</span>}
-        {dirty && (
-          <span
-            className="card__git-dirty"
-            title="Uncommitted changes in working tree"
-          >
-            ●
-          </span>
-        )}
-        {(ahead > 0 || behind > 0) && (
-          <span
-            className="card__git-ahead-behind"
-            title={`${ahead} ahead, ${behind} behind origin/develop`}
-          >
-            {ahead > 0 && `↑${ahead}`}
-            {behind > 0 && `↓${behind}`}
-          </span>
-        )}
-      </div>
-      {lastCommit && (
-        <div
-          className="card__git-commit"
-          title={`${lastCommit.sha} · ${lastCommit.age}`}
-        >
-          <code>{lastCommit.sha}</code> {truncate(lastCommit.message, 60)}{' '}
-          <span className="card__git-age">· {lastCommit.age}</span>
-        </div>
+    <span className="git-inline">
+      <span className="git-inline__branch">{branch}</span>
+      {ticket && <span className="ticket-pill">{ticket}</span>}
+      {dirty && (
+        <span className="git-inline__dirty" title="uncommitted changes">
+          ●
+        </span>
       )}
-    </div>
+      {(ahead > 0 || behind > 0) && (
+        <span
+          className="git-inline__ahead-behind"
+          title={`${ahead} ahead, ${behind} behind origin/develop`}
+        >
+          {ahead > 0 && `↑${ahead}`}
+          {behind > 0 && `↓${behind}`}
+        </span>
+      )}
+    </span>
   );
 }
 
-function ProcessRow({
-  processState,
-}: {
-  processState: CCProcessState | null;
-}): JSX.Element | null {
-  if (!processState) return null;
-  const tmuxBadge = processState.tmux ? (
-    <span
-      className="proc-badge proc-badge--ok"
-      title={
-        processState.tmux.attachedClients > 0
-          ? `tmux session with ${processState.tmux.attachedClients} client(s)`
-          : 'tmux session detached but alive'
-      }
-    >
-      tmux ✓ {processState.tmux.attachedClients > 0 ? '· attached' : ''}
-    </span>
-  ) : (
-    <span className="proc-badge proc-badge--off" title="No ranch- tmux session">
-      tmux —
-    </span>
-  );
-  const claudePids = processState.claudeProcesses.map((p) => p.pid).join(', ');
-  const claudeBadge = processState.claudeRunning ? (
-    <span
-      className="proc-badge proc-badge--ok"
-      title={`claude PID(s): ${claudePids}`}
-    >
-      claude · {processState.claudeProcesses.length}
-    </span>
-  ) : (
-    <span
-      className="proc-badge proc-badge--off"
-      title="No claude process in this worktree"
-    >
-      claude —
-    </span>
-  );
-  return (
-    <div className="card__procs">
-      {tmuxBadge}
-      {claudeBadge}
-    </div>
-  );
-}
-
-function TopicLine({
-  session,
-}: {
-  session: SessionState | null;
-}): JSX.Element | null {
-  if (!session || session.status === 'none') return null;
-  const inProgress = session.todos.find((t) => t.status === 'in_progress');
-  const topic =
-    inProgress?.activeForm ??
-    inProgress?.content ??
-    session.lastUserPrompt ??
-    null;
-  if (!topic) return null;
-  return <p className="card__topic">{truncate(topic, 140)}</p>;
-}
-
-function TodoSummary({ todos }: { todos: TodoItem[] }): JSX.Element | null {
-  if (todos.length === 0) return null;
-  const done = todos.filter((t) => t.status === 'completed').length;
-  const inProgress = todos.filter((t) => t.status === 'in_progress').length;
-  return (
-    <div className="card__todos">
-      <div className="card__todos-summary">
-        <strong>
-          {done} / {todos.length}
-        </strong>{' '}
-        complete
-        {inProgress > 0 && <span> · {inProgress} in progress</span>}
-      </div>
-      <ul className="todo-list">
-        {todos.map((t, i) => (
-          <li
-            key={i}
-            className={`todo todo--${t.status.replace('_', '-')}`}
-            title={t.content}
-          >
-            <span className="todo__icon">{todoIcon(t.status)}</span>
-            <span className="todo__text">{t.content}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function PortsRow({
+function PortsInline({
   ports,
-  source,
 }: {
   ports: WorktreeBasics['ports'];
-  source: WorktreeBasics['portsSource'];
 }): JSX.Element | null {
   const buttons: { label: string; port: number }[] = [];
   if (ports.django !== undefined)
-    buttons.push({ label: 'Django', port: ports.django });
-  if (ports.vite !== undefined)
-    buttons.push({ label: 'Vite', port: ports.vite });
+    buttons.push({ label: 'D', port: ports.django });
+  if (ports.vite !== undefined) buttons.push({ label: 'V', port: ports.vite });
   if (buttons.length === 0) return null;
-  const sourceLabel =
-    source === 'ranch-config'
-      ? 'from ~/.ranch/config.toml'
-      : source === 'env-agent'
-        ? 'from .env.agent (may drift)'
-        : '';
   return (
-    <div className="card__ports">
+    <span className="ports-inline">
       {buttons.map((b) => (
         <a
           key={b.label}
-          className="port-button"
+          className="port-mini"
           href={`http://localhost:${b.port}`}
           target="_blank"
           rel="noreferrer"
-          title={`${b.label} :${b.port} ${sourceLabel}`}
+          onClick={(e) => e.stopPropagation()}
+          title={`Open localhost:${b.port}`}
         >
-          {b.label} <span className="port-button__num">:{b.port}</span>
+          {b.label}:{b.port}
         </a>
       ))}
-    </div>
+    </span>
   );
 }
 
-function DriftWarnings({
-  worktree,
-}: {
-  worktree: WorktreeBasics;
-}): JSX.Element | null {
-  const messages: string[] = [];
-
-  if (!worktree.envAgentMatches && worktree.envAgentName !== undefined) {
-    messages.push(
-      `.env.agent says AGENT_NAME=${worktree.envAgentName}, but this worktree is registered as ${worktree.agent}. Run \`make sync-env\` to repair.`,
-    );
-  }
-
-  if (worktree.portsSource === 'ranch-config') {
-    const drift: string[] = [];
-    if (
-      worktree.ports.django !== undefined &&
-      worktree.envAgentPorts.django !== undefined &&
-      worktree.ports.django !== worktree.envAgentPorts.django
-    ) {
-      drift.push(
-        `DJANGO_PORT (env: ${worktree.envAgentPorts.django}, config: ${worktree.ports.django})`,
-      );
-    }
-    if (
-      worktree.ports.vite !== undefined &&
-      worktree.envAgentPorts.vite !== undefined &&
-      worktree.ports.vite !== worktree.envAgentPorts.vite
-    ) {
-      drift.push(
-        `VITE_PORT (env: ${worktree.envAgentPorts.vite}, config: ${worktree.ports.vite})`,
-      );
-    }
-    if (drift.length > 0) {
-      messages.push(`.env.agent ports drift: ${drift.join(', ')}`);
-    }
-  }
-
-  if (messages.length === 0) return null;
-  return (
-    <div className="card__drift">
-      {messages.map((m, i) => (
-        <p key={i} className="card__warn">
-          ⚠ {m}
-        </p>
-      ))}
-    </div>
-  );
-}
-
-// ─── helpers ─────────────────────────────────────────────────────────────
-
-function todoIcon(status: TodoItem['status']): string {
-  switch (status) {
-    case 'completed':
-      return '✓';
-    case 'in_progress':
-      return '◐';
-    case 'pending':
-      return '○';
-  }
-}
+// ─── helpers ─────────────────────────────────────────────────
 
 function truncate(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + '…';
@@ -742,11 +589,11 @@ function relativeAge(iso: string | undefined): string {
   const t = Date.parse(iso);
   if (Number.isNaN(t)) return '?';
   const sec = Math.max(0, Math.round((Date.now() - t) / 1000));
-  if (sec < 60) return `${sec}s ago`;
+  if (sec < 60) return `${sec}s`;
   const min = Math.round(sec / 60);
-  if (min < 60) return `${min}m ago`;
+  if (min < 60) return `${min}m`;
   const hr = Math.round(min / 60);
-  if (hr < 24) return `${hr}h ago`;
+  if (hr < 24) return `${hr}h`;
   const day = Math.round(hr / 24);
-  return `${day}d ago`;
+  return `${day}d`;
 }

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -3,6 +3,7 @@
   --bg-elevated: #161922;
   --bg-card: #181c27;
   --border: #232838;
+  --border-strong: #2c3346;
   --text: #e6e9ef;
   --text-muted: #9aa3b2;
   --text-dim: #6b7384;
@@ -29,6 +30,8 @@ body,
   color: var(--text);
 }
 
+/* ─── App shell ──────────────────────────────────────── */
+
 .app {
   display: flex;
   flex-direction: column;
@@ -37,272 +40,146 @@ body,
 
 .app__header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.75rem;
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 0.85rem;
   border-bottom: 1px solid var(--border);
   background: var(--bg-elevated);
+  flex-shrink: 0;
 }
 
 .app__header h1 {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: 0.04em;
 }
 
 .app__version {
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }
 
-.app__layout {
+.app__warn {
+  font-size: 0.72rem;
+  color: var(--yellow);
+  margin-left: auto;
+  padding: 0.2rem 0.5rem;
+  background: rgba(246, 193, 119, 0.08);
+  border: 1px solid rgba(246, 193, 119, 0.3);
+  border-radius: 4px;
+  cursor: help;
+}
+
+.app__warn code {
+  background: rgba(246, 193, 119, 0.12);
+  padding: 0 0.25rem;
+  border-radius: 2px;
+}
+
+.app__grid {
+  flex: 1;
+  min-height: 0;
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 1px;
   background: var(--border);
-  flex: 1;
-  min-height: 0;
-}
-
-.pane {
-  background: var(--bg);
-  padding: 0.75rem 1rem;
-  overflow: auto;
-  min-height: 0;
-}
-
-.pane h2 {
-  margin: 0 0 0.5rem 0;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-
-.pane--terminal {
-  padding: 0.75rem 0.5rem 0.5rem 0.5rem;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
 }
 
 .placeholder {
   color: var(--text-muted);
   font-size: 0.85rem;
+  padding: 1rem;
+}
+
+.placeholder--center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 1rem;
 }
 
 .placeholder--error {
   color: var(--error);
 }
 
-.placeholder code {
-  background: var(--bg-elevated);
-  padding: 0.1rem 0.35rem;
-  border-radius: 3px;
-  font-size: 0.85em;
-}
+/* ─── Cell ───────────────────────────────────────────── */
 
-/* ─── Worktree grid ────────────────────────────────────────────── */
-
-.grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
-  gap: 0.6rem;
-}
-
-.card {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 0.75rem 0.85rem;
+.cell {
+  background: var(--bg);
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  font-size: 0.85rem;
+  min-height: 0;
+  min-width: 0;
   position: relative;
-  transition: border-color 0.2s ease;
+  border: 1px solid transparent;
+  transition: border-color 0.15s ease;
 }
 
-.card--needs-input {
-  border-color: rgba(246, 193, 119, 0.55);
-  box-shadow: 0 0 0 1px rgba(246, 193, 119, 0.2);
+.cell--focused {
+  border-color: var(--accent);
 }
 
-.card--needs-input::before {
+.cell--needs-input {
+  border-color: rgba(246, 193, 119, 0.7);
+}
+.cell--needs-input::before {
   content: '';
   position: absolute;
-  left: -1px;
-  top: -1px;
-  bottom: -1px;
+  left: 0;
+  top: 0;
+  bottom: 0;
   width: 3px;
   background: var(--yellow);
-  border-radius: 6px 0 0 6px;
+  z-index: 2;
 }
 
-.card__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.6rem;
-}
-
-.card__identity {
+.cell__header {
+  background: var(--bg-elevated);
+  padding: 0.4rem 0.65rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.05rem;
-  min-width: 0;
+  gap: 0.3rem;
 }
 
-.card__name {
-  font-weight: 700;
-  font-size: 0.95rem;
-  color: var(--accent);
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-}
-
-.card__desc {
-  font-size: 0.7rem;
-  color: var(--text-dim);
-  font-style: italic;
-}
-
-.card__divider {
-  height: 1px;
-  background: var(--border);
-  margin: 0.15rem 0;
-}
-
-.card__path {
-  margin: 0;
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 0.72rem;
-  color: var(--text-dim);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  display: block;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: copy;
-  font-family-: inherit;
-}
-
-.card__path:hover {
-  color: var(--text-muted);
-}
-
-.card__path:active {
-  color: var(--accent);
-}
-
-.card__branch {
+.cell__top {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  margin: 0;
-  font-size: 0.78rem;
-}
-
-.card__branch-name {
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  color: var(--text-muted);
-}
-
-.card__git {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  font-size: 0.78rem;
-}
-
-.card__git-line {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
+  gap: 0.5rem;
   flex-wrap: wrap;
 }
 
-.card__git-dirty {
-  color: var(--yellow);
-  font-size: 0.85em;
-}
-
-.card__git-ahead-behind {
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  color: var(--text-muted);
-  font-size: 0.85em;
-  letter-spacing: -0.02em;
-}
-
-.card__git-commit {
-  font-size: 0.72rem;
-  color: var(--text-dim);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.card__git-commit code {
-  background: var(--bg-elevated);
-  padding: 0.05rem 0.3rem;
-  border-radius: 2px;
-  font-size: 0.95em;
-  color: var(--accent);
-}
-
-.card__git-age {
-  color: var(--text-dim);
-  font-style: italic;
-}
-
-.card__ticket {
-  background: rgba(106, 162, 255, 0.15);
-  color: var(--accent);
-  padding: 0.05rem 0.4rem;
-  border-radius: 3px;
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 0.7rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-.card__topic {
-  margin: 0;
-  color: var(--text);
+.cell__name {
+  font-weight: 700;
   font-size: 0.85rem;
-  line-height: 1.35;
+  color: var(--accent);
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
 }
 
-.card__warn {
-  margin: 0;
-  font-size: 0.72rem;
-  color: var(--yellow);
+.cell__notes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
 }
 
-.card__warn code {
-  background: rgba(246, 193, 119, 0.1);
-  padding: 0.05rem 0.3rem;
-  border-radius: 2px;
-  font-size: 0.95em;
-}
+/* ─── Pill ───────────────────────────────────────────── */
 
 .pill {
-  font-size: 0.65rem;
+  font-size: 0.62rem;
   font-weight: 600;
-  padding: 0.1rem 0.45rem;
+  padding: 0.05rem 0.4rem;
   border-radius: 999px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  background: var(--bg-elevated);
+  background: var(--bg);
   color: var(--text-dim);
-  border: 1px solid var(--border);
+  border: 1px solid var(--border-strong);
   white-space: nowrap;
 }
 
@@ -316,7 +193,7 @@ body,
   background: rgba(246, 193, 119, 0.18);
   color: var(--yellow);
   border-color: rgba(246, 193, 119, 0.5);
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .pill--active {
@@ -326,7 +203,7 @@ body,
 }
 
 .pill--idle {
-  background: var(--bg-elevated);
+  background: var(--bg);
   color: var(--text-dim);
 }
 
@@ -336,290 +213,161 @@ body,
   border-color: rgba(255, 106, 106, 0.3);
 }
 
-/* ─── Todos ────────────────────────────────────────────────────── */
+/* ─── Inline git + ports ─────────────────────────────── */
 
-.card__todos {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  margin-top: 0.1rem;
-}
-
-.card__todos-summary {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-}
-
-.todo-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  max-height: 8.5rem;
-  overflow-y: auto;
-}
-
-.todo {
-  display: grid;
-  grid-template-columns: 1.2rem 1fr;
-  gap: 0.35rem;
-  align-items: baseline;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
-.todo__icon {
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 0.85em;
-  text-align: center;
-}
-
-.todo__text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.todo--completed {
-  color: var(--text-dim);
-  text-decoration: line-through;
-  text-decoration-color: var(--text-dim);
-}
-.todo--completed .todo__icon {
-  color: var(--green);
-}
-
-.todo--in-progress {
-  color: var(--text);
-}
-.todo--in-progress .todo__icon {
-  color: var(--yellow);
-}
-
-.todo--pending .todo__icon {
-  color: var(--text-dim);
-}
-
-/* ─── Process badges ───────────────────────────────────────────── */
-
-.card__procs {
-  display: flex;
-  gap: 0.35rem;
-  flex-wrap: wrap;
-  margin-top: 0.05rem;
-}
-
-.proc-badge {
-  font-size: 0.68rem;
-  padding: 0.1rem 0.45rem;
-  border-radius: 3px;
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  letter-spacing: 0;
-  border: 1px solid var(--border);
-  background: var(--bg-elevated);
-}
-
-.proc-badge--ok {
-  color: var(--green);
-  border-color: rgba(92, 212, 122, 0.3);
-  background: rgba(92, 212, 122, 0.06);
-}
-
-.proc-badge--off {
-  color: var(--text-dim);
-}
-
-/* ─── Ports row ────────────────────────────────────────────────── */
-
-.card__ports {
-  display: flex;
-  gap: 0.4rem;
-  margin-top: 0.1rem;
-  flex-wrap: wrap;
-}
-
-.port-button {
-  background: var(--bg-elevated);
-  color: var(--text);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0.25rem 0.55rem;
-  font-size: 0.74rem;
-  text-decoration: none;
-  font-family: -apple-system, sans-serif;
+.git-inline {
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.3rem;
-  transition: border-color 0.15s ease;
-}
-
-.port-button:hover {
-  border-color: var(--accent);
-}
-
-.port-button__num {
-  color: var(--accent);
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 0.95em;
-}
-
-/* ─── Card actions ─────────────────────────────────────────────── */
-
-.card__actions {
-  display: flex;
-  gap: 0.4rem;
-  margin-top: 0.25rem;
-}
-
-.card__action {
-  background: var(--bg-elevated);
-  border: 1px solid var(--border);
-  color: var(--text);
-  padding: 0.3rem 0.65rem;
-  border-radius: 4px;
-  font-size: 0.78rem;
-  cursor: pointer;
-  font-family: inherit;
-  transition:
-    border-color 0.15s ease,
-    background 0.15s ease;
-}
-
-.card__action:hover:not(:disabled) {
-  border-color: var(--accent);
-  background: rgba(106, 162, 255, 0.08);
-}
-
-.card__action:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-}
-
-.card__action--primary {
-  background: rgba(106, 162, 255, 0.12);
-  border-color: rgba(106, 162, 255, 0.4);
-  color: var(--accent);
-  font-weight: 600;
-}
-
-.card__action--primary:hover:not(:disabled) {
-  background: rgba(106, 162, 255, 0.2);
-  border-color: var(--accent);
-}
-
-.card__warn--banner {
-  margin: 0 0 0.6rem 0;
-  background: rgba(246, 193, 119, 0.08);
-  border: 1px solid rgba(246, 193, 119, 0.3);
-  border-radius: 4px;
-  padding: 0.35rem 0.6rem;
-}
-
-/* ─── Fleet warnings ───────────────────────────────────────────── */
-
-.fleet-warnings {
-  margin: 0 0 0.6rem 0;
-  background: rgba(246, 193, 119, 0.06);
-  border: 1px solid rgba(246, 193, 119, 0.3);
-  border-radius: 4px;
-  padding: 0.45rem 0.65rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.fleet-warnings__heading {
-  margin: 0;
-  font-size: 0.78rem;
-  color: var(--yellow);
-  font-weight: 600;
-}
-
-.fleet-warnings__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-}
-
-.fleet-warnings__item {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.5rem;
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   color: var(--text-muted);
-  align-items: baseline;
 }
 
-.fleet-warnings__item code {
-  background: var(--bg-elevated);
-  padding: 0.05rem 0.35rem;
-  border-radius: 2px;
-  font-size: 0.95em;
-  color: var(--accent);
-}
-
-.fleet-warnings__path {
+.git-inline__branch {
   font-family: 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 0.92em;
-  color: var(--text-dim);
+  max-width: 18ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.card__drift {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-}
-
-/* ─── Terminal pane ────────────────────────────────────────────── */
-
-.pane__heading {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.pane__heading h2 {
-  margin: 0;
-}
-
-.pane__heading-sub {
-  font-family: 'SF Mono', Menlo, Consolas, monospace;
-  letter-spacing: 0;
-  text-transform: none;
+.ticket-pill {
+  background: rgba(106, 162, 255, 0.15);
   color: var(--accent);
-  font-weight: 500;
+  padding: 0 0.3rem;
+  border-radius: 2px;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+
+.git-inline__dirty {
+  color: var(--yellow);
+}
+
+.git-inline__ahead-behind {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  letter-spacing: -0.02em;
   font-size: 0.7rem;
 }
 
-.link-button {
+.ports-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+.port-mini {
+  background: var(--bg);
+  color: var(--accent);
+  border: 1px solid var(--border-strong);
+  border-radius: 3px;
+  padding: 0.05rem 0.35rem;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.65rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.port-mini:hover {
+  border-color: var(--accent);
+}
+
+/* ─── Note (editable label) ──────────────────────────── */
+
+.note__display,
+.note__display--empty,
+.note__input {
+  font: inherit;
+  font-size: 0.78rem;
   background: none;
   border: none;
-  color: var(--text-muted);
-  font-family: inherit;
-  font-size: 0.72rem;
-  cursor: pointer;
-  padding: 0.15rem 0.4rem;
+  padding: 0.1rem 0;
+  margin: 0;
+  text-align: left;
+  color: var(--text);
+  cursor: text;
+  width: 100%;
+  font-weight: 500;
+  outline: none;
   border-radius: 3px;
 }
 
-.link-button:hover {
+.note__display:hover {
+  background: rgba(106, 162, 255, 0.08);
+}
+
+.note__display--empty {
+  color: var(--text-dim);
+  font-style: italic;
+  font-weight: 400;
+}
+
+.note__input {
+  background: var(--bg);
+  border: 1px solid var(--accent);
+  padding: 0.1rem 0.4rem;
   color: var(--text);
-  background: var(--bg-elevated);
+  font-weight: 500;
+}
+
+/* ─── Activity line (auto-derived signal) ────────────── */
+
+.cell__activity {
+  margin: 0;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.cell__activity--tool {
+  color: var(--text-dim);
+}
+
+.cell__activity-label {
+  color: var(--green);
+  font-weight: 600;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cell__activity code {
+  background: var(--bg);
+  padding: 0 0.3rem;
+  border-radius: 2px;
+  color: var(--accent);
+  font-size: 0.95em;
+  border: 1px solid var(--border);
+}
+
+.cell__activity-arg {
+  color: var(--text-muted);
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.95em;
+}
+
+/* ─── Embedded terminal ──────────────────────────────── */
+
+.cell__terminal {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  background: var(--bg);
 }
 
 .terminal {
   position: relative;
   width: 100%;
-  height: calc(100% - 1.6rem);
+  height: 100%;
   background: var(--bg);
   display: flex;
   flex-direction: column;
@@ -628,7 +376,7 @@ body,
 .terminal__pane {
   flex: 1;
   min-height: 0;
-  padding: 0.5rem;
+  padding: 0.4rem;
 }
 
 .terminal__pane .xterm,

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -152,6 +152,14 @@ export type SessionRunState =
   | 'idle'
   | 'unknown';
 
+/** A single tool_use the assistant is running but hasn't received a result for. */
+export interface InFlightTool {
+  /** Tool name, e.g. "Bash", "Edit", "Read" */
+  name: string;
+  /** Short, human-readable summary of the tool's input */
+  summary: string;
+}
+
 export interface SessionState {
   /** 'active' = transcript exists; 'none' = no transcript directory */
   status: 'active' | 'none';
@@ -160,14 +168,32 @@ export interface SessionState {
   transcriptPath?: string;
   /** ISO timestamp of the last entry */
   lastActivityAt?: string;
-  /** Most recent user prompt text (for "topic" derivation in the card) */
-  lastUserPrompt?: string;
+  /**
+   * Claude's most recent assistant text content — usually a "here's
+   * what I just did" wrap-up. Far more useful than the user's last
+   * prompt when surfacing on a card.
+   */
+  lastAssistantText?: string;
+  /**
+   * Tool currently in flight when runState === 'tool_in_flight'.
+   * The first unanswered tool_use from the latest assistant turn.
+   */
+  currentTool?: InFlightTool;
   /** Most recent TodoWrite list — empty if the agent never used TodoWrite */
   todos: TodoItem[];
   /** Branch CC was on at the latest entry (assistant entries include `gitBranch`) */
   gitBranch?: string;
   /** Inferred run state — see SessionRunState */
   runState: SessionRunState;
+}
+
+// ─── Notes (operator-owned per-agent labels) ─────────────────────────────
+
+export interface AgentNote {
+  /** Free-form text the operator wrote for this agent */
+  label: string;
+  /** ISO timestamp of last edit */
+  updatedAt: string;
 }
 
 // ─── Terminal (MVP-6) ────────────────────────────────────────────────────
@@ -223,6 +249,12 @@ export interface RanchApi {
     git: (agent: string) => Promise<WorktreeGitState>;
     /** Fleet snapshot — one ps + one tmux-list per call, all agents. */
     processSnapshot: () => Promise<ProcessSnapshot>;
+  };
+  notes: {
+    /** Returns notes keyed by agent name. Missing key = no note. */
+    getAll: () => Promise<Record<string, AgentNote>>;
+    /** Pass empty string to clear. */
+    set: (agent: string, label: string) => Promise<AgentNote | null>;
   };
   terminal: {
     env: () => Promise<TerminalEnv>;


### PR DESCRIPTION
## Summary

Big layout pivot. The grid + single-terminal-pane model is replaced with a **2x2 mission-control grid**: each cell is one worktree, with its metadata strip on top and a live embedded terminal below. **All four claudes are visible and running simultaneously.**

## What you'll see

\`\`\`
┌─ Ranch ─────────────────────────────────────── ⚠ orphans?  ────┐
├──────────────────────────────┬─────────────────────────────────┤
│ max  [needs input] feature/… │ jeffy  [working]  feature/…    │
│ ECD-1234  ↑3  D:8003 V:3003  │ ECD-9999  ●  D:8001 V:3001     │
│ "scrapers tickets today"     │ "fixing the auth bug"          │
│ Claude finished refactoring… │ running Bash: npm test          │
│ ┌─────────────────────────┐  │ ┌─────────────────────────┐    │
│ │   live terminal #1      │  │ │   live terminal #2      │    │
│ │                         │  │ │                         │    │
│ └─────────────────────────┘  │ └─────────────────────────┘    │
├──────────────────────────────┼─────────────────────────────────┤
│ arnold [no session] develop  │ kesha [last · 3d] develop       │
│ ...                          │ ...                             │
└──────────────────────────────┴─────────────────────────────────┘
\`\`\`

## Per-cell metadata strip

- **Status pill** — \`running\` / \`working\` / \`needs input\` / \`last · 14m\` / \`no session\`
- **Branch + ticket pill** + dirty dot + ↑/↓ ahead/behind (compact inline)
- **Port-mini buttons** \`D:8003 V:3003\` — click to open in browser
- **Editable note** (operator-owned) — \"max will work on scrapers tickets today\". Click to edit, Enter to save, Esc to cancel. Persists in \`~/.ranch/notes.json\`.
- **Activity line** — what claude is doing right now: \`running Bash: npm test\`, or claude's most recent text response (the summary at the end of a turn). NOT the user's last prompt — that was useless and is gone.

## Behavior

- All four tmux sessions auto-attach on app open. Sessions persist when ranch closes (tmux semantics).
- Click a cell → border highlights, keyboard input goes to that terminal.
- Cell with awaiting-input claude → yellow left bar, visible across the grid.
- Orphan claude warning collapses into a small \`⚠ orphan claudes\` pill in the header.

## Editable notes

Stored at \`~/.ranch/notes.json\`. Agents can't touch this file (it's outside every worktree, by design). Polled every 15s so external edits flow back.

\`\`\`json
{
  \"agents\": {
    \"max\": {
      \"label\": \"working on scrapers tickets today\",
      \"updatedAt\": \"2026-04-30T03:00:00.000Z\"
    }
  }
}
\`\`\`

## Activity signal upgrade

Old: \"last user prompt\" — useless, you wrote it.
New: priority chain → \`currentTool\` (e.g. \`Running Bash: npm test\`) → claude's most recent text → in-progress todo. The transcript parser now extracts \`lastAssistantText\` and \`currentTool\` from the JSONL tail.

## Verification

- \`pnpm typecheck\` — clean
- \`pnpm lint\` — clean
- \`pnpm format:check\` — clean
- \`pnpm build\` — main 22 kB, preload 2 kB, renderer ~810 kB

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Window opens with 4 cells; all four claudes auto-launch on first open into their respective tmux sessions
- [ ] Click into one cell, type → keystrokes go to that terminal; click another, switch
- [ ] Add a note (\"working on scrapers today\") on max → persists across reload
- [ ] Run a long Bash in one — its activity line should read \`running Bash: …\` while in flight
- [ ] Once that finishes and claude wraps up — activity line should show claude's summary text
- [ ] Pause one — within ~5s pill flips to \`needs input\` (yellow) and the cell gets a yellow left bar visible across the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)