### PR TITLE
feat(console): clickable port buttons + agent detail sidebar

### DIFF
--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -47,6 +47,7 @@ export const IPC_CHANNELS = {
   terminalExit: 'terminal:exit',
   appVersion: 'ranch:app:version',
   appRevealInFinder: 'ranch:app:revealInFinder',
+  appOpenExternal: 'ranch:app:openExternal',
 } as const;
 
 export function registerIpcHandlers(): void {
@@ -161,5 +162,14 @@ export function registerIpcHandlers(): void {
     // if it's a file, or showing the directory). Safer than openPath which
     // would try to "open" the directory in whatever the default handler is.
     shell.showItemInFolder(path);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.appOpenExternal, async (_event, url: unknown) => {
+    if (typeof url !== 'string' || !url) return;
+    // Allowlist: http(s) and the file:// scheme. Anything else is rejected
+    // — we don't want a stray IPC message launching a `file://` script or a
+    // custom-protocol handler we didn't authorize.
+    if (!/^(https?:|file:)\/\//.test(url)) return;
+    await shell.openExternal(url);
   });
 }

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -40,6 +40,7 @@ const IPC_CHANNELS = {
   terminalExit: 'terminal:exit',
   appVersion: 'ranch:app:version',
   appRevealInFinder: 'ranch:app:revealInFinder',
+  appOpenExternal: 'ranch:app:openExternal',
 } as const;
 
 /**
@@ -96,6 +97,8 @@ const api: RanchApi = {
     version: () => ipcRenderer.invoke(IPC_CHANNELS.appVersion),
     revealInFinder: (path) =>
       ipcRenderer.invoke(IPC_CHANNELS.appRevealInFinder, path),
+    openExternal: (url) =>
+      ipcRenderer.invoke(IPC_CHANNELS.appOpenExternal, url),
   },
 };
 

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import type {
   AgentNote,
   CCProcessState,
@@ -39,6 +46,7 @@ export function App(): JSX.Element {
     useState<ProcessSnapshot>(EMPTY_SNAPSHOT);
   const [notes, setNotes] = useState<Record<string, AgentNote>>({});
   const [focusedAgent, setFocusedAgent] = useState<string | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
 
   // ─── one-shot loads ────────────────────────────────────────
   useEffect(() => {
@@ -144,6 +152,11 @@ export function App(): JSX.Element {
     }
   }, []);
 
+  const focusedWorktree =
+    focusedAgent !== null
+      ? (state.worktrees.find((w) => w.agent === focusedAgent) ?? null)
+      : null;
+
   return (
     <div className="app">
       <header className="app__header">
@@ -157,28 +170,57 @@ export function App(): JSX.Element {
             ⚠ tmux not found — install with <code>brew install tmux</code>
           </span>
         )}
+        <button
+          type="button"
+          className={`sidebar-toggle${sidebarOpen ? ' sidebar-toggle--open' : ''}`}
+          onClick={() => setSidebarOpen((v) => !v)}
+          title={sidebarOpen ? 'Hide detail sidebar' : 'Show detail sidebar'}
+        >
+          {sidebarOpen ? 'Hide details ›' : '‹ Details'}
+        </button>
       </header>
-      <main className="app__grid">
-        {state.status === 'loading' && (
-          <p className="placeholder">Loading worktrees…</p>
+      <div className={`app__body${sidebarOpen ? ' app__body--sidebar' : ''}`}>
+        <main className="app__grid">
+          {state.status === 'loading' && (
+            <p className="placeholder">Loading worktrees…</p>
+          )}
+          {state.status === 'error' && (
+            <p className="placeholder placeholder--error">
+              Error: {state.error}
+            </p>
+          )}
+          {state.status === 'ready' &&
+            state.worktrees.map((wt) => (
+              <AgentCell
+                key={wt.agent}
+                worktree={wt}
+                processState={processSnapshot.perAgent[wt.agent] ?? null}
+                note={notes[wt.agent] ?? null}
+                terminalEnv={terminalEnv}
+                focused={focusedAgent === wt.agent}
+                onFocus={() => setFocusedAgent(wt.agent)}
+                onSaveNote={(label) => saveNote(wt.agent, label)}
+              />
+            ))}
+        </main>
+        {sidebarOpen && (
+          <aside className="sidebar">
+            {focusedWorktree ? (
+              <AgentDetail
+                worktree={focusedWorktree}
+                processState={
+                  processSnapshot.perAgent[focusedWorktree.agent] ?? null
+                }
+                note={notes[focusedWorktree.agent] ?? null}
+              />
+            ) : (
+              <p className="placeholder">
+                Click a cell to see its detail here.
+              </p>
+            )}
+          </aside>
         )}
-        {state.status === 'error' && (
-          <p className="placeholder placeholder--error">Error: {state.error}</p>
-        )}
-        {state.status === 'ready' &&
-          state.worktrees.map((wt) => (
-            <AgentCell
-              key={wt.agent}
-              worktree={wt}
-              processState={processSnapshot.perAgent[wt.agent] ?? null}
-              note={notes[wt.agent] ?? null}
-              terminalEnv={terminalEnv}
-              focused={focusedAgent === wt.agent}
-              onFocus={() => setFocusedAgent(wt.agent)}
-              onSaveNote={(label) => saveNote(wt.agent, label)}
-            />
-          ))}
-      </main>
+      </div>
     </div>
   );
 }
@@ -557,19 +599,261 @@ function PortsInline({
   return (
     <span className="ports-inline">
       {buttons.map((b) => (
-        <a
+        <button
           key={b.label}
           className="port-mini"
-          href={`http://localhost:${b.port}`}
-          target="_blank"
-          rel="noreferrer"
-          onClick={(e) => e.stopPropagation()}
-          title={`Open localhost:${b.port}`}
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            void window.ranch.app.openExternal(`http://localhost:${b.port}`);
+          }}
+          title={`Open http://localhost:${b.port} in your browser`}
         >
           {b.label}:{b.port}
-        </a>
+          <span className="port-mini__arrow">↗</span>
+        </button>
       ))}
     </span>
+  );
+}
+
+// ─── Sidebar AgentDetail ─────────────────────────────────────
+
+function AgentDetail({
+  worktree,
+  processState,
+  note,
+}: {
+  worktree: WorktreeBasics;
+  processState: CCProcessState | null;
+  note: AgentNote | null;
+}): JSX.Element {
+  const [session, setSession] = useState<SessionState | null>(null);
+  const [git, setGit] = useState<WorktreeGitState | null>(null);
+
+  // Sidebar polls its own copies. We refetch on agent change so switching
+  // between cells gets fresh data immediately rather than after the next tick.
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      try {
+        const [s, g] = await Promise.all([
+          window.ranch.worktrees.session(worktree.agent),
+          window.ranch.worktrees.git(worktree.agent),
+        ]);
+        if (!cancelled) {
+          setSession(s);
+          setGit(g);
+        }
+      } catch {
+        // ignore
+      }
+    }
+    void refresh();
+    const handle = setInterval(refresh, 5000);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [worktree.agent]);
+
+  return (
+    <div className="detail">
+      <div className="detail__header">
+        <span className="detail__name">{worktree.agent}</span>
+        {note?.label && <p className="detail__label">{note.label}</p>}
+        <button
+          type="button"
+          className="detail__reveal"
+          onClick={() =>
+            void window.ranch.app.revealInFinder(worktree.worktreePath)
+          }
+          title="Reveal worktree in Finder"
+        >
+          Reveal in Finder
+        </button>
+      </div>
+
+      <DetailSection title="Status">
+        <DetailRow label="run state" value={session?.runState ?? '…'} />
+        <DetailRow
+          label="last activity"
+          value={relativeAge(session?.lastActivityAt)}
+        />
+        <DetailRow
+          label="claude PID(s)"
+          value={
+            processState && processState.claudeProcesses.length > 0
+              ? processState.claudeProcesses.map((p) => p.pid).join(', ')
+              : '—'
+          }
+        />
+        <DetailRow
+          label="tmux"
+          value={
+            processState?.tmux
+              ? `${processState.tmux.sessionName} (${processState.tmux.attachedClients} client${processState.tmux.attachedClients === 1 ? '' : 's'})`
+              : '—'
+          }
+        />
+      </DetailSection>
+
+      <DetailSection title="Branch">
+        {git?.status === 'ok' ? (
+          <>
+            <DetailRow label="branch" value={git.branch} mono />
+            <DetailRow label="dirty" value={git.dirty ? 'yes' : 'no'} />
+            <DetailRow
+              label="vs origin/develop"
+              value={`↑${git.ahead ?? 0}  ↓${git.behind ?? 0}`}
+              mono
+            />
+            {git.lastCommit && (
+              <DetailRow
+                label="last commit"
+                value={`${git.lastCommit.sha} · ${git.lastCommit.message} · ${git.lastCommit.age}`}
+              />
+            )}
+          </>
+        ) : (
+          <p className="detail__empty">no git repository</p>
+        )}
+      </DetailSection>
+
+      <DetailSection title="Ports">
+        <DetailRow
+          label="source"
+          value={
+            worktree.portsSource === 'ranch-config'
+              ? 'ranch config (canonical)'
+              : worktree.portsSource === 'env-agent'
+                ? '.env.agent (may drift)'
+                : 'unknown'
+          }
+        />
+        {worktree.ports.django !== undefined && (
+          <DetailRow
+            label="django"
+            value={String(worktree.ports.django)}
+            mono
+          />
+        )}
+        {worktree.ports.vite !== undefined && (
+          <DetailRow label="vite" value={String(worktree.ports.vite)} mono />
+        )}
+        {worktree.envAgentPath && (
+          <DetailRow label=".env.agent" value={worktree.envAgentPath} mono />
+        )}
+        {!worktree.envAgentMatches && worktree.envAgentName && (
+          <p className="detail__warn">
+            ⚠ .env.agent says <code>AGENT_NAME={worktree.envAgentName}</code>{' '}
+            but this worktree is registered as <code>{worktree.agent}</code>.
+            Run <code>make sync-env</code> from citemed_web on develop.
+          </p>
+        )}
+      </DetailSection>
+
+      {processState?.claudeRunning &&
+        processState.claudeProcesses.length > 1 && (
+          <DetailSection title="⚠ Multiple claude processes">
+            <p className="detail__warn">
+              {processState.claudeProcesses.length} claude processes detected
+              here — duplicate session is likely.
+            </p>
+            <ul className="detail__pids">
+              {processState.claudeProcesses.map((p) => (
+                <li key={p.pid}>
+                  <code>PID {p.pid}</code>
+                  {p.cwd && <span className="detail__path"> · {p.cwd}</span>}
+                </li>
+              ))}
+            </ul>
+          </DetailSection>
+        )}
+
+      {processState?.claudeRunning && !processState.tmux && (
+        <DetailSection title="⚠ Outside ranch">
+          <p className="detail__warn">
+            Claude is running in this worktree but no{' '}
+            <code>ranch-{worktree.agent}</code> tmux session exists. It was
+            likely started outside the console.
+          </p>
+        </DetailSection>
+      )}
+
+      <DetailSection title="Todos" count={session?.todos.length ?? 0}>
+        {session && session.todos.length > 0 ? (
+          <ul className="detail__todos">
+            {session.todos.map((t, i) => (
+              <li
+                key={i}
+                className={`detail__todo detail__todo--${t.status.replace('_', '-')}`}
+              >
+                <span className="detail__todo-icon">
+                  {t.status === 'completed'
+                    ? '✓'
+                    : t.status === 'in_progress'
+                      ? '◐'
+                      : '○'}
+                </span>
+                <span className="detail__todo-text">{t.content}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="detail__empty">no todos in this session</p>
+        )}
+      </DetailSection>
+
+      {session?.lastAssistantText && (
+        <DetailSection title="Latest assistant text">
+          <p className="detail__text">{session.lastAssistantText}</p>
+        </DetailSection>
+      )}
+    </div>
+  );
+}
+
+function DetailSection({
+  title,
+  count,
+  children,
+}: {
+  title: string;
+  count?: number;
+  children: ReactNode;
+}): JSX.Element {
+  return (
+    <section className="detail__section">
+      <h3 className="detail__section-title">
+        {title}
+        {count !== undefined && count > 0 && (
+          <span className="detail__count">{count}</span>
+        )}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}): JSX.Element {
+  return (
+    <div className="detail__row">
+      <span className="detail__row-label">{label}</span>
+      <span
+        className={`detail__row-value${mono ? ' detail__row-value--mono' : ''}`}
+      >
+        {value}
+      </span>
+    </div>
   );
 }
 

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -78,14 +78,55 @@ body,
   border-radius: 2px;
 }
 
-.app__grid {
+.app__body {
   flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  transition: grid-template-columns 0.18s ease;
+}
+
+.app__body--sidebar {
+  grid-template-columns: 1fr 380px;
+}
+
+.app__grid {
   min-height: 0;
   display: grid;
   grid-template-columns: 1fr 1fr;
   grid-template-rows: 1fr 1fr;
   gap: 1px;
   background: var(--border);
+}
+
+.sidebar {
+  background: var(--bg-elevated);
+  border-left: 1px solid var(--border);
+  overflow-y: auto;
+  min-width: 0;
+}
+
+.sidebar-toggle {
+  margin-left: 0.5rem;
+  background: var(--bg);
+  color: var(--text-muted);
+  border: 1px solid var(--border-strong);
+  padding: 0.2rem 0.6rem;
+  font: inherit;
+  font-size: 0.72rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sidebar-toggle:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.sidebar-toggle--open {
+  background: rgba(106, 162, 255, 0.1);
+  color: var(--accent);
+  border-color: rgba(106, 162, 255, 0.4);
 }
 
 .placeholder {
@@ -263,15 +304,36 @@ body,
   color: var(--accent);
   border: 1px solid var(--border-strong);
   border-radius: 3px;
-  padding: 0.05rem 0.35rem;
+  padding: 0.1rem 0.4rem;
   font-family: 'SF Mono', Menlo, Consolas, monospace;
   font-size: 0.65rem;
   text-decoration: none;
   white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  cursor: pointer;
+  font: inherit;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.65rem;
+  font-weight: 600;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
 }
 
 .port-mini:hover {
   border-color: var(--accent);
+  background: rgba(106, 162, 255, 0.1);
+}
+
+.port-mini__arrow {
+  color: var(--text-dim);
+  font-size: 0.85em;
+}
+
+.port-mini:hover .port-mini__arrow {
+  color: var(--accent);
 }
 
 /* ─── Note (editable label) ──────────────────────────── */
@@ -400,4 +462,209 @@ body,
 .terminal__overlay--error {
   color: var(--red);
   pointer-events: auto;
+}
+
+/* ─── Sidebar / AgentDetail ──────────────────────────── */
+
+.detail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 0.85rem 0.95rem 1.5rem;
+}
+
+.detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.detail__name {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--accent);
+}
+
+.detail__label {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.detail__reveal {
+  align-self: flex-start;
+  background: var(--bg);
+  color: var(--text-muted);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  padding: 0.2rem 0.55rem;
+  font: inherit;
+  font-size: 0.7rem;
+  cursor: pointer;
+}
+
+.detail__reveal:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.detail__section-title {
+  margin: 0;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.detail__count {
+  background: var(--bg);
+  color: var(--text-dim);
+  font-size: 0.85em;
+  padding: 0 0.35rem;
+  border-radius: 8px;
+  font-weight: 600;
+  letter-spacing: 0;
+  border: 1px solid var(--border);
+}
+
+.detail__row {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 0.5rem;
+  font-size: 0.74rem;
+  align-items: baseline;
+}
+
+.detail__row-label {
+  color: var(--text-dim);
+  text-transform: lowercase;
+}
+
+.detail__row-value {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail__row-value--mono {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.93em;
+}
+
+.detail__warn {
+  margin: 0;
+  color: var(--yellow);
+  font-size: 0.74rem;
+  line-height: 1.4;
+}
+
+.detail__warn code {
+  background: rgba(246, 193, 119, 0.1);
+  padding: 0 0.3rem;
+  border-radius: 2px;
+  font-size: 0.95em;
+}
+
+.detail__empty {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 0.74rem;
+  font-style: italic;
+}
+
+.detail__pids {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.72rem;
+}
+
+.detail__pids code {
+  background: var(--bg);
+  padding: 0 0.3rem;
+  border-radius: 2px;
+  color: var(--accent);
+  border: 1px solid var(--border);
+}
+
+.detail__path {
+  color: var(--text-dim);
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.95em;
+}
+
+.detail__todos {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.detail__todo {
+  display: grid;
+  grid-template-columns: 1.2rem 1fr;
+  gap: 0.4rem;
+  align-items: baseline;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+
+.detail__todo-icon {
+  text-align: center;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+}
+
+.detail__todo--completed {
+  color: var(--text-dim);
+  text-decoration: line-through;
+}
+.detail__todo--completed .detail__todo-icon {
+  color: var(--green);
+}
+
+.detail__todo--in-progress {
+  color: var(--text);
+  font-weight: 500;
+}
+.detail__todo--in-progress .detail__todo-icon {
+  color: var(--yellow);
+}
+
+.detail__todo--pending .detail__todo-icon {
+  color: var(--text-dim);
+}
+
+.detail__text {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: var(--bg);
+  padding: 0.5rem 0.6rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  max-height: 18rem;
+  overflow-y: auto;
 }

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -272,6 +272,8 @@ export interface RanchApi {
     version: () => Promise<string>;
     /** Open a path in the OS file manager. */
     revealInFinder: (path: string) => Promise<void>;
+    /** Open a URL in the user's default browser (or whatever shell handles it). */
+    openExternal: (url: string) => Promise<void>;
   };
 }
 


### PR DESCRIPTION
## Summary

Two changes:

1. **Port buttons actually click.** Replaced anchor + \`target=\"_blank\"\` with a real button that calls a new \`ranch.app.openExternal(url)\` IPC. Added a small ↗ glyph and stronger hover state so the affordance is unmistakable. The IPC allowlists only \`http(s):\` and \`file://\` schemes.
2. **Detail sidebar.** Toggleable slide-out on the right side. Shows the focused agent's deep context — the stuff the cell strip deliberately hides to keep the grid scannable.

## Sidebar contents

When focused on an agent, the sidebar surfaces:

- **Status** — run state, last activity, claude PIDs, tmux session info
- **Branch** — branch name, dirty/clean, ahead/behind origin/develop, last commit
- **Ports** — source (canonical ranch-config vs drift-prone .env.agent), values, file path, AGENT_NAME mismatch warning
- **Cross-contamination warnings** — multiple claudes here? claude running outside a ranch- tmux session?
- **Full todo list** — every todo with status icon, no truncation
- **Latest assistant text** — claude's full most-recent response, scrollable
- **Reveal in Finder** affordance

Click a cell → sidebar auto-shows that agent. Toggle off to reclaim the full grid width.

## Followup roadmap (not in this PR)

- **Docker management section** — per-agent stack up/down, log tail
- **Fleet config UI** — edit \`~/.ranch/config.toml\` (agent paths, descriptions, canonical ports) from the app

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Click a port button (D:8003 / V:3003) → opens that localhost URL in your default browser
- [ ] Click \"Details\" in header → sidebar slides in
- [ ] Click different cells → sidebar swaps to show whichever agent
- [ ] Sidebar updates live (todos, status, last activity)
- [ ] Click \"Reveal in Finder\" in sidebar → Finder opens worktree
- [ ] Toggle Details off → grid expands to full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)