### PR TITLE
feat(console): Interactive | Automated mode tabs + automated view stub

### DIFF
--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -47,6 +47,7 @@ export function App(): JSX.Element {
   const [notes, setNotes] = useState<Record<string, AgentNote>>({});
   const [focusedAgent, setFocusedAgent] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+  const [mode, setMode] = useState<'interactive' | 'automated'>('interactive');
 
   // ─── one-shot loads ────────────────────────────────────────
   useEffect(() => {
@@ -161,67 +162,221 @@ export function App(): JSX.Element {
     <div className="app">
       <header className="app__header">
         <h1>Ranch</h1>
+        <ModeTabs mode={mode} onChange={setMode} />
         <span className="app__version">
           {state.appVersion ? `v${state.appVersion}` : ''}
         </span>
         <FleetWarnings snapshot={processSnapshot} />
-        {terminalEnv && !terminalEnv.tmuxAvailable && (
-          <span className="app__warn">
-            ⚠ tmux not found — install with <code>brew install tmux</code>
-          </span>
+        {mode === 'interactive' &&
+          terminalEnv &&
+          !terminalEnv.tmuxAvailable && (
+            <span className="app__warn">
+              ⚠ tmux not found — install with <code>brew install tmux</code>
+            </span>
+          )}
+        {mode === 'interactive' && (
+          <button
+            type="button"
+            className={`sidebar-toggle${sidebarOpen ? ' sidebar-toggle--open' : ''}`}
+            onClick={() => setSidebarOpen((v) => !v)}
+            title={sidebarOpen ? 'Hide detail sidebar' : 'Show detail sidebar'}
+          >
+            {sidebarOpen ? 'Hide details ›' : '‹ Details'}
+          </button>
         )}
-        <button
-          type="button"
-          className={`sidebar-toggle${sidebarOpen ? ' sidebar-toggle--open' : ''}`}
-          onClick={() => setSidebarOpen((v) => !v)}
-          title={sidebarOpen ? 'Hide detail sidebar' : 'Show detail sidebar'}
-        >
-          {sidebarOpen ? 'Hide details ›' : '‹ Details'}
-        </button>
       </header>
-      <div className={`app__body${sidebarOpen ? ' app__body--sidebar' : ''}`}>
-        <main className="app__grid">
-          {state.status === 'loading' && (
-            <p className="placeholder">Loading worktrees…</p>
-          )}
-          {state.status === 'error' && (
-            <p className="placeholder placeholder--error">
-              Error: {state.error}
-            </p>
-          )}
-          {state.status === 'ready' &&
-            state.worktrees.map((wt) => (
-              <AgentCell
-                key={wt.agent}
-                worktree={wt}
-                processState={processSnapshot.perAgent[wt.agent] ?? null}
-                note={notes[wt.agent] ?? null}
-                terminalEnv={terminalEnv}
-                focused={focusedAgent === wt.agent}
-                onFocus={() => setFocusedAgent(wt.agent)}
-                onSaveNote={(label) => saveNote(wt.agent, label)}
-              />
-            ))}
-        </main>
-        {sidebarOpen && (
-          <aside className="sidebar">
-            {focusedWorktree ? (
-              <AgentDetail
-                worktree={focusedWorktree}
-                processState={
-                  processSnapshot.perAgent[focusedWorktree.agent] ?? null
-                }
-                note={notes[focusedWorktree.agent] ?? null}
-              />
-            ) : (
-              <p className="placeholder">
-                Click a cell to see its detail here.
+      {mode === 'interactive' ? (
+        <div className={`app__body${sidebarOpen ? ' app__body--sidebar' : ''}`}>
+          <main className="app__grid">
+            {state.status === 'loading' && (
+              <p className="placeholder">Loading worktrees…</p>
+            )}
+            {state.status === 'error' && (
+              <p className="placeholder placeholder--error">
+                Error: {state.error}
               </p>
             )}
-          </aside>
-        )}
+            {state.status === 'ready' &&
+              state.worktrees.map((wt) => (
+                <AgentCell
+                  key={wt.agent}
+                  worktree={wt}
+                  processState={processSnapshot.perAgent[wt.agent] ?? null}
+                  note={notes[wt.agent] ?? null}
+                  terminalEnv={terminalEnv}
+                  focused={focusedAgent === wt.agent}
+                  onFocus={() => setFocusedAgent(wt.agent)}
+                  onSaveNote={(label) => saveNote(wt.agent, label)}
+                />
+              ))}
+          </main>
+          {sidebarOpen && (
+            <aside className="sidebar">
+              {focusedWorktree ? (
+                <AgentDetail
+                  worktree={focusedWorktree}
+                  processState={
+                    processSnapshot.perAgent[focusedWorktree.agent] ?? null
+                  }
+                  note={notes[focusedWorktree.agent] ?? null}
+                />
+              ) : (
+                <p className="placeholder">
+                  Click a cell to see its detail here.
+                </p>
+              )}
+            </aside>
+          )}
+        </div>
+      ) : (
+        <AutomatedView />
+      )}
+    </div>
+  );
+}
+
+// ─── Mode tabs ────────────────────────────────────────────────
+
+function ModeTabs({
+  mode,
+  onChange,
+}: {
+  mode: 'interactive' | 'automated';
+  onChange: (mode: 'interactive' | 'automated') => void;
+}): JSX.Element {
+  return (
+    <div className="mode-tabs" role="tablist">
+      <button
+        role="tab"
+        aria-selected={mode === 'interactive'}
+        type="button"
+        className={`mode-tab${mode === 'interactive' ? ' mode-tab--active' : ''}`}
+        onClick={() => onChange('interactive')}
+      >
+        Interactive
+      </button>
+      <button
+        role="tab"
+        aria-selected={mode === 'automated'}
+        type="button"
+        className={`mode-tab${mode === 'automated' ? ' mode-tab--active' : ''}`}
+        onClick={() => onChange('automated')}
+      >
+        Automated
+      </button>
+    </div>
+  );
+}
+
+// ─── AutomatedView (stub) ─────────────────────────────────────
+
+function AutomatedView(): JSX.Element {
+  return (
+    <div className="automated">
+      <div className="automated__intro">
+        <h2>Automated runs</h2>
+        <p>
+          Fire-and-forget Claude SDK sessions running in the background. Each
+          run shows up as a card here with its current status —{' '}
+          <em>planning</em>, <em>working</em>, <em>awaiting approval</em>,{' '}
+          <em>done</em>, or <em>blocked</em>. The console bubbles up which ones
+          need your input or review so nothing falls through.
+        </p>
+        <p className="automated__hint">
+          The Python orchestrator already powers this — see{' '}
+          <code>ranch dispatch</code>, <code>ranch runs</code>,{' '}
+          <code>ranch approve</code>. Wiring that data into this view is the
+          next PR.
+        </p>
+      </div>
+
+      <div className="automated__demo">
+        <h3>What the run cards will look like</h3>
+        <div className="automated__cards">
+          <DemoRunCard
+            agent="max"
+            ticket="ECD-1234"
+            brief="Add /healthz endpoint with status checks"
+            status="awaiting_approval"
+            ageMin={2}
+          />
+          <DemoRunCard
+            agent="jeffy"
+            ticket="ECD-9988"
+            brief="Migrate legacy export job to celery beat"
+            status="working"
+            ageMin={14}
+          />
+          <DemoRunCard
+            agent="arnold"
+            ticket="ECD-1471"
+            brief="Fix flaky test_export_csv"
+            status="done"
+            ageMin={37}
+          />
+          <DemoRunCard
+            agent="kesha"
+            ticket="ECD-1502"
+            brief="Investigate slow AE-table query"
+            status="blocked"
+            ageMin={62}
+          />
+        </div>
       </div>
     </div>
+  );
+}
+
+function DemoRunCard({
+  agent,
+  ticket,
+  brief,
+  status,
+  ageMin,
+}: {
+  agent: string;
+  ticket: string;
+  brief: string;
+  status: 'planning' | 'working' | 'awaiting_approval' | 'done' | 'blocked';
+  ageMin: number;
+}): JSX.Element {
+  return (
+    <article className={`run-card run-card--${status}`}>
+      <header className="run-card__head">
+        <span className="run-card__agent">{agent}</span>
+        <span className="run-card__ticket">{ticket}</span>
+        <RunStatusPill status={status} />
+      </header>
+      <p className="run-card__brief">{brief}</p>
+      <footer className="run-card__foot">
+        <span className="run-card__age">last update {ageMin}m ago</span>
+        {status === 'awaiting_approval' && (
+          <span className="run-card__action-hint">click to review →</span>
+        )}
+        {status === 'blocked' && (
+          <span className="run-card__action-hint">needs unblock →</span>
+        )}
+      </footer>
+    </article>
+  );
+}
+
+function RunStatusPill({
+  status,
+}: {
+  status: 'planning' | 'working' | 'awaiting_approval' | 'done' | 'blocked';
+}): JSX.Element {
+  const labels = {
+    planning: 'planning',
+    working: 'working',
+    awaiting_approval: 'needs approval',
+    done: 'done',
+    blocked: 'blocked',
+  };
+  return (
+    <span className={`pill run-pill run-pill--${status}`}>
+      {labels[status]}
+    </span>
   );
 }
 

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -64,12 +64,52 @@ body,
 .app__warn {
   font-size: 0.72rem;
   color: var(--yellow);
-  margin-left: auto;
   padding: 0.2rem 0.5rem;
   background: rgba(246, 193, 119, 0.08);
   border: 1px solid rgba(246, 193, 119, 0.3);
   border-radius: 4px;
   cursor: help;
+  margin-left: auto;
+}
+
+/* ─── Mode tabs ──────────────────────────────────────── */
+
+.mode-tabs {
+  display: inline-flex;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 2px;
+  gap: 2px;
+  margin-left: 0.5rem;
+}
+
+.mode-tab {
+  background: none;
+  color: var(--text-muted);
+  border: none;
+  padding: 0.25rem 0.85rem;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  border-radius: 4px;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.mode-tab:hover {
+  color: var(--text);
+}
+
+.mode-tab--active {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.mode-tab--active:hover {
+  color: var(--bg);
 }
 
 .app__warn code {
@@ -667,4 +707,168 @@ body,
   border: 1px solid var(--border);
   max-height: 18rem;
   overflow-y: auto;
+}
+
+/* ─── Automated view ─────────────────────────────────── */
+
+.automated {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1.5rem 1.75rem 2.5rem;
+  background: var(--bg);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.automated__intro {
+  max-width: 60ch;
+}
+
+.automated__intro h2 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.automated__intro p {
+  margin: 0 0 0.6rem 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.automated__hint {
+  font-size: 0.75rem !important;
+  color: var(--text-dim) !important;
+}
+
+.automated__hint code {
+  background: var(--bg-elevated);
+  padding: 0 0.35rem;
+  border-radius: 2px;
+  font-size: 0.95em;
+  color: var(--accent);
+  border: 1px solid var(--border);
+}
+
+.automated__demo h3 {
+  margin: 0 0 0.6rem 0;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.automated__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 0.7rem;
+}
+
+.run-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.7rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+}
+
+.run-card:hover {
+  border-color: var(--border-strong);
+}
+
+.run-card--awaiting_approval {
+  border-color: rgba(246, 193, 119, 0.55);
+}
+.run-card--awaiting_approval::before {
+  /* small left bar — same vocabulary as the interactive cell needs-input */
+  content: '';
+}
+
+.run-card--blocked {
+  border-color: rgba(255, 106, 106, 0.5);
+}
+
+.run-card--done {
+  opacity: 0.75;
+}
+
+.run-card__head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.run-card__agent {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-weight: 700;
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+
+.run-card__ticket {
+  background: rgba(106, 162, 255, 0.15);
+  color: var(--accent);
+  padding: 0 0.35rem;
+  border-radius: 2px;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.run-card__brief {
+  margin: 0;
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--text);
+}
+
+.run-card__foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--text-dim);
+}
+
+.run-card__action-hint {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.run-pill--planning {
+  background: rgba(106, 162, 255, 0.12);
+  color: var(--accent);
+  border-color: rgba(106, 162, 255, 0.3);
+}
+.run-pill--working {
+  background: rgba(92, 212, 122, 0.18);
+  color: var(--green);
+  border-color: rgba(92, 212, 122, 0.45);
+}
+.run-pill--awaiting_approval {
+  background: rgba(246, 193, 119, 0.18);
+  color: var(--yellow);
+  border-color: rgba(246, 193, 119, 0.5);
+  font-weight: 700;
+}
+.run-pill--done {
+  background: var(--bg);
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+.run-pill--blocked {
+  background: rgba(255, 106, 106, 0.12);
+  color: var(--red);
+  border-color: rgba(255, 106, 106, 0.3);
+  font-weight: 700;
 }


### PR DESCRIPTION
## Summary

Adds the dual-mode product structure: a big tab toggle at the top of the window between **Interactive** (the 4-up live terminal grid) and **Automated** (fire-and-forget Claude SDK runs, status-driven cards, no terminals).

Per the recent UX design discussion: automated runs don't need terminal display — what they need is **status surfacing and bubble-up of which ones need your attention/feedback/testing**. This PR ships the framework for that.

## What's in this PR

- Header mode tab toggle (Interactive default)
- Refactored body to render either view
- Sidebar toggle becomes mode-local (interactive only — automated has its own sidebar concept later)
- AutomatedView with **stub data** showing four demo cards in the four states:
  - \`needs approval\` (yellow) — the awaiting-approval state, prominent
  - \`working\` (green) — mid-execution
  - \`done\` (dimmed)
  - \`blocked\` (red) — needs unblock
- Visual vocabulary matches the interactive cells: yellow accent for \"needs your input,\" red for \"blocked,\" green for \"working\"

## What's NOT in this PR (intentional)

- **Real data wiring.** The orchestrator already runs in Python (\`ranch dispatch\`, \`ranch runs\`) and writes to \`~/.ranch/ranch.db\` (Run / Checkpoint / Decision / Interjection tables). Reading that DB into the renderer is the next PR.
- **Lifecycle controls.** \`approve\` / \`reject\` / \`note\` / \`stop\` exist as Python CLI commands; surfacing them as buttons in the cards comes after the data is wired up.
- **Run dispatch from the UI.** Same — needs a \"new automated run\" form that calls into the Python orchestrator.

This PR sets up the structural framework so each of those lands in a focused, scoped follow-up.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Header shows two tabs: Interactive (active) | Automated
- [ ] Click Automated → 4-up grid disappears, replaced with intro text + 4 demo run cards
- [ ] Each demo card has appropriate visual treatment (needs-approval yellow, blocked red, etc.)
- [ ] Click Interactive → back to the live grid

## Why this lands now

Getting the **mode toggle** in place early means everything we build for automated runs has the right home. Otherwise we'd retrofit later. The demo cards also serve as a visual spec for the next implementer (you, me, or future iteration) — \"this is what the wired-up version should look like.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)