### PR TITLE
feat(console): wire Automated view to ~/.ranch/ranch.db (live runs)

### DIFF
--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -20,6 +20,7 @@ import { getActiveSession } from './transcript.js';
 import { getWorktreeGitState } from './git.js';
 import { snapshotProcessState } from './process.js';
 import { getAllNotes, setNote } from './notes.js';
+import { listRuns, getRun } from './runs.js';
 import {
   attachTerminal,
   detachTerminal,
@@ -36,6 +37,8 @@ export const IPC_CHANNELS = {
   worktreesProcessSnapshot: 'ranch:worktrees:processSnapshot',
   notesGetAll: 'ranch:notes:getAll',
   notesSet: 'ranch:notes:set',
+  runsList: 'ranch:runs:list',
+  runsGet: 'ranch:runs:get',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -100,6 +103,18 @@ export function registerIpcHandlers(): void {
       return setNote(agent, label);
     },
   );
+
+  ipcMain.handle(IPC_CHANNELS.runsList, async (_event, limit: unknown) => {
+    const n = typeof limit === 'number' ? limit : 50;
+    return listRuns(n);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.runsGet, async (_event, id: unknown) => {
+    if (typeof id !== 'number') {
+      throw new Error('runs.get requires a numeric id');
+    }
+    return getRun(id);
+  });
 
   ipcMain.handle(IPC_CHANNELS.terminalEnv, async () => getTerminalEnv());
 

--- a/console/src/main/runs.ts
+++ b/console/src/main/runs.ts
@@ -1,0 +1,208 @@
+/**
+ * Read-only access to the Python orchestrator's run history.
+ *
+ * The Python `ranch dispatch / run / runs / approve / reject` CLI writes
+ * to ~/.ranch/ranch.db (SQLite). We surface it here for the Automated
+ * mode in the console. Lifecycle controls (approve/reject/stop) keep
+ * happening through the Python CLI for now — this module is read-only.
+ *
+ * Implementation note: we shell out to /usr/bin/sqlite3 with -json flag
+ * rather than pulling in a native sqlite library. Avoids another
+ * electron-rebuild step. Performance is fine for the volumes ranch
+ * deals with (dozens of runs).
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import type {
+  RunCheckpoint,
+  RunDetail,
+  RunInterjection,
+  RunRecord,
+  RunStatus,
+} from '../shared/types.js';
+
+const execFile = promisify(execFileCb);
+
+const RANCH_DIR = process.env.RANCH_HOME ?? join(homedir(), '.ranch');
+const DB_PATH = join(RANCH_DIR, 'ranch.db');
+
+async function query(sql: string): Promise<unknown[]> {
+  if (!existsSync(DB_PATH)) return [];
+  const { stdout } = await execFile('/usr/bin/sqlite3', [
+    DB_PATH,
+    '-json',
+    sql,
+  ]);
+  if (!stdout.trim()) return [];
+  try {
+    const parsed: unknown = JSON.parse(stdout);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function asNumber(v: unknown): number | undefined {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string') {
+    const n = Number.parseInt(v, 10);
+    if (Number.isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+/**
+ * Map the orchestrator's state vocabulary onto the smaller set the UI
+ * uses. Tests-green/pre-push checkpoints flow through `needs_approval`
+ * generically — we don't try to disambiguate those at the card level.
+ */
+function mapState(raw: unknown): RunStatus {
+  switch (raw) {
+    case 'planning':
+      return 'planning';
+    case 'needs_approval':
+      return 'awaiting_approval';
+    case 'in_development':
+    case 'tests_green':
+      return 'working';
+    case 'queued':
+      return 'queued';
+    case 'completed':
+      return 'done';
+    case 'stopped':
+      return 'stopped';
+    case 'error':
+      return 'blocked';
+    default:
+      return 'unknown';
+  }
+}
+
+/** Trim a long brief down for display. */
+function summarizeBrief(text: string | undefined, max = 200): string {
+  if (!text) return '';
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  return oneLine.length <= max ? oneLine : oneLine.slice(0, max - 1) + '…';
+}
+
+function rowToRunRecord(row: Record<string, unknown>): RunRecord {
+  const id = asNumber(row['id'])!;
+  const status = mapState(row['state']);
+  const brief = summarizeBrief(asString(row['initial_prompt']));
+  const rec: RunRecord = {
+    id,
+    agent: asString(row['agent']) ?? 'unknown',
+    status,
+    brief,
+    rawState: asString(row['state']) ?? 'unknown',
+    dispatchMode:
+      asString(row['dispatch_mode']) === 'background'
+        ? 'background'
+        : 'foreground',
+  };
+  const ticket = asString(row['ticket']);
+  if (ticket) rec.ticket = ticket;
+  const startedAt = asString(row['started_at']);
+  if (startedAt) rec.startedAt = startedAt;
+  const endedAt = asString(row['ended_at']);
+  if (endedAt) rec.endedAt = endedAt;
+  const prUrl = asString(row['pr_url']);
+  if (prUrl) rec.prUrl = prUrl;
+  const pid = asNumber(row['pid']);
+  if (pid !== undefined) rec.pid = pid;
+  const logPath = asString(row['log_path']);
+  if (logPath) rec.logPath = logPath;
+  const branchName = asString(row['branch_name']);
+  if (branchName) rec.branchName = branchName;
+  return rec;
+}
+
+function rowToCheckpoint(row: Record<string, unknown>): RunCheckpoint {
+  const id = asNumber(row['id'])!;
+  const cp: RunCheckpoint = {
+    id,
+    runId: asNumber(row['run_id'])!,
+    kind: asString(row['kind']) ?? 'unknown',
+    decision: (asString(row['decision']) ??
+      'pending') as RunCheckpoint['decision'],
+  };
+  const summary = asString(row['summary']);
+  if (summary) cp.summary = summary;
+  const createdAt = asString(row['created_at']);
+  if (createdAt) cp.createdAt = createdAt;
+  const decidedAt = asString(row['decided_at']);
+  if (decidedAt) cp.decidedAt = decidedAt;
+  const note = asString(row['decision_note']);
+  if (note) cp.decisionNote = note;
+  return cp;
+}
+
+function rowToInterjection(row: Record<string, unknown>): RunInterjection {
+  const inj: RunInterjection = {
+    id: asNumber(row['id'])!,
+    runId: asNumber(row['run_id'])!,
+    kind: asString(row['kind']) ?? 'unknown',
+  };
+  const content = asString(row['content']);
+  if (content) inj.content = content;
+  const createdAt = asString(row['created_at']);
+  if (createdAt) inj.createdAt = createdAt;
+  const processedAt = asString(row['processed_at']);
+  if (processedAt) inj.processedAt = processedAt;
+  return inj;
+}
+
+export async function listRuns(limit = 50): Promise<RunRecord[]> {
+  const rows = (await query(
+    `SELECT id, agent, ticket, state, dispatch_mode, started_at, ended_at,
+            initial_prompt, pid, log_path, branch_name, pr_url
+     FROM runs
+     ORDER BY id DESC
+     LIMIT ${Number(limit)}`,
+  )) as Record<string, unknown>[];
+  return rows.map(rowToRunRecord);
+}
+
+export async function getRun(id: number): Promise<RunDetail | null> {
+  const runRows = (await query(
+    `SELECT id, agent, ticket, state, dispatch_mode, started_at, ended_at,
+            initial_prompt, pid, log_path, branch_name, pr_url
+     FROM runs WHERE id = ${Number(id)} LIMIT 1`,
+  )) as Record<string, unknown>[];
+  const row = runRows[0];
+  if (!row) return null;
+  const run = rowToRunRecord(row);
+
+  const checkpointRows = (await query(
+    `SELECT id, run_id, kind, summary, created_at, decision, decision_note,
+            decided_at
+     FROM checkpoints WHERE run_id = ${Number(id)} ORDER BY id`,
+  )) as Record<string, unknown>[];
+  const checkpoints = checkpointRows.map(rowToCheckpoint);
+
+  const interjectionRows = (await query(
+    `SELECT id, run_id, kind, content, created_at, processed_at
+     FROM interjections WHERE run_id = ${Number(id)} ORDER BY id`,
+  )) as Record<string, unknown>[];
+  const interjections = interjectionRows.map(rowToInterjection);
+
+  // Read the initial_prompt fully (rather than the truncated `brief` on
+  // RunRecord) — detail view wants the whole thing.
+  const initialPromptFull = asString(row['initial_prompt']);
+
+  const detail: RunDetail = {
+    ...run,
+    checkpoints,
+    interjections,
+  };
+  if (initialPromptFull) detail.initialPrompt = initialPromptFull;
+  return detail;
+}

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -31,6 +31,8 @@ const IPC_CHANNELS = {
   worktreesProcessSnapshot: 'ranch:worktrees:processSnapshot',
   notesGetAll: 'ranch:notes:getAll',
   notesSet: 'ranch:notes:set',
+  runsList: 'ranch:runs:list',
+  runsGet: 'ranch:runs:get',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -77,6 +79,10 @@ const api: RanchApi = {
     getAll: () => ipcRenderer.invoke(IPC_CHANNELS.notesGetAll),
     set: (agent, label) =>
       ipcRenderer.invoke(IPC_CHANNELS.notesSet, agent, label),
+  },
+  runs: {
+    list: (limit) => ipcRenderer.invoke(IPC_CHANNELS.runsList, limit),
+    get: (id) => ipcRenderer.invoke(IPC_CHANNELS.runsGet, id),
   },
   terminal: {
     env: () => ipcRenderer.invoke(IPC_CHANNELS.terminalEnv),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -10,6 +10,9 @@ import type {
   AgentNote,
   CCProcessState,
   ProcessSnapshot,
+  RunDetail,
+  RunRecord,
+  RunStatus,
   SessionState,
   TerminalEnv,
   WorktreeBasics,
@@ -268,93 +271,190 @@ function ModeTabs({
   );
 }
 
-// ─── AutomatedView (stub) ─────────────────────────────────────
+// ─── AutomatedView (live data from ~/.ranch/ranch.db) ─────────
+
+const RUNS_POLL_MS = 5000;
+
+const STATUS_ORDER: Record<RunStatus, number> = {
+  awaiting_approval: 0,
+  blocked: 1,
+  working: 2,
+  planning: 3,
+  queued: 4,
+  done: 5,
+  stopped: 6,
+  unknown: 7,
+};
 
 function AutomatedView(): JSX.Element {
+  const [runs, setRuns] = useState<RunRecord[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      try {
+        const list = await window.ranch.runs.list(50);
+        if (!cancelled) {
+          setRuns(list);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    }
+    void refresh();
+    const handle = setInterval(refresh, RUNS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, []);
+
+  const sortedRuns = useMemo(() => {
+    if (!runs) return null;
+    return [...runs].sort((a, b) => {
+      const sa = STATUS_ORDER[a.status] ?? 99;
+      const sb = STATUS_ORDER[b.status] ?? 99;
+      if (sa !== sb) return sa - sb;
+      return b.id - a.id;
+    });
+  }, [runs]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = {};
+    if (runs) {
+      for (const r of runs) c[r.status] = (c[r.status] ?? 0) + 1;
+    }
+    return c;
+  }, [runs]);
+
   return (
     <div className="automated">
-      <div className="automated__intro">
+      <div className="automated__top">
         <h2>Automated runs</h2>
-        <p>
-          Fire-and-forget Claude SDK sessions running in the background. Each
-          run shows up as a card here with its current status —{' '}
-          <em>planning</em>, <em>working</em>, <em>awaiting approval</em>,{' '}
-          <em>done</em>, or <em>blocked</em>. The console bubbles up which ones
-          need your input or review so nothing falls through.
+        <p className="automated__sub">
+          Fire-and-forget Claude SDK sessions managed by the Python
+          orchestrator. Lifecycle controls (<code>approve</code>,{' '}
+          <code>reject</code>, <code>stop</code>) still happen via{' '}
+          <code>ranch &lt;cmd&gt; &lt;run_id&gt;</code> in your terminal — UI
+          buttons coming next.
         </p>
-        <p className="automated__hint">
-          The Python orchestrator already powers this — see{' '}
-          <code>ranch dispatch</code>, <code>ranch runs</code>,{' '}
-          <code>ranch approve</code>. Wiring that data into this view is the
-          next PR.
-        </p>
-      </div>
-
-      <div className="automated__demo">
-        <h3>What the run cards will look like</h3>
-        <div className="automated__cards">
-          <DemoRunCard
-            agent="max"
-            ticket="ECD-1234"
-            brief="Add /healthz endpoint with status checks"
-            status="awaiting_approval"
-            ageMin={2}
-          />
-          <DemoRunCard
-            agent="jeffy"
-            ticket="ECD-9988"
-            brief="Migrate legacy export job to celery beat"
-            status="working"
-            ageMin={14}
-          />
-          <DemoRunCard
-            agent="arnold"
-            ticket="ECD-1471"
-            brief="Fix flaky test_export_csv"
-            status="done"
-            ageMin={37}
-          />
-          <DemoRunCard
-            agent="kesha"
-            ticket="ECD-1502"
-            brief="Investigate slow AE-table query"
-            status="blocked"
-            ageMin={62}
-          />
+        <div className="automated__counts">
+          {Object.entries(counts).map(([status, n]) => (
+            <span
+              key={status}
+              className={`pill run-pill run-pill--${status}`}
+              title={`${n} ${status.replace('_', ' ')}`}
+            >
+              {statusLabel(status as RunStatus)} · {n}
+            </span>
+          ))}
         </div>
       </div>
+
+      {error && (
+        <p className="placeholder placeholder--error">
+          Couldn&apos;t read ~/.ranch/ranch.db: {error}
+        </p>
+      )}
+
+      {sortedRuns === null && !error && (
+        <p className="placeholder">Loading runs…</p>
+      )}
+
+      {sortedRuns && sortedRuns.length === 0 && (
+        <div className="placeholder">
+          No automated runs yet. Dispatch one from a terminal:
+          <pre className="automated__empty-hint">
+            ranch dispatch &lt;agent&gt; --ticket &lt;ID&gt; --brief
+            &quot;...&quot;
+          </pre>
+        </div>
+      )}
+
+      {sortedRuns && sortedRuns.length > 0 && (
+        <div className="automated__cards">
+          {sortedRuns.map((run) => (
+            <RunCard
+              key={run.id}
+              run={run}
+              selected={selectedId === run.id}
+              onSelect={() => setSelectedId(run.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {selectedId !== null && (
+        <RunDetailModal
+          runId={selectedId}
+          onClose={() => setSelectedId(null)}
+        />
+      )}
     </div>
   );
 }
 
-function DemoRunCard({
-  agent,
-  ticket,
-  brief,
-  status,
-  ageMin,
+function RunCard({
+  run,
+  selected,
+  onSelect,
 }: {
-  agent: string;
-  ticket: string;
-  brief: string;
-  status: 'planning' | 'working' | 'awaiting_approval' | 'done' | 'blocked';
-  ageMin: number;
+  run: RunRecord;
+  selected: boolean;
+  onSelect: () => void;
 }): JSX.Element {
+  const ageRef = run.endedAt ?? run.startedAt;
+  const ageStr = relativeAge(ageRef);
+  const actionHint =
+    run.status === 'awaiting_approval'
+      ? 'click to review →'
+      : run.status === 'blocked'
+        ? 'needs unblock →'
+        : null;
   return (
-    <article className={`run-card run-card--${status}`}>
+    <article
+      className={`run-card run-card--${run.status}${selected ? ' run-card--selected' : ''}`}
+      onClick={onSelect}
+    >
       <header className="run-card__head">
-        <span className="run-card__agent">{agent}</span>
-        <span className="run-card__ticket">{ticket}</span>
-        <RunStatusPill status={status} />
+        <span className="run-card__agent">{run.agent}</span>
+        {run.ticket && <span className="run-card__ticket">{run.ticket}</span>}
+        <RunStatusPill status={run.status} rawState={run.rawState} />
+        <span className="run-card__id" title={`Run ID ${run.id}`}>
+          #{run.id}
+        </span>
       </header>
-      <p className="run-card__brief">{brief}</p>
+      <p className="run-card__brief">
+        {run.brief || <em className="run-card__brief-empty">no brief</em>}
+      </p>
       <footer className="run-card__foot">
-        <span className="run-card__age">last update {ageMin}m ago</span>
-        {status === 'awaiting_approval' && (
-          <span className="run-card__action-hint">click to review →</span>
+        <span className="run-card__age">
+          {run.endedAt ? `ended ${ageStr} ago` : `started ${ageStr} ago`}
+        </span>
+        {run.dispatchMode === 'background' && (
+          <span className="run-card__mode">bg</span>
         )}
-        {status === 'blocked' && (
-          <span className="run-card__action-hint">needs unblock →</span>
+        {run.prUrl && (
+          <a
+            className="run-card__pr"
+            href={run.prUrl}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              void window.ranch.app.openExternal(run.prUrl!);
+            }}
+            title={run.prUrl}
+          >
+            PR ↗
+          </a>
+        )}
+        {actionHint && (
+          <span className="run-card__action-hint">{actionHint}</span>
         )}
       </footer>
     </article>
@@ -363,20 +463,203 @@ function DemoRunCard({
 
 function RunStatusPill({
   status,
+  rawState,
 }: {
-  status: 'planning' | 'working' | 'awaiting_approval' | 'done' | 'blocked';
+  status: RunStatus;
+  rawState?: string;
 }): JSX.Element {
-  const labels = {
-    planning: 'planning',
-    working: 'working',
-    awaiting_approval: 'needs approval',
-    done: 'done',
-    blocked: 'blocked',
-  };
   return (
-    <span className={`pill run-pill run-pill--${status}`}>
-      {labels[status]}
+    <span
+      className={`pill run-pill run-pill--${status}`}
+      title={rawState ? `orchestrator state: ${rawState}` : undefined}
+    >
+      {statusLabel(status)}
     </span>
+  );
+}
+
+function statusLabel(status: RunStatus): string {
+  switch (status) {
+    case 'awaiting_approval':
+      return 'needs approval';
+    case 'unknown':
+      return '?';
+    default:
+      return status;
+  }
+}
+
+// ─── Run detail modal ─────────────────────────────────────────
+
+function RunDetailModal({
+  runId,
+  onClose,
+}: {
+  runId: number;
+  onClose: () => void;
+}): JSX.Element {
+  const [detail, setDetail] = useState<RunDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      try {
+        const d = await window.ranch.runs.get(runId);
+        if (!cancelled) {
+          setDetail(d);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    }
+    void refresh();
+    const handle = setInterval(refresh, 4000);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [runId]);
+
+  return (
+    <div className="run-modal__backdrop" onClick={onClose}>
+      <div className="run-modal" onClick={(e) => e.stopPropagation()}>
+        <header className="run-modal__head">
+          <h3>Run #{runId}</h3>
+          <button type="button" className="run-modal__close" onClick={onClose}>
+            ✕
+          </button>
+        </header>
+        {error && (
+          <p className="placeholder placeholder--error">Error: {error}</p>
+        )}
+        {!error && !detail && (
+          <p className="placeholder">Loading run detail…</p>
+        )}
+        {detail && (
+          <div className="run-modal__body">
+            <DetailSection title="Run">
+              <DetailRow label="agent" value={detail.agent} mono />
+              {detail.ticket && (
+                <DetailRow label="ticket" value={detail.ticket} mono />
+              )}
+              <DetailRow
+                label="status"
+                value={`${statusLabel(detail.status)} (${detail.rawState})`}
+              />
+              <DetailRow label="dispatch" value={detail.dispatchMode} />
+              {detail.startedAt && (
+                <DetailRow
+                  label="started"
+                  value={`${relativeAge(detail.startedAt)} ago`}
+                />
+              )}
+              {detail.endedAt && (
+                <DetailRow
+                  label="ended"
+                  value={`${relativeAge(detail.endedAt)} ago`}
+                />
+              )}
+              {detail.branchName && (
+                <DetailRow label="branch" value={detail.branchName} mono />
+              )}
+              {detail.pid !== undefined && (
+                <DetailRow label="pid" value={String(detail.pid)} mono />
+              )}
+              {detail.prUrl && (
+                <div className="detail__row">
+                  <span className="detail__row-label">PR</span>
+                  <a
+                    className="detail__pr-link"
+                    href={detail.prUrl}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      void window.ranch.app.openExternal(detail.prUrl!);
+                    }}
+                  >
+                    {detail.prUrl} ↗
+                  </a>
+                </div>
+              )}
+            </DetailSection>
+
+            {detail.initialPrompt && (
+              <DetailSection title="Brief">
+                <p className="detail__text">{detail.initialPrompt}</p>
+              </DetailSection>
+            )}
+
+            <DetailSection
+              title="Checkpoints"
+              count={detail.checkpoints.length}
+            >
+              {detail.checkpoints.length === 0 ? (
+                <p className="detail__empty">no checkpoints recorded</p>
+              ) : (
+                <ul className="run-cps">
+                  {detail.checkpoints.map((cp) => (
+                    <li key={cp.id} className={`run-cp run-cp--${cp.decision}`}>
+                      <span className="run-cp__kind">{cp.kind}</span>
+                      <span
+                        className={`run-cp__decision run-cp__decision--${cp.decision}`}
+                      >
+                        {cp.decision}
+                      </span>
+                      {cp.summary && (
+                        <span className="run-cp__summary">{cp.summary}</span>
+                      )}
+                      {cp.decisionNote && (
+                        <span className="run-cp__note">
+                          — {cp.decisionNote}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </DetailSection>
+
+            {detail.interjections.length > 0 && (
+              <DetailSection
+                title="Interjections"
+                count={detail.interjections.length}
+              >
+                <ul className="run-cps">
+                  {detail.interjections.map((inj) => (
+                    <li key={inj.id} className="run-cp">
+                      <span className="run-cp__kind">{inj.kind}</span>
+                      {inj.processedAt && (
+                        <span className="run-cp__decision run-cp__decision--approved">
+                          processed
+                        </span>
+                      )}
+                      {inj.content && (
+                        <span className="run-cp__summary">{inj.content}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </DetailSection>
+            )}
+
+            <DetailSection title="Lifecycle (CLI)">
+              <p className="detail__empty">
+                Approve / reject / stop via terminal until UI buttons land:
+              </p>
+              <pre className="run-modal__cli">
+                ranch approve {runId}
+                {'\n'}ranch reject {runId} &quot;reason&quot;
+                {'\n'}ranch note {runId} &quot;note text&quot;
+                {'\n'}ranch stop {runId}
+              </pre>
+            </DetailSection>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -872,3 +872,271 @@ body,
   border-color: rgba(255, 106, 106, 0.3);
   font-weight: 700;
 }
+
+.run-pill--queued {
+  background: var(--bg);
+  color: var(--text-muted);
+  border-color: var(--border);
+}
+
+.run-pill--stopped {
+  background: var(--bg);
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+
+.run-pill--unknown {
+  background: var(--bg);
+  color: var(--text-dim);
+}
+
+/* Automated header counts row */
+
+.automated__top {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.automated__top h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--text);
+}
+
+.automated__sub {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  max-width: 80ch;
+}
+
+.automated__sub code {
+  background: var(--bg-elevated);
+  padding: 0 0.3rem;
+  border-radius: 2px;
+  color: var(--accent);
+  border: 1px solid var(--border);
+  font-size: 0.92em;
+}
+
+.automated__counts {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  margin-top: 0.2rem;
+}
+
+.automated__empty-hint {
+  background: var(--bg-elevated);
+  padding: 0.5rem 0.7rem;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  font-size: 0.78rem;
+  margin-top: 0.5rem;
+  color: var(--text);
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+}
+
+.run-card {
+  position: relative;
+}
+
+.run-card--selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(106, 162, 255, 0.3);
+}
+
+.run-card__id {
+  margin-left: auto;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.7rem;
+  color: var(--text-dim);
+}
+
+.run-card__brief-empty {
+  color: var(--text-dim);
+}
+
+.run-card__mode {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.65rem;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+  padding: 0 0.3rem;
+  border-radius: 2px;
+}
+
+.run-card__pr {
+  font-size: 0.7rem;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.run-card__pr:hover {
+  text-decoration: underline;
+}
+
+/* Run detail modal */
+
+.run-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 2rem;
+}
+
+.run-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  width: min(720px, 100%);
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+}
+
+.run-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.run-modal__head h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  color: var(--accent);
+}
+
+.run-modal__close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+}
+
+.run-modal__close:hover {
+  background: var(--bg);
+  color: var(--text);
+}
+
+.run-modal__body {
+  overflow-y: auto;
+  padding: 0.75rem 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.run-modal__cli {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.5rem 0.7rem;
+  margin: 0.2rem 0 0;
+  font-size: 0.75rem;
+  color: var(--text);
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  overflow-x: auto;
+}
+
+.detail__pr-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.detail__pr-link:hover {
+  text-decoration: underline;
+}
+
+/* Run checkpoints / interjections */
+
+.run-cps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.run-cp {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  padding: 0.35rem 0.55rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+.run-cp__kind {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-weight: 600;
+  color: var(--accent);
+  font-size: 0.75rem;
+}
+
+.run-cp__decision {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 700;
+  padding: 0 0.35rem;
+  border-radius: 2px;
+  border: 1px solid var(--border-strong);
+}
+
+.run-cp__decision--approved {
+  background: rgba(92, 212, 122, 0.15);
+  color: var(--green);
+  border-color: rgba(92, 212, 122, 0.4);
+}
+.run-cp__decision--rejected {
+  background: rgba(255, 106, 106, 0.15);
+  color: var(--red);
+  border-color: rgba(255, 106, 106, 0.4);
+}
+.run-cp__decision--pending {
+  background: rgba(246, 193, 119, 0.15);
+  color: var(--yellow);
+  border-color: rgba(246, 193, 119, 0.4);
+}
+
+.run-cp__summary {
+  flex: 1;
+  min-width: 0;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.run-cp__note {
+  color: var(--text-dim);
+  font-style: italic;
+  flex-basis: 100%;
+}

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -196,6 +196,69 @@ export interface AgentNote {
   updatedAt: string;
 }
 
+// ─── Automated runs (read from ~/.ranch/ranch.db) ────────────────────────
+
+/**
+ * Card-level status that the UI distinguishes between. Maps from the
+ * orchestrator's wider state vocabulary in src/main/runs.ts. The UI
+ * groups multiple raw states under one status when they look the same
+ * to the operator.
+ */
+export type RunStatus =
+  | 'planning'
+  | 'queued'
+  | 'working'
+  | 'awaiting_approval'
+  | 'done'
+  | 'stopped'
+  | 'blocked'
+  | 'unknown';
+
+export interface RunRecord {
+  id: number;
+  agent: string;
+  ticket?: string;
+  status: RunStatus;
+  /** The orchestrator's raw state string — useful for tooltips. */
+  rawState: string;
+  /** Truncated initial_prompt for the card. */
+  brief: string;
+  startedAt?: string;
+  endedAt?: string;
+  dispatchMode: 'foreground' | 'background';
+  prUrl?: string;
+  pid?: number;
+  logPath?: string;
+  branchName?: string;
+}
+
+export interface RunCheckpoint {
+  id: number;
+  runId: number;
+  kind: string;
+  summary?: string;
+  createdAt?: string;
+  decision: 'pending' | 'approved' | 'rejected' | string;
+  decisionNote?: string;
+  decidedAt?: string;
+}
+
+export interface RunInterjection {
+  id: number;
+  runId: number;
+  kind: string;
+  content?: string;
+  createdAt?: string;
+  processedAt?: string;
+}
+
+export interface RunDetail extends RunRecord {
+  /** The full, untruncated initial_prompt. */
+  initialPrompt?: string;
+  checkpoints: RunCheckpoint[];
+  interjections: RunInterjection[];
+}
+
 // ─── Terminal (MVP-6) ────────────────────────────────────────────────────
 
 export interface TerminalEnv {
@@ -255,6 +318,11 @@ export interface RanchApi {
     getAll: () => Promise<Record<string, AgentNote>>;
     /** Pass empty string to clear. */
     set: (agent: string, label: string) => Promise<AgentNote | null>;
+  };
+  runs: {
+    /** Read-only. Lifecycle controls go through the Python CLI for now. */
+    list: (limit?: number) => Promise<RunRecord[]>;
+    get: (id: number) => Promise<RunDetail | null>;
   };
   terminal: {
     env: () => Promise<TerminalEnv>;


### PR DESCRIPTION
## Summary

The Automated view is now backed by **real data** from the Python orchestrator's SQLite store at \`~/.ranch/ranch.db\`. The demo cards are gone. Click a run card to open a modal with full detail (checkpoints, interjections, brief, branch, PR link).

This is read-only — lifecycle controls (\`approve\`, \`reject\`, \`note\`, \`stop\`) still happen through the Python CLI for now, with a CLI snippet shown in each detail modal. UI buttons for those land in the next PR.

## Implementation

\`src/main/runs.ts\` shells out to \`/usr/bin/sqlite3 -json\` rather than pulling in a native sqlite library — no electron-rebuild dance, fast enough for ranch's volumes (dozens of runs per operator).

State mapping:
| orchestrator state | UI status |
|---|---|
| planning | planning |
| needs_approval | awaiting_approval (yellow) |
| in_development / tests_green | working (green) |
| queued | queued |
| completed | done (dim) |
| stopped | stopped (dim) |
| error | blocked (red) |

## What you'll see

When you switch to **Automated** in the header now:

- Top row: counts per status (badges)
- Cards sorted **active-first**: awaiting_approval → blocked → working → planning → queued → done/stopped
- Each card: agent + ticket pill + #id + status + brief + started/ended age + dispatch mode (foreground/bg) + PR link if any
- Cards with action hints: \"click to review →\" for awaiting_approval, \"needs unblock →\" for blocked
- Click a card → modal with: full brief, checkpoints (kind + decision + summary + note), interjections, CLI snippet for lifecycle
- Polling: list every 5s, detail every 4s while modal is open

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Switch to Automated tab → see counts and live runs from ~/.ranch/ranch.db
- [ ] Click a run card → modal opens with full detail (brief, checkpoints, interjections)
- [ ] If you have a run with a PR, click \"PR ↗\" → opens in browser
- [ ] Run \`ranch dispatch jeffy --ticket TEST-1 --brief \"hi\"\` in a terminal → within ~5s the new run appears in the grid
- [ ] Run \`ranch approve <id>\` → checkpoint decision in the detail modal updates within ~4s

## What's next (suggested PRs)

1. **Lifecycle UI buttons** — Approve / Reject / Note / Stop directly on each card. Calls into Python CLI subprocess (\`ranch approve <id>\`) since that machinery already exists and is the source of truth.
2. **Dispatch from UI** — \"+ New automated run\" form
3. **Docker management** in the interactive sidebar (the piece I paused earlier)
4. **Fleet config UI** — edit \`~/.ranch/config.toml\` from the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)