### PR TITLE
feat(console): zombie detection + Active filter for automated runs

### DIFF
--- a/console/src/main/runs.ts
+++ b/console/src/main/runs.ts
@@ -86,6 +86,37 @@ function mapState(raw: unknown): RunStatus {
   }
 }
 
+/**
+ * State values where we'd expect the orchestrator process to still be
+ * alive. If the recorded PID is dead in any of these, we override the
+ * status to 'abandoned' so the operator can tell what's actually live.
+ */
+const ACTIVE_STATES = new Set([
+  'planning',
+  'in_development',
+  'tests_green',
+  'needs_approval',
+  'queued',
+]);
+
+/** kill(pid, 0) returns without throwing iff the process exists. */
+function isPidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH = no such process; EPERM = exists but we can't signal it.
+    // EPERM still means alive.
+    return (
+      typeof err === 'object' &&
+      err !== null &&
+      'code' in err &&
+      (err as { code: unknown }).code === 'EPERM'
+    );
+  }
+}
+
 /** Trim a long brief down for display. */
 function summarizeBrief(text: string | undefined, max = 200): string {
   if (!text) return '';
@@ -95,14 +126,30 @@ function summarizeBrief(text: string | undefined, max = 200): string {
 
 function rowToRunRecord(row: Record<string, unknown>): RunRecord {
   const id = asNumber(row['id'])!;
-  const status = mapState(row['state']);
+  const rawState = asString(row['state']) ?? 'unknown';
+  let status = mapState(rawState);
   const brief = summarizeBrief(asString(row['initial_prompt']));
+  const pid = asNumber(row['pid']);
+
+  // Zombie detection: if the orchestrator says the run is in an active
+  // state but the recorded PID is dead (or there's no PID at all for an
+  // active state), treat it as abandoned. Without this, runs from
+  // crashed/killed orchestrator processes look like they're still going.
+  let pidAlive: boolean | undefined;
+  if (pid !== undefined) pidAlive = isPidAlive(pid);
+
+  if (ACTIVE_STATES.has(rawState)) {
+    if (pid === undefined || pidAlive === false) {
+      status = 'abandoned';
+    }
+  }
+
   const rec: RunRecord = {
     id,
     agent: asString(row['agent']) ?? 'unknown',
     status,
     brief,
-    rawState: asString(row['state']) ?? 'unknown',
+    rawState,
     dispatchMode:
       asString(row['dispatch_mode']) === 'background'
         ? 'background'
@@ -116,8 +163,8 @@ function rowToRunRecord(row: Record<string, unknown>): RunRecord {
   if (endedAt) rec.endedAt = endedAt;
   const prUrl = asString(row['pr_url']);
   if (prUrl) rec.prUrl = prUrl;
-  const pid = asNumber(row['pid']);
   if (pid !== undefined) rec.pid = pid;
+  if (pidAlive !== undefined) rec.pidAlive = pidAlive;
   const logPath = asString(row['log_path']);
   if (logPath) rec.logPath = logPath;
   const branchName = asString(row['branch_name']);

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -283,19 +283,35 @@ const STATUS_ORDER: Record<RunStatus, number> = {
   queued: 4,
   done: 5,
   stopped: 6,
-  unknown: 7,
+  abandoned: 7,
+  unknown: 8,
 };
+
+/**
+ * "Active" = still demanding operator attention or actually doing work.
+ * Everything else (done / stopped / abandoned) is history.
+ */
+const ACTIVE_STATUSES: RunStatus[] = [
+  'awaiting_approval',
+  'blocked',
+  'working',
+  'planning',
+  'queued',
+];
+
+type RunFilter = 'active' | 'all';
 
 function AutomatedView(): JSX.Element {
   const [runs, setRuns] = useState<RunRecord[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [filter, setFilter] = useState<RunFilter>('active');
 
   useEffect(() => {
     let cancelled = false;
     async function refresh(): Promise<void> {
       try {
-        const list = await window.ranch.runs.list(50);
+        const list = await window.ranch.runs.list(100);
         if (!cancelled) {
           setRuns(list);
           setError(null);
@@ -316,13 +332,17 @@ function AutomatedView(): JSX.Element {
 
   const sortedRuns = useMemo(() => {
     if (!runs) return null;
-    return [...runs].sort((a, b) => {
+    const filtered =
+      filter === 'active'
+        ? runs.filter((r) => ACTIVE_STATUSES.includes(r.status))
+        : runs;
+    return [...filtered].sort((a, b) => {
       const sa = STATUS_ORDER[a.status] ?? 99;
       const sb = STATUS_ORDER[b.status] ?? 99;
       if (sa !== sb) return sa - sb;
       return b.id - a.id;
     });
-  }, [runs]);
+  }, [runs, filter]);
 
   const counts = useMemo(() => {
     const c: Record<string, number> = {};
@@ -332,27 +352,67 @@ function AutomatedView(): JSX.Element {
     return c;
   }, [runs]);
 
+  const activeCount = useMemo(() => {
+    if (!runs) return 0;
+    return runs.filter((r) => ACTIVE_STATUSES.includes(r.status)).length;
+  }, [runs]);
+
+  const totalCount = runs?.length ?? 0;
+
   return (
     <div className="automated">
       <div className="automated__top">
-        <h2>Automated runs</h2>
+        <div className="automated__top-row">
+          <h2>Automated runs</h2>
+          <div className="automated__filter">
+            <button
+              type="button"
+              className={`automated__filter-btn${filter === 'active' ? ' automated__filter-btn--active' : ''}`}
+              onClick={() => setFilter('active')}
+            >
+              Active · {activeCount}
+            </button>
+            <button
+              type="button"
+              className={`automated__filter-btn${filter === 'all' ? ' automated__filter-btn--active' : ''}`}
+              onClick={() => setFilter('all')}
+            >
+              All · {totalCount}
+            </button>
+          </div>
+        </div>
         <p className="automated__sub">
           Fire-and-forget Claude SDK sessions managed by the Python
-          orchestrator. Lifecycle controls (<code>approve</code>,{' '}
-          <code>reject</code>, <code>stop</code>) still happen via{' '}
-          <code>ranch &lt;cmd&gt; &lt;run_id&gt;</code> in your terminal — UI
-          buttons coming next.
+          orchestrator. Each row in this list is one historical{' '}
+          <code>ranch dispatch</code> invocation. Lifecycle controls (
+          <code>approve</code>, <code>reject</code>, <code>stop</code>) still
+          happen via <code>ranch &lt;cmd&gt; &lt;run_id&gt;</code> in your
+          terminal — UI buttons coming next.
         </p>
+        {filter === 'active' && (
+          <p className="automated__hint">
+            Showing only <em>active</em> runs (waiting on you, working,
+            planning, queued). Toggle <strong>All</strong> to see history,
+            including <em>abandoned</em> runs whose orchestrator process is no
+            longer alive.
+          </p>
+        )}
         <div className="automated__counts">
-          {Object.entries(counts).map(([status, n]) => (
-            <span
-              key={status}
-              className={`pill run-pill run-pill--${status}`}
-              title={`${n} ${status.replace('_', ' ')}`}
-            >
-              {statusLabel(status as RunStatus)} · {n}
-            </span>
-          ))}
+          {Object.entries(counts)
+            .sort(
+              ([a], [b]) =>
+                (STATUS_ORDER[a as RunStatus] ?? 99) -
+                (STATUS_ORDER[b as RunStatus] ?? 99),
+            )
+            .map(([status, n]) => (
+              <span
+                key={status}
+                className={`pill run-pill run-pill--${status}`}
+                title={`${n} ${status.replace('_', ' ')}`}
+              >
+                {statusLabel(status as RunStatus)} · {n}
+              </span>
+            ))}
         </div>
       </div>
 
@@ -368,11 +428,21 @@ function AutomatedView(): JSX.Element {
 
       {sortedRuns && sortedRuns.length === 0 && (
         <div className="placeholder">
-          No automated runs yet. Dispatch one from a terminal:
-          <pre className="automated__empty-hint">
-            ranch dispatch &lt;agent&gt; --ticket &lt;ID&gt; --brief
-            &quot;...&quot;
-          </pre>
+          {filter === 'active' && totalCount > 0 ? (
+            <>
+              No active runs right now. {totalCount} historical{' '}
+              {totalCount === 1 ? 'run' : 'runs'} in the DB — toggle{' '}
+              <strong>All</strong> above to see them.
+            </>
+          ) : (
+            <>
+              No automated runs yet. Dispatch one from a terminal:
+              <pre className="automated__empty-hint">
+                ranch dispatch &lt;agent&gt; --ticket &lt;ID&gt; --brief
+                &quot;...&quot;
+              </pre>
+            </>
+          )}
         </div>
       )}
 
@@ -432,6 +502,17 @@ function RunCard({
       <p className="run-card__brief">
         {run.brief || <em className="run-card__brief-empty">no brief</em>}
       </p>
+      {run.status === 'abandoned' && (
+        <p className="run-card__zombie">
+          orchestrator state is <code>{run.rawState}</code> but the process{' '}
+          {run.pid !== undefined ? (
+            <>(PID {run.pid}) is no longer alive</>
+          ) : (
+            'has no recorded PID'
+          )}
+          .
+        </p>
+      )}
       <footer className="run-card__foot">
         <span className="run-card__age">
           {run.endedAt ? `ended ${ageStr} ago` : `started ${ageStr} ago`}
@@ -482,6 +563,8 @@ function statusLabel(status: RunStatus): string {
   switch (status) {
     case 'awaiting_approval':
       return 'needs approval';
+    case 'abandoned':
+      return 'abandoned';
     case 'unknown':
       return '?';
     default:

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -800,6 +800,32 @@ body,
   opacity: 0.75;
 }
 
+.run-card--abandoned {
+  opacity: 0.65;
+  border-color: var(--border);
+  background: var(--bg);
+}
+
+.run-card--stopped {
+  opacity: 0.75;
+}
+
+.run-card__zombie {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
+.run-card__zombie code {
+  background: var(--bg-elevated);
+  color: var(--text-muted);
+  padding: 0 0.25rem;
+  border-radius: 2px;
+  font-size: 0.95em;
+  font-style: normal;
+}
+
 .run-card__head {
   display: flex;
   align-items: center;
@@ -890,6 +916,14 @@ body,
   color: var(--text-dim);
 }
 
+.run-pill--abandoned {
+  background: var(--bg);
+  color: var(--text-dim);
+  border-color: var(--border);
+  text-decoration: line-through;
+  text-decoration-color: var(--text-dim);
+}
+
 /* Automated header counts row */
 
 .automated__top {
@@ -900,10 +934,62 @@ body,
   border-bottom: 1px solid var(--border);
 }
 
+.automated__top-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .automated__top h2 {
   margin: 0;
   font-size: 1.05rem;
   color: var(--text);
+}
+
+.automated__filter {
+  display: inline-flex;
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 2px;
+  gap: 2px;
+}
+
+.automated__filter-btn {
+  background: none;
+  color: var(--text-muted);
+  border: none;
+  padding: 0.25rem 0.7rem;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 600;
+  border-radius: 4px;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.automated__filter-btn:hover {
+  color: var(--text);
+}
+
+.automated__filter-btn--active {
+  background: var(--accent);
+  color: var(--bg);
+}
+
+.automated__filter-btn--active:hover {
+  color: var(--bg);
+}
+
+.automated__hint {
+  margin: 0.1rem 0 0;
+  font-size: 0.72rem;
+  color: var(--text-dim);
+  line-height: 1.45;
 }
 
 .automated__sub {

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -212,6 +212,7 @@ export type RunStatus =
   | 'done'
   | 'stopped'
   | 'blocked'
+  | 'abandoned'
   | 'unknown';
 
 export interface RunRecord {
@@ -228,6 +229,13 @@ export interface RunRecord {
   dispatchMode: 'foreground' | 'background';
   prUrl?: string;
   pid?: number;
+  /**
+   * Was the recorded PID still a live process at snapshot time?
+   *   true  — process exists and answers signal 0
+   *   false — pid was set but the process is gone (zombie)
+   *   undefined — no pid recorded for this run
+   */
+  pidAlive?: boolean;
   logPath?: string;
   branchName?: string;
 }


### PR DESCRIPTION
## Summary

Fixes the \"16 sessions can't all be valid\" problem.

The Automated tab was showing every \`ranch dispatch\` row from \`~/.ranch/ranch.db\` ever, most of which were stale. Two changes:

### 1. Zombie detection

For each run in an \"active\" state (planning / in_development / tests_green / needs_approval / queued), check if the recorded PID is still alive via \`process.kill(pid, 0)\`. If the process is gone (or no PID was ever recorded for an active state), override the status to **abandoned**.

This catches the very common case where the orchestrator process dies (terminal closed, machine restart, orchestrator crash) without updating the DB to \`stopped\`. Without this fix, those runs masquerade as \"in development\" indefinitely.

### 2. Default filter: Active

New filter buttons at the top right: **Active** | **All**.

- **Active** (default): only runs in active states (awaiting_approval, blocked, working, planning, queued). Hides done/stopped/abandoned.
- **All**: full history.

Counts shown next to each filter button so you know how many you're hiding.

## Why it matters

You said it: \"there are like 16 sessions in here they can't all be valid and most seem like repeats.\" Right. By default Active will probably show 0–2. Toggling to All reveals the full picture for review.

The abandoned state is loudly visible too — strike-through pill, dimmed card, and a one-line note explaining the orchestrator says active but the process is gone.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Switch to Automated → defaults to Active filter; should be near-empty if you have no live runs
- [ ] Click \"All · N\" → see the full set including done/stopped/abandoned
- [ ] Abandoned cards (formerly the \"in_development\" ones whose PID is dead) are dim, strike-through pill, with a zombie note
- [ ] Dispatch a fresh run from a terminal → appears in Active within 5s
- [ ] Kill that orchestrator process (e.g. close the dispatching terminal) → run flips to Abandoned in the All view within 5s

## What's next

Lifecycle UI buttons next — approve / reject / stop on each card calling into the Python CLI. That makes Automated mode self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)