### PR TITLE
feat(console): one-click cleanup of abandoned runs

### DIFF
--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -20,7 +20,7 @@ import { getActiveSession } from './transcript.js';
 import { getWorktreeGitState } from './git.js';
 import { snapshotProcessState } from './process.js';
 import { getAllNotes, setNote } from './notes.js';
-import { listRuns, getRun } from './runs.js';
+import { listRuns, getRun, cleanupAbandonedRuns } from './runs.js';
 import {
   attachTerminal,
   detachTerminal,
@@ -39,6 +39,7 @@ export const IPC_CHANNELS = {
   notesSet: 'ranch:notes:set',
   runsList: 'ranch:runs:list',
   runsGet: 'ranch:runs:get',
+  runsCleanupAbandoned: 'ranch:runs:cleanupAbandoned',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -114,6 +115,10 @@ export function registerIpcHandlers(): void {
       throw new Error('runs.get requires a numeric id');
     }
     return getRun(id);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.runsCleanupAbandoned, async () => {
+    return cleanupAbandonedRuns();
   });
 
   ipcMain.handle(IPC_CHANNELS.terminalEnv, async () => getTerminalEnv());

--- a/console/src/main/runs.ts
+++ b/console/src/main/runs.ts
@@ -218,6 +218,50 @@ export async function listRuns(limit = 50): Promise<RunRecord[]> {
   return rows.map(rowToRunRecord);
 }
 
+/**
+ * Mark stale/abandoned runs as stopped. Soft delete: sets state =
+ * 'stopped', records exit_reason and ended_at. Operates on:
+ *
+ *   - any run in an ACTIVE_STATES whose pid is null
+ *   - any run in an ACTIVE_STATES whose pid is no longer a live process
+ *
+ * Returns the number of rows affected.
+ */
+export async function cleanupAbandonedRuns(): Promise<number> {
+  if (!existsSync(DB_PATH)) return 0;
+
+  // Pull candidate rows (active state) and decide which are dead in JS,
+  // since the SQLite shell can't probe process liveness directly.
+  const rows = (await query(
+    `SELECT id, pid FROM runs
+     WHERE state IN (${[...ACTIVE_STATES].map((s) => `'${s}'`).join(',')})`,
+  )) as Record<string, unknown>[];
+
+  const deadIds: number[] = [];
+  for (const row of rows) {
+    const id = asNumber(row['id']);
+    if (id === undefined) continue;
+    const pid = asNumber(row['pid']);
+    if (pid === undefined || !isPidAlive(pid)) deadIds.push(id);
+  }
+
+  if (deadIds.length === 0) return 0;
+
+  // SQL injection isn't a concern here — these are rowids from our own
+  // query above, all integers. But sanitize anyway for paranoia.
+  const idList = deadIds.filter((n) => Number.isInteger(n)).join(',');
+  const reason = 'cleanup: orchestrator process no longer alive';
+  await execFile('/usr/bin/sqlite3', [
+    DB_PATH,
+    `UPDATE runs
+       SET state = 'stopped',
+           ended_at = COALESCE(ended_at, datetime('now')),
+           exit_reason = COALESCE(exit_reason, '${reason}')
+     WHERE id IN (${idList})`,
+  ]);
+  return deadIds.length;
+}
+
 export async function getRun(id: number): Promise<RunDetail | null> {
   const runRows = (await query(
     `SELECT id, agent, ticket, state, dispatch_mode, started_at, ended_at,

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -33,6 +33,7 @@ const IPC_CHANNELS = {
   notesSet: 'ranch:notes:set',
   runsList: 'ranch:runs:list',
   runsGet: 'ranch:runs:get',
+  runsCleanupAbandoned: 'ranch:runs:cleanupAbandoned',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -83,6 +84,8 @@ const api: RanchApi = {
   runs: {
     list: (limit) => ipcRenderer.invoke(IPC_CHANNELS.runsList, limit),
     get: (id) => ipcRenderer.invoke(IPC_CHANNELS.runsGet, id),
+    cleanupAbandoned: () =>
+      ipcRenderer.invoke(IPC_CHANNELS.runsCleanupAbandoned),
   },
   terminal: {
     env: () => ipcRenderer.invoke(IPC_CHANNELS.terminalEnv),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -306,6 +306,8 @@ function AutomatedView(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [filter, setFilter] = useState<RunFilter>('active');
+  const [cleaningUp, setCleaningUp] = useState(false);
+  const [cleanupResult, setCleanupResult] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -357,30 +359,78 @@ function AutomatedView(): JSX.Element {
     return runs.filter((r) => ACTIVE_STATUSES.includes(r.status)).length;
   }, [runs]);
 
+  const abandonedCount = useMemo(() => {
+    if (!runs) return 0;
+    return runs.filter((r) => r.status === 'abandoned').length;
+  }, [runs]);
+
   const totalCount = runs?.length ?? 0;
+
+  async function handleCleanup(): Promise<void> {
+    if (cleaningUp) return;
+    const ok = window.confirm(
+      `Mark ${abandonedCount} abandoned run${abandonedCount === 1 ? '' : 's'} as stopped?\n\n` +
+        'This sets state=stopped and exit_reason="cleanup: orchestrator process no longer alive" — ' +
+        'rows stay in the DB but are properly classified as historical.',
+    );
+    if (!ok) return;
+    setCleaningUp(true);
+    try {
+      const n = await window.ranch.runs.cleanupAbandoned();
+      setCleanupResult(`Cleaned up ${n} abandoned run${n === 1 ? '' : 's'}.`);
+      // Force-refresh the list so the operator sees the change instantly
+      const list = await window.ranch.runs.list(100);
+      setRuns(list);
+      setTimeout(() => setCleanupResult(null), 4000);
+    } catch (err) {
+      setCleanupResult(
+        `Cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setCleaningUp(false);
+    }
+  }
 
   return (
     <div className="automated">
       <div className="automated__top">
         <div className="automated__top-row">
           <h2>Automated runs</h2>
-          <div className="automated__filter">
-            <button
-              type="button"
-              className={`automated__filter-btn${filter === 'active' ? ' automated__filter-btn--active' : ''}`}
-              onClick={() => setFilter('active')}
-            >
-              Active · {activeCount}
-            </button>
-            <button
-              type="button"
-              className={`automated__filter-btn${filter === 'all' ? ' automated__filter-btn--active' : ''}`}
-              onClick={() => setFilter('all')}
-            >
-              All · {totalCount}
-            </button>
+          <div className="automated__top-actions">
+            {abandonedCount > 0 && (
+              <button
+                type="button"
+                className="automated__cleanup-btn"
+                onClick={handleCleanup}
+                disabled={cleaningUp}
+                title={`Mark ${abandonedCount} abandoned runs as stopped — they're orchestrator processes that died without cleanup.`}
+              >
+                {cleaningUp
+                  ? 'Cleaning up…'
+                  : `Clean up ${abandonedCount} abandoned`}
+              </button>
+            )}
+            <div className="automated__filter">
+              <button
+                type="button"
+                className={`automated__filter-btn${filter === 'active' ? ' automated__filter-btn--active' : ''}`}
+                onClick={() => setFilter('active')}
+              >
+                Active · {activeCount}
+              </button>
+              <button
+                type="button"
+                className={`automated__filter-btn${filter === 'all' ? ' automated__filter-btn--active' : ''}`}
+                onClick={() => setFilter('all')}
+              >
+                All · {totalCount}
+              </button>
+            </div>
           </div>
         </div>
+        {cleanupResult && (
+          <p className="automated__cleanup-result">{cleanupResult}</p>
+        )}
         <p className="automated__sub">
           Fire-and-forget Claude SDK sessions managed by the Python
           orchestrator. Each row in this list is one historical{' '}

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -985,6 +985,47 @@ body,
   color: var(--bg);
 }
 
+.automated__top-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.automated__cleanup-btn {
+  background: var(--bg);
+  color: var(--text-muted);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 0.25rem 0.7rem;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.automated__cleanup-btn:hover:not(:disabled) {
+  border-color: var(--yellow);
+  color: var(--yellow);
+}
+
+.automated__cleanup-btn:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.automated__cleanup-result {
+  margin: 0.2rem 0 0;
+  padding: 0.3rem 0.6rem;
+  font-size: 0.74rem;
+  color: var(--green);
+  background: rgba(92, 212, 122, 0.08);
+  border: 1px solid rgba(92, 212, 122, 0.3);
+  border-radius: 4px;
+}
+
 .automated__hint {
   margin: 0.1rem 0 0;
   font-size: 0.72rem;

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -328,9 +328,14 @@ export interface RanchApi {
     set: (agent: string, label: string) => Promise<AgentNote | null>;
   };
   runs: {
-    /** Read-only. Lifecycle controls go through the Python CLI for now. */
+    /** Read-only listing — lifecycle controls go through Python CLI for now. */
     list: (limit?: number) => Promise<RunRecord[]>;
     get: (id: number) => Promise<RunDetail | null>;
+    /**
+     * Mark stale/abandoned runs (active state, dead PID) as stopped.
+     * Returns the number of rows updated.
+     */
+    cleanupAbandoned: () => Promise<number>;
   };
   terminal: {
     env: () => Promise<TerminalEnv>;


### PR DESCRIPTION
## Summary

Adds a **\"Clean up N abandoned\"** button to the Automated view that retires zombie runs in one click. Soft delete: marks them \`stopped\` with \`exit_reason = \"cleanup: orchestrator process no longer alive\"\`. Rows stay in the DB but are properly classified.

## Why

You've been seeing a pile of historical runs in the DB that aren't actually doing anything. They came from past \`ranch dispatch\` invocations whose orchestrator process died (terminal closed, machine restarted, crash) without updating the DB to \`state=stopped\`. The PIDs you see are real numbers from those dead processes — long since recycled.

PR #53 surfaced these as \`abandoned\` and hid them by default behind the Active filter. This PR lets you clear them out for good with one click.

## Behavior

- Button only appears when there's at least 1 abandoned run
- Click → native \`confirm()\` dialog with explanation
- After approval → IPC into \`runs.cleanupAbandoned()\` which:
  1. Queries all runs in active states
  2. Probes each PID with \`process.kill(pid, 0)\`
  3. \`UPDATE\`s dead ones to \`state='stopped'\`, \`exit_reason='cleanup: ...'\`, \`ended_at=now\` (if null)
- Returns count, list refreshes immediately, toast message confirms

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Switch to Automated → toggle to All → see N abandoned cards
- [ ] Click \"Clean up N abandoned\" → confirm → list refreshes, abandoned cards now show as \`stopped\` (dimmed)
- [ ] Open one of them in the modal → \`exit_reason\` shows the cleanup string
- [ ] Click button again — should be gone (no abandoned runs left)
- [ ] sqlite3 ~/.ranch/ranch.db \"SELECT id, state, exit_reason FROM runs WHERE id IN (...)\" confirms the soft delete

## What's next

With the noise cleared, the Automated tab is finally usable. Suggested next: lifecycle UI buttons (Approve / Reject / Stop) on each card, calling into the existing Python CLI (\`ranch approve <id>\` etc.) — makes Automated mode self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)