### PR TITLE
feat(console): per-cell session controls (Send Ctrl-C / Restart / Kill)

### DIFF
--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -25,7 +25,9 @@ import {
   attachTerminal,
   detachTerminal,
   getTerminalEnv,
+  killTmuxSession,
   resizeTerminal,
+  sendKeysToSession,
   writeTerminal,
 } from './pty.js';
 
@@ -45,6 +47,8 @@ export const IPC_CHANNELS = {
   terminalWrite: 'ranch:terminal:write',
   terminalResize: 'ranch:terminal:resize',
   terminalDetach: 'ranch:terminal:detach',
+  terminalKillSession: 'ranch:terminal:killSession',
+  terminalSendKeys: 'ranch:terminal:sendKeys',
   // Push channels (main → renderer). No registration needed in main —
   // we just call webContents.send(...). Listed here for grep-ability.
   terminalData: 'terminal:data',
@@ -173,6 +177,29 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.terminalDetach, (_event, terminalId: unknown) => {
     if (typeof terminalId === 'string') detachTerminal(terminalId);
   });
+
+  ipcMain.handle(
+    IPC_CHANNELS.terminalKillSession,
+    async (_event, agent: unknown) => {
+      if (typeof agent !== 'string' || !agent) {
+        throw new Error('terminal.killSession requires an agent name');
+      }
+      await killTmuxSession(agent);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.terminalSendKeys,
+    async (_event, agent: unknown, keys: unknown) => {
+      if (typeof agent !== 'string' || !agent) {
+        throw new Error('terminal.sendKeys requires an agent name');
+      }
+      if (!Array.isArray(keys) || !keys.every((k) => typeof k === 'string')) {
+        throw new Error('terminal.sendKeys requires a string array');
+      }
+      await sendKeysToSession(agent, keys as string[]);
+    },
+  );
 
   ipcMain.handle(IPC_CHANNELS.appVersion, () => app.getVersion());
 

--- a/console/src/main/pty.ts
+++ b/console/src/main/pty.ts
@@ -245,3 +245,45 @@ export function detachAllForWebContents(wc: WebContents): void {
     }
   }
 }
+
+/**
+ * Kill the underlying tmux session for an agent. Used as the "nuclear"
+ * recovery option when claude is hung — wipes the session so the next
+ * attach creates fresh.
+ *
+ * Force-detaches our pty handle first so we don't keep a dangling client
+ * pointed at a soon-to-be-dead session.
+ */
+export async function killTmuxSession(agent: string): Promise<void> {
+  const tmuxPath = await findTmux();
+  if (!tmuxPath) {
+    throw new Error('tmux is not installed');
+  }
+  const sessionName = `ranch-${agent}`;
+  detachInternal(sessionName, true);
+  try {
+    await execFile(tmuxPath, ['kill-session', '-t', sessionName]);
+  } catch (err) {
+    // Session not found is fine — already gone is the goal.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!/can't find session|no server running/i.test(msg)) throw err;
+  }
+}
+
+/**
+ * Send keystrokes (or named tmux keys like `C-c`) to an agent's session.
+ * Lets the operator interrupt or signal claude without killing the
+ * whole session.
+ */
+export async function sendKeysToSession(
+  agent: string,
+  keys: string[],
+): Promise<void> {
+  const tmuxPath = await findTmux();
+  if (!tmuxPath) {
+    throw new Error('tmux is not installed');
+  }
+  const sessionName = `ranch-${agent}`;
+  // -t <session> targets the active window/pane
+  await execFile(tmuxPath, ['send-keys', '-t', sessionName, ...keys]);
+}

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -39,6 +39,8 @@ const IPC_CHANNELS = {
   terminalWrite: 'ranch:terminal:write',
   terminalResize: 'ranch:terminal:resize',
   terminalDetach: 'ranch:terminal:detach',
+  terminalKillSession: 'ranch:terminal:killSession',
+  terminalSendKeys: 'ranch:terminal:sendKeys',
   terminalData: 'terminal:data',
   terminalExit: 'terminal:exit',
   appVersion: 'ranch:app:version',
@@ -97,6 +99,10 @@ const api: RanchApi = {
       ipcRenderer.invoke(IPC_CHANNELS.terminalResize, terminalId, cols, rows),
     detach: (terminalId) =>
       ipcRenderer.invoke(IPC_CHANNELS.terminalDetach, terminalId),
+    killSession: (agent) =>
+      ipcRenderer.invoke(IPC_CHANNELS.terminalKillSession, agent),
+    sendKeys: (agent, keys) =>
+      ipcRenderer.invoke(IPC_CHANNELS.terminalSendKeys, agent, keys),
     onData: (handler) =>
       subscribe<TerminalDataEvent>(IPC_CHANNELS.terminalData, handler),
     onExit: (handler) =>

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -51,6 +51,19 @@ export function App(): JSX.Element {
   const [focusedAgent, setFocusedAgent] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
   const [mode, setMode] = useState<'interactive' | 'automated'>('interactive');
+  // Per-agent generation counter — bumping it forces the Terminal
+  // component to remount, which triggers a fresh tmux attach. Used by
+  // the "Restart Claude" action.
+  const [terminalGenerations, setTerminalGenerations] = useState<
+    Record<string, number>
+  >({});
+
+  const bumpTerminalGeneration = useCallback((agent: string) => {
+    setTerminalGenerations((prev) => ({
+      ...prev,
+      [agent]: (prev[agent] ?? 0) + 1,
+    }));
+  }, []);
 
   // ─── one-shot loads ────────────────────────────────────────
   useEffect(() => {
@@ -208,8 +221,10 @@ export function App(): JSX.Element {
                   note={notes[wt.agent] ?? null}
                   terminalEnv={terminalEnv}
                   focused={focusedAgent === wt.agent}
+                  generation={terminalGenerations[wt.agent] ?? 1}
                   onFocus={() => setFocusedAgent(wt.agent)}
                   onSaveNote={(label) => saveNote(wt.agent, label)}
+                  onBumpGeneration={() => bumpTerminalGeneration(wt.agent)}
                 />
               ))}
           </main>
@@ -826,8 +841,10 @@ interface AgentCellProps {
   note: AgentNote | null;
   terminalEnv: TerminalEnv | null;
   focused: boolean;
+  generation: number;
   onFocus: () => void;
   onSaveNote: (label: string) => void;
+  onBumpGeneration: () => void;
 }
 
 function AgentCell({
@@ -836,11 +853,65 @@ function AgentCell({
   note,
   terminalEnv,
   focused,
+  generation,
   onFocus,
   onSaveNote,
+  onBumpGeneration,
 }: AgentCellProps): JSX.Element {
   const [session, setSession] = useState<SessionState | null>(null);
   const [git, setGit] = useState<WorktreeGitState | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  async function sendCtrlC(): Promise<void> {
+    try {
+      await window.ranch.terminal.sendKeys(worktree.agent, ['C-c']);
+      flashMessage('Ctrl-C sent');
+    } catch (err) {
+      flashMessage(
+        `Failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  async function restartClaude(): Promise<void> {
+    const ok = window.confirm(
+      `Restart Claude in ranch-${worktree.agent}?\n\n` +
+        'This kills the tmux session and creates a fresh one running ' +
+        '`claude`. Any unsaved scrollback will be lost.',
+    );
+    if (!ok) return;
+    try {
+      await window.ranch.terminal.killSession(worktree.agent);
+      onBumpGeneration();
+      flashMessage('Restarting…');
+    } catch (err) {
+      flashMessage(
+        `Failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  async function killSession(): Promise<void> {
+    const ok = window.confirm(
+      `Kill the ranch-${worktree.agent} tmux session?\n\n` +
+        'The terminal will be empty until you click "Open Claude" again. ' +
+        'Useful when claude AND its host shell are both hung.',
+    );
+    if (!ok) return;
+    try {
+      await window.ranch.terminal.killSession(worktree.agent);
+      flashMessage('Session killed');
+    } catch (err) {
+      flashMessage(
+        `Failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  function flashMessage(msg: string): void {
+    setActionMessage(msg);
+    setTimeout(() => setActionMessage(null), 2500);
+  }
 
   // Per-cell transcript polling.
   useEffect(() => {
@@ -904,14 +975,20 @@ function AgentCell({
         git={git}
         note={note}
         onSaveNote={onSaveNote}
+        onSendCtrlC={sendCtrlC}
+        onRestartClaude={restartClaude}
+        onKillSession={killSession}
       />
       <div className="cell__terminal">
         {terminalEnv && terminalEnv.tmuxAvailable ? (
-          <Terminal agent={worktree.agent} generation={1} />
+          <Terminal agent={worktree.agent} generation={generation} />
         ) : (
           <p className="placeholder placeholder--center">
             tmux not installed — terminals unavailable
           </p>
+        )}
+        {actionMessage && (
+          <div className="cell__action-flash">{actionMessage}</div>
         )}
       </div>
     </article>
@@ -927,6 +1004,9 @@ function CellHeader({
   git,
   note,
   onSaveNote,
+  onSendCtrlC,
+  onRestartClaude,
+  onKillSession,
 }: {
   worktree: WorktreeBasics;
   session: SessionState | null;
@@ -934,6 +1014,9 @@ function CellHeader({
   git: WorktreeGitState | null;
   note: AgentNote | null;
   onSaveNote: (label: string) => void;
+  onSendCtrlC: () => void;
+  onRestartClaude: () => void;
+  onKillSession: () => void;
 }): JSX.Element {
   return (
     <header className="cell__header">
@@ -942,6 +1025,11 @@ function CellHeader({
         <SessionPill session={session} processState={processState} />
         <GitInline git={git} session={session} />
         <PortsInline ports={worktree.ports} />
+        <SessionMenu
+          onSendCtrlC={onSendCtrlC}
+          onRestartClaude={onRestartClaude}
+          onKillSession={onKillSession}
+        />
       </div>
       <div className="cell__notes">
         <EditableNote
@@ -952,6 +1040,95 @@ function CellHeader({
         <ActivityLine session={session} />
       </div>
     </header>
+  );
+}
+
+// ─── Session controls menu (kebab) ────────────────────────────
+
+function SessionMenu({
+  onSendCtrlC,
+  onRestartClaude,
+  onKillSession,
+}: {
+  onSendCtrlC: () => void;
+  onRestartClaude: () => void;
+  onKillSession: () => void;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent): void {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  function run(action: () => void): void {
+    setOpen(false);
+    action();
+  }
+
+  return (
+    <div className="session-menu" ref={containerRef}>
+      <button
+        type="button"
+        className="session-menu__trigger"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        title="Session controls"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        ⋯
+      </button>
+      {open && (
+        <div className="session-menu__popover" role="menu">
+          <button
+            type="button"
+            className="session-menu__item"
+            onClick={(e) => {
+              e.stopPropagation();
+              run(onSendCtrlC);
+            }}
+            title="Send Ctrl-C to interrupt the running command"
+          >
+            Send Ctrl-C
+          </button>
+          <button
+            type="button"
+            className="session-menu__item"
+            onClick={(e) => {
+              e.stopPropagation();
+              run(onRestartClaude);
+            }}
+            title="Kill tmux session and start a fresh one running claude"
+          >
+            Restart Claude
+          </button>
+          <button
+            type="button"
+            className="session-menu__item session-menu__item--danger"
+            onClick={(e) => {
+              e.stopPropagation();
+              run(onKillSession);
+            }}
+            title="Kill tmux session entirely (next attach starts fresh)"
+          >
+            Kill session
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -339,6 +339,89 @@ body,
   margin-left: auto;
 }
 
+/* ─── Session menu (kebab) ───────────────────────────── */
+
+.session-menu {
+  position: relative;
+}
+
+.session-menu__trigger {
+  background: var(--bg);
+  color: var(--text-muted);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  padding: 0 0.45rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  height: 1.55rem;
+  line-height: 1;
+  letter-spacing: 0.1em;
+  transition:
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.session-menu__trigger:hover {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.session-menu__popover {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  z-index: 50;
+}
+
+.session-menu__item {
+  background: none;
+  border: none;
+  color: var(--text);
+  padding: 0.4rem 0.6rem;
+  font: inherit;
+  font-size: 0.78rem;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.session-menu__item:hover {
+  background: rgba(106, 162, 255, 0.12);
+  color: var(--accent);
+}
+
+.session-menu__item--danger {
+  color: var(--red);
+}
+
+.session-menu__item--danger:hover {
+  background: rgba(255, 106, 106, 0.12);
+  color: var(--red);
+}
+
+.cell__action-flash {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: rgba(106, 162, 255, 0.18);
+  color: var(--accent);
+  border: 1px solid rgba(106, 162, 255, 0.45);
+  border-radius: 4px;
+  padding: 0.25rem 0.55rem;
+  font-size: 0.72rem;
+  pointer-events: none;
+  z-index: 5;
+  font-weight: 600;
+}
+
 .port-mini {
   background: var(--bg);
   color: var(--accent);

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -346,6 +346,13 @@ export interface RanchApi {
     write: (terminalId: string, data: string) => Promise<void>;
     resize: (terminalId: string, cols: number, rows: number) => Promise<void>;
     detach: (terminalId: string) => Promise<void>;
+    /** Kill the tmux session for an agent (recovery from hangs). */
+    killSession: (agent: string) => Promise<void>;
+    /**
+     * Send keys to an agent's tmux session — accepts both plain strings
+     * and tmux key names like `C-c`, `Enter`, `Escape`.
+     */
+    sendKeys: (agent: string, keys: string[]) => Promise<void>;
     onData: (handler: (event: TerminalDataEvent) => void) => Unsubscribe;
     onExit: (handler: (event: TerminalExitEvent) => void) => Unsubscribe;
   };


### PR DESCRIPTION
## Summary

Recovery options when claude (or its host shell) hangs. Adds a kebab menu (\`⋯\`) to each interactive cell header with three actions:

| Action | What it does |
|---|---|
| **Send Ctrl-C** | \`tmux send-keys -t ranch-<agent> C-c\` — gentle interrupt, no kill. Often enough to free a stuck claude prompt. |
| **Restart Claude** | Kills the tmux session, then bumps a per-agent generation counter that forces the Terminal component to remount — which triggers a fresh attach + claude (via the existing \`-A\` + \`command:claude\` flow). |
| **Kill session** | Nuclear: \`tmux kill-session -t ranch-<agent>\`, no auto-recreate. Operator clicks \"Open Claude\" to start fresh. Useful when claude AND its host shell are both wedged. |

Both destructive actions go through native \`confirm()\` dialogs with copy explaining what survives (rows in the DB, scrollback, etc.).

## Implementation

New IPC:
- \`ranch.terminal.killSession(agent)\` — \`tmux kill-session\` + force-detach our pty handle
- \`ranch.terminal.sendKeys(agent, keys)\` — \`tmux send-keys -t ...\` accepting tmux key syntax (\`C-c\`, \`Enter\`, etc.)

Renderer: a per-agent \`generation\` counter in App state, bumped on Restart. Each AgentCell passes its current generation down to its \`<Terminal>\`. Bumping triggers the Terminal effect to re-run, which closes the old IPC subscription and opens a new \`attach\` — landing on the freshly-spawned tmux session running claude.

A tiny flash overlay in the corner of the cell confirms the action (\"Ctrl-C sent\", \"Restarting…\", \"Session killed\") and fades after 2.5s.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Cell header now has a small \`⋯\` button on the right of the top strip
- [ ] Click it → menu pops up with three options
- [ ] **Send Ctrl-C** while claude is running a long bash → it interrupts (back to claude prompt)
- [ ] **Restart Claude** on a hung session → confirm → tmux session is recreated, claude relaunches in the embedded terminal within ~1s
- [ ] **Kill session** → confirm → terminal pane shows \"tmux client detached\"; \`tmux ls\` outside the app no longer lists \`ranch-<agent>\`
- [ ] After Kill, the cell still shows correctly; clicking the kebab again still works (no stuck state)

## Why this is in the cell, not the sidebar

When you're staring at a hung terminal and want to recover, the sidebar is one click away. The kebab is right there next to the terminal. Direct ergonomics matter more for destructive recovery than they do for inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)