### PR TITLE
feat(console): Approve/Reject/Note/Stop buttons for automated runs

### DIFF
--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -20,7 +20,15 @@ import { getActiveSession } from './transcript.js';
 import { getWorktreeGitState } from './git.js';
 import { snapshotProcessState } from './process.js';
 import { getAllNotes, setNote } from './notes.js';
-import { listRuns, getRun, cleanupAbandonedRuns } from './runs.js';
+import {
+  listRuns,
+  getRun,
+  cleanupAbandonedRuns,
+  approveRun,
+  rejectRun,
+  noteRun,
+  stopRun,
+} from './runs.js';
 import {
   attachTerminal,
   detachTerminal,
@@ -42,6 +50,10 @@ export const IPC_CHANNELS = {
   runsList: 'ranch:runs:list',
   runsGet: 'ranch:runs:get',
   runsCleanupAbandoned: 'ranch:runs:cleanupAbandoned',
+  runsApprove: 'ranch:runs:approve',
+  runsReject: 'ranch:runs:reject',
+  runsNote: 'ranch:runs:note',
+  runsStop: 'ranch:runs:stop',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -123,6 +135,36 @@ export function registerIpcHandlers(): void {
 
   ipcMain.handle(IPC_CHANNELS.runsCleanupAbandoned, async () => {
     return cleanupAbandonedRuns();
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.runsApprove,
+    async (_event, id: unknown, note: unknown) => {
+      if (typeof id !== 'number') throw new Error('runs.approve needs id');
+      await approveRun(id, typeof note === 'string' ? note : undefined);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.runsReject,
+    async (_event, id: unknown, reason: unknown) => {
+      if (typeof id !== 'number') throw new Error('runs.reject needs id');
+      await rejectRun(id, typeof reason === 'string' ? reason : undefined);
+    },
+  );
+
+  ipcMain.handle(
+    IPC_CHANNELS.runsNote,
+    async (_event, id: unknown, text: unknown) => {
+      if (typeof id !== 'number') throw new Error('runs.note needs id');
+      if (typeof text !== 'string') throw new Error('runs.note needs text');
+      await noteRun(id, text);
+    },
+  );
+
+  ipcMain.handle(IPC_CHANNELS.runsStop, async (_event, id: unknown) => {
+    if (typeof id !== 'number') throw new Error('runs.stop needs id');
+    await stopRun(id);
   });
 
   ipcMain.handle(IPC_CHANNELS.terminalEnv, async () => getTerminalEnv());

--- a/console/src/main/runs.ts
+++ b/console/src/main/runs.ts
@@ -30,6 +30,68 @@ const execFile = promisify(execFileCb);
 const RANCH_DIR = process.env.RANCH_HOME ?? join(homedir(), '.ranch');
 const DB_PATH = join(RANCH_DIR, 'ranch.db');
 
+/**
+ * Locate the `ranch` Python CLI. Electron's spawned PATH on macOS may
+ * not include /opt/homebrew/bin, so we look there explicitly first.
+ * Cached after first lookup.
+ */
+let cachedRanchBin: string | null | undefined;
+async function findRanchBin(): Promise<string | null> {
+  if (cachedRanchBin !== undefined) return cachedRanchBin;
+  const override = process.env['RANCH_BIN'];
+  if (override && existsSync(override)) {
+    cachedRanchBin = override;
+    return override;
+  }
+  for (const candidate of ['/opt/homebrew/bin/ranch', '/usr/local/bin/ranch']) {
+    if (existsSync(candidate)) {
+      cachedRanchBin = candidate;
+      return candidate;
+    }
+  }
+  try {
+    const { stdout } = await execFile('which', ['ranch']);
+    const path = stdout.trim();
+    cachedRanchBin = path.length > 0 ? path : null;
+    return cachedRanchBin;
+  } catch {
+    cachedRanchBin = null;
+    return null;
+  }
+}
+
+async function runRanchCli(args: string[]): Promise<{ stdout: string }> {
+  const bin = await findRanchBin();
+  if (!bin) {
+    throw new Error(
+      'ranch CLI not found on PATH. Set RANCH_BIN or install via pip.',
+    );
+  }
+  return execFile(bin, args, { maxBuffer: 1024 * 1024 });
+}
+
+export async function approveRun(id: number, note?: string): Promise<void> {
+  const args = ['approve', String(id)];
+  if (note && note.trim()) args.push('--note', note.trim());
+  await runRanchCli(args);
+}
+
+export async function rejectRun(id: number, reason?: string): Promise<void> {
+  const args = ['reject', String(id)];
+  if (reason && reason.trim()) args.push(reason.trim());
+  await runRanchCli(args);
+}
+
+export async function noteRun(id: number, text: string): Promise<void> {
+  const trimmed = text.trim();
+  if (!trimmed) throw new Error('note text cannot be empty');
+  await runRanchCli(['note', String(id), trimmed]);
+}
+
+export async function stopRun(id: number): Promise<void> {
+  await runRanchCli(['stop', String(id)]);
+}
+
 async function query(sql: string): Promise<unknown[]> {
   if (!existsSync(DB_PATH)) return [];
   const { stdout } = await execFile('/usr/bin/sqlite3', [

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -34,6 +34,10 @@ const IPC_CHANNELS = {
   runsList: 'ranch:runs:list',
   runsGet: 'ranch:runs:get',
   runsCleanupAbandoned: 'ranch:runs:cleanupAbandoned',
+  runsApprove: 'ranch:runs:approve',
+  runsReject: 'ranch:runs:reject',
+  runsNote: 'ranch:runs:note',
+  runsStop: 'ranch:runs:stop',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -88,6 +92,12 @@ const api: RanchApi = {
     get: (id) => ipcRenderer.invoke(IPC_CHANNELS.runsGet, id),
     cleanupAbandoned: () =>
       ipcRenderer.invoke(IPC_CHANNELS.runsCleanupAbandoned),
+    approve: (id, note) =>
+      ipcRenderer.invoke(IPC_CHANNELS.runsApprove, id, note),
+    reject: (id, reason) =>
+      ipcRenderer.invoke(IPC_CHANNELS.runsReject, id, reason),
+    note: (id, text) => ipcRenderer.invoke(IPC_CHANNELS.runsNote, id, text),
+    stop: (id) => ipcRenderer.invoke(IPC_CHANNELS.runsStop, id),
   },
   terminal: {
     env: () => ipcRenderer.invoke(IPC_CHANNELS.terminalEnv),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -648,10 +648,23 @@ function RunDetailModal({
 }): JSX.Element {
   const [detail, setDetail] = useState<RunDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [actionMsg, setActionMsg] = useState<string | null>(null);
+
+  async function refreshNow(): Promise<void> {
+    try {
+      const d = await window.ranch.runs.get(runId);
+      setDetail(d);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
     async function refresh(): Promise<void> {
+      if (cancelled) return;
       try {
         const d = await window.ranch.runs.get(runId);
         if (!cancelled) {
@@ -671,6 +684,76 @@ function RunDetailModal({
       clearInterval(handle);
     };
   }, [runId]);
+
+  function flashAction(msg: string): void {
+    setActionMsg(msg);
+    setTimeout(() => setActionMsg(null), 3500);
+  }
+
+  async function withBusy(
+    label: string,
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    setBusy(label);
+    try {
+      await fn();
+      flashAction(`${label} succeeded`);
+      await refreshNow();
+    } catch (err) {
+      flashAction(
+        `${label} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleApprove(): Promise<void> {
+    const note = window.prompt(
+      'Optional note for approval (leave blank to skip):',
+      '',
+    );
+    if (note === null) return; // user cancelled
+    await withBusy('Approve', () =>
+      window.ranch.runs.approve(runId, note || undefined),
+    );
+  }
+
+  async function handleReject(): Promise<void> {
+    const reason = window.prompt(
+      'Reason for rejection (the agent will see this):',
+      '',
+    );
+    if (reason === null) return;
+    if (!reason.trim()) {
+      flashAction('Reject needs a reason — cancelled.');
+      return;
+    }
+    await withBusy('Reject', () => window.ranch.runs.reject(runId, reason));
+  }
+
+  async function handleNote(): Promise<void> {
+    const text = window.prompt(
+      'Note to send mid-run (the agent receives this on its next tick):',
+      '',
+    );
+    if (text === null) return;
+    if (!text.trim()) {
+      flashAction('Note text required — cancelled.');
+      return;
+    }
+    await withBusy('Note', () => window.ranch.runs.note(runId, text));
+  }
+
+  async function handleStop(): Promise<void> {
+    const ok = window.confirm(
+      `Stop run #${runId}?\n\n` +
+        'This sends a clean stop signal to the orchestrator. ' +
+        'Any in-flight tool call may still complete before exit.',
+    );
+    if (!ok) return;
+    await withBusy('Stop', () => window.ranch.runs.stop(runId));
+  }
 
   return (
     <div className="run-modal__backdrop" onClick={onClose}>
@@ -793,16 +876,18 @@ function RunDetailModal({
               </DetailSection>
             )}
 
-            <DetailSection title="Lifecycle (CLI)">
-              <p className="detail__empty">
-                Approve / reject / stop via terminal until UI buttons land:
-              </p>
-              <pre className="run-modal__cli">
-                ranch approve {runId}
-                {'\n'}ranch reject {runId} &quot;reason&quot;
-                {'\n'}ranch note {runId} &quot;note text&quot;
-                {'\n'}ranch stop {runId}
-              </pre>
+            <DetailSection title="Actions">
+              <RunActions
+                detail={detail}
+                busy={busy}
+                onApprove={handleApprove}
+                onReject={handleReject}
+                onNote={handleNote}
+                onStop={handleStop}
+              />
+              {actionMsg && (
+                <p className="run-modal__action-msg">{actionMsg}</p>
+              )}
             </DetailSection>
           </div>
         )}
@@ -1601,6 +1686,85 @@ function DetailRow({
       >
         {value}
       </span>
+    </div>
+  );
+}
+
+// ─── Run lifecycle action buttons ─────────────────────────────
+
+function RunActions({
+  detail,
+  busy,
+  onApprove,
+  onReject,
+  onNote,
+  onStop,
+}: {
+  detail: RunDetail;
+  busy: string | null;
+  onApprove: () => void;
+  onReject: () => void;
+  onNote: () => void;
+  onStop: () => void;
+}): JSX.Element {
+  // Whether each action is contextually relevant. Buttons stay visible
+  // but are disabled if the run state doesn't make them sensible — that
+  // way the operator always sees what's possible, not just what's wired.
+  const awaitingApproval = detail.rawState === 'needs_approval';
+  const isActive = [
+    'planning',
+    'in_development',
+    'tests_green',
+    'needs_approval',
+    'queued',
+  ].includes(detail.rawState);
+
+  return (
+    <div className="run-actions">
+      <button
+        type="button"
+        className="run-action run-action--approve"
+        onClick={onApprove}
+        disabled={!awaitingApproval || busy !== null}
+        title={
+          awaitingApproval
+            ? 'Approve the current checkpoint (ranch approve)'
+            : 'Only available when state = needs_approval'
+        }
+      >
+        {busy === 'Approve' ? '…' : 'Approve'}
+      </button>
+      <button
+        type="button"
+        className="run-action run-action--reject"
+        onClick={onReject}
+        disabled={!awaitingApproval || busy !== null}
+        title={
+          awaitingApproval
+            ? 'Reject the current checkpoint with a reason (ranch reject)'
+            : 'Only available when state = needs_approval'
+        }
+      >
+        {busy === 'Reject' ? '…' : 'Reject'}
+      </button>
+      <button
+        type="button"
+        className="run-action"
+        onClick={onNote}
+        disabled={!isActive || busy !== null}
+        title="Send a note to the agent mid-run (ranch note)"
+      >
+        {busy === 'Note' ? '…' : 'Note'}
+      </button>
+      <button
+        type="button"
+        className="run-action run-action--stop"
+        onClick={onStop}
+        disabled={!isActive || busy !== null}
+        title="Stop the run cleanly (ranch stop)"
+      >
+        {busy === 'Stop' ? '…' : 'Stop'}
+      </button>
     </div>
   );
 }

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -1266,6 +1266,79 @@ body,
   overflow-x: auto;
 }
 
+.run-modal__action-msg {
+  margin: 0.4rem 0 0;
+  font-size: 0.74rem;
+  padding: 0.3rem 0.55rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-muted);
+}
+
+/* ─── Run action buttons ───────────────────────────── */
+
+.run-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.run-action {
+  background: var(--bg-elevated);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 0.35rem 0.8rem;
+  border-radius: 4px;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color 0.12s ease,
+    background 0.12s ease;
+  min-width: 4.5rem;
+}
+
+.run-action:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.run-action:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.run-action--approve {
+  background: rgba(92, 212, 122, 0.14);
+  color: var(--green);
+  border-color: rgba(92, 212, 122, 0.35);
+}
+.run-action--approve:hover:not(:disabled) {
+  background: rgba(92, 212, 122, 0.22);
+  border-color: var(--green);
+}
+
+.run-action--reject {
+  background: rgba(255, 106, 106, 0.12);
+  color: var(--red);
+  border-color: rgba(255, 106, 106, 0.3);
+}
+.run-action--reject:hover:not(:disabled) {
+  background: rgba(255, 106, 106, 0.18);
+  border-color: var(--red);
+}
+
+.run-action--stop {
+  background: rgba(255, 106, 106, 0.08);
+  color: var(--red);
+  border-color: rgba(255, 106, 106, 0.25);
+}
+.run-action--stop:hover:not(:disabled) {
+  background: rgba(255, 106, 106, 0.14);
+  border-color: var(--red);
+}
+
 .detail__pr-link {
   color: var(--accent);
   text-decoration: none;

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -328,7 +328,6 @@ export interface RanchApi {
     set: (agent: string, label: string) => Promise<AgentNote | null>;
   };
   runs: {
-    /** Read-only listing — lifecycle controls go through Python CLI for now. */
     list: (limit?: number) => Promise<RunRecord[]>;
     get: (id: number) => Promise<RunDetail | null>;
     /**
@@ -336,6 +335,11 @@ export interface RanchApi {
      * Returns the number of rows updated.
      */
     cleanupAbandoned: () => Promise<number>;
+    /** Lifecycle — each shells out to the Python `ranch` CLI. */
+    approve: (id: number, note?: string) => Promise<void>;
+    reject: (id: number, reason?: string) => Promise<void>;
+    note: (id: number, text: string) => Promise<void>;
+    stop: (id: number) => Promise<void>;
   };
   terminal: {
     env: () => Promise<TerminalEnv>;


### PR DESCRIPTION
## Summary

Closes the automated run loop. The detail modal now has an **Actions** section with the four key lifecycle buttons:

- **Approve** (green) — \`ranch approve <id> [--note ...]\`. Prompts for an optional note.
- **Reject** (red) — \`ranch reject <id> \"reason\"\`. Requires a reason.
- **Note** — \`ranch note <id> \"text\"\`. Mid-run guidance to the agent.
- **Stop** (red) — \`ranch stop <id>\`. Confirms before sending.

Buttons stay visible always (so the operator sees what's possible) but are disabled when the run state doesn't make them sensible. Approve/Reject only fire during \`needs_approval\`; Note/Stop only during active states.

## Why shell out to the Python CLI

The orchestrator already implements all the lifecycle correctness — DB updates, interjection table writes, signal sending, etc. Reimplementing that in TS would be wrong; the CLI is the source of truth, the console is a window onto it. Same approach for dispatch + everything else lifecycle-shaped.

CLI discovery: \`RANCH_BIN\` env override → \`/opt/homebrew/bin/ranch\` → \`/usr/local/bin/ranch\` → \`which ranch\`. Same pattern as tmux discovery in pty.ts.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Switch to Automated → click any run card → Actions section appears at bottom of modal
- [ ] On a run currently in \`needs_approval\` (or dispatch one and let it hit a checkpoint): Approve / Reject buttons enable
- [ ] Click **Approve** → prompt for note → submit → modal refreshes within ~4s, checkpoint shows decision: approved
- [ ] Click **Reject** on a fresh checkpoint → requires reason → submit → checkpoint decision: rejected, run state changes
- [ ] On any active run, click **Note** → enter text → confirm → next time the agent ticks it picks up the interjection
- [ ] Click **Stop** → confirm → run transitions to stopped within seconds

## What's next

- **Dispatch from UI** (\"+ New automated run\") — answer to \"how do I trigger a run\"
- **Cross-mode link** — \"Open in Interactive\" on a run card to drop into that worktree's terminal
- **Diff preview** in modal — \`git diff origin/develop...<branch>\` rendered inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)