### PR TITLE
feat(console): per-agent docker management in detail sidebar

### DIFF
--- a/console/src/main/docker.ts
+++ b/console/src/main/docker.ts
@@ -1,0 +1,293 @@
+/**
+ * Docker introspection + per-agent compose lifecycle.
+ *
+ * Read state via `docker ps --format json`. Manage stacks via
+ * `docker compose -p citemed_<agent>` shelling out. Convention matches
+ * citemed_web's Makefile:
+ *
+ *   docker compose --env-file <worktree>/.env.agent
+ *     -f <worktree>/docker-compose.yml
+ *     -f <worktree>/docker-compose.agent.yml
+ *     -p citemed_<agent>
+ *
+ * For drift tolerance we also match a project named just `<agent>`
+ * (some old stacks were started without the citemed_ prefix).
+ */
+
+import { execFile as execFileCb } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import type {
+  DockerContainer,
+  DockerEnv,
+  DockerStackSnapshot,
+} from '../shared/types.js';
+
+const execFile = promisify(execFileCb);
+
+let cachedDockerPath: string | null | undefined;
+
+async function findDocker(): Promise<string | null> {
+  if (cachedDockerPath !== undefined) return cachedDockerPath;
+  for (const candidate of [
+    '/opt/homebrew/bin/docker',
+    '/usr/local/bin/docker',
+    '/usr/bin/docker',
+  ]) {
+    if (existsSync(candidate)) {
+      cachedDockerPath = candidate;
+      return candidate;
+    }
+  }
+  try {
+    const { stdout } = await execFile('which', ['docker']);
+    const path = stdout.trim();
+    cachedDockerPath = path.length > 0 ? path : null;
+    return cachedDockerPath;
+  } catch {
+    cachedDockerPath = null;
+    return null;
+  }
+}
+
+export async function getDockerEnv(): Promise<DockerEnv> {
+  const path = await findDocker();
+  if (!path) return { dockerAvailable: false };
+  // Probe daemon connectivity. `docker info` fails fast when the
+  // engine isn't running (Docker Desktop quit, etc.).
+  try {
+    await execFile(path, ['info', '--format', '{{.ServerVersion}}'], {
+      timeout: 4000,
+    });
+    return { dockerAvailable: true, dockerPath: path };
+  } catch {
+    return { dockerAvailable: false, dockerPath: path };
+  }
+}
+
+interface SnapshotInput {
+  /** agent name → worktree path (for compose file resolution on lifecycle ops). */
+  agents: Record<string, string>;
+}
+
+interface RawPsRow {
+  ID?: unknown;
+  Names?: unknown;
+  Image?: unknown;
+  State?: unknown;
+  Status?: unknown;
+  Ports?: unknown;
+  RunningFor?: unknown;
+  Labels?: unknown;
+}
+
+function parseLabels(raw: unknown): Record<string, string> {
+  if (typeof raw !== 'string') return {};
+  const out: Record<string, string> = {};
+  // docker formats labels as a comma-separated list of key=value pairs.
+  // Values themselves don't contain `=`, so split on the first `=` only.
+  for (const part of raw.split(',')) {
+    const eq = part.indexOf('=');
+    if (eq <= 0) continue;
+    const k = part.slice(0, eq).trim();
+    const v = part.slice(eq + 1).trim();
+    out[k] = v;
+  }
+  return out;
+}
+
+function projectMatchesAgent(project: string, agent: string): boolean {
+  // Accept canonical name + drift variant (some stacks started without prefix).
+  return project === `citemed_${agent}` || project === agent;
+}
+
+function rowToContainer(row: RawPsRow): DockerContainer | null {
+  const labels = parseLabels(row.Labels);
+  const project = labels['com.docker.compose.project'];
+  const service = labels['com.docker.compose.service'];
+  if (!project) return null;
+  const id = typeof row.ID === 'string' ? row.ID : '';
+  const name = typeof row.Names === 'string' ? row.Names : '';
+  const image = typeof row.Image === 'string' ? row.Image : '';
+  const state = typeof row.State === 'string' ? row.State : 'unknown';
+  const status = typeof row.Status === 'string' ? row.Status : '';
+  const ports = typeof row.Ports === 'string' ? row.Ports : '';
+  const c: DockerContainer = {
+    id,
+    name,
+    image,
+    state,
+    status,
+    project,
+  };
+  if (service) c.service = service;
+  if (ports) c.ports = ports;
+  return c;
+}
+
+export async function snapshotDockerState(
+  input: SnapshotInput,
+): Promise<DockerStackSnapshot> {
+  const dockerPath = await findDocker();
+  const empty: DockerStackSnapshot = {
+    available: false,
+    perAgent: {},
+    shared: [],
+  };
+  if (!dockerPath) return empty;
+
+  let parsed: RawPsRow[] = [];
+  try {
+    const { stdout } = await execFile(
+      dockerPath,
+      ['ps', '-a', '--format', 'json'],
+      { timeout: 5000 },
+    );
+    // docker emits one JSON object per line, NOT a JSON array.
+    for (const line of stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const obj = JSON.parse(trimmed) as RawPsRow;
+        parsed.push(obj);
+      } catch {
+        /* malformed line — skip */
+      }
+    }
+  } catch {
+    return { ...empty, available: true };
+  }
+
+  const containers: DockerContainer[] = [];
+  for (const row of parsed) {
+    const c = rowToContainer(row);
+    if (c) containers.push(c);
+  }
+
+  const perAgent: Record<string, DockerContainer[]> = {};
+  for (const agent of Object.keys(input.agents)) {
+    perAgent[agent] = containers.filter((c) =>
+      projectMatchesAgent(c.project, agent),
+    );
+  }
+  const shared = containers.filter((c) => c.project === 'citemed_shared');
+
+  return {
+    available: true,
+    perAgent,
+    shared,
+  };
+}
+
+// ─── Lifecycle ───────────────────────────────────────────────
+
+interface ComposeFiles {
+  composeFile: string;
+  agentComposeFile: string;
+  envFile: string;
+}
+
+function resolveComposeFiles(worktreePath: string): ComposeFiles | null {
+  const composeFile = join(worktreePath, 'docker-compose.yml');
+  const agentComposeFile = join(worktreePath, 'docker-compose.agent.yml');
+  const envFile = join(worktreePath, '.env.agent');
+  // We need at least the base compose file. agent override + env are
+  // expected for citemed_web but soft-fail on simpler projects.
+  if (!existsSync(composeFile)) return null;
+  return { composeFile, agentComposeFile, envFile };
+}
+
+interface ComposeRunResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+async function composeRun(
+  agent: string,
+  worktreePath: string,
+  args: string[],
+  needsFiles: boolean,
+): Promise<ComposeRunResult> {
+  const dockerPath = await findDocker();
+  if (!dockerPath) {
+    return { ok: false, stdout: '', stderr: 'docker not installed' };
+  }
+  const project = `citemed_${agent}`;
+  const composeArgs: string[] = ['compose'];
+
+  if (needsFiles) {
+    const files = resolveComposeFiles(worktreePath);
+    if (!files) {
+      return {
+        ok: false,
+        stdout: '',
+        stderr: `no docker-compose.yml found at ${worktreePath}`,
+      };
+    }
+    if (existsSync(files.envFile)) {
+      composeArgs.push('--env-file', files.envFile);
+    }
+    composeArgs.push('-f', files.composeFile);
+    if (existsSync(files.agentComposeFile)) {
+      composeArgs.push('-f', files.agentComposeFile);
+    }
+  }
+
+  composeArgs.push('-p', project, ...args);
+
+  try {
+    const { stdout, stderr } = await execFile(dockerPath, composeArgs, {
+      cwd: worktreePath,
+      maxBuffer: 4 * 1024 * 1024,
+      timeout: 120_000,
+    });
+    return { ok: true, stdout, stderr };
+  } catch (err) {
+    const stderr =
+      err && typeof err === 'object' && 'stderr' in err
+        ? String((err as { stderr: unknown }).stderr ?? '')
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { ok: false, stdout: '', stderr };
+  }
+}
+
+export async function dockerStackUp(
+  agent: string,
+  worktreePath: string,
+): Promise<ComposeRunResult> {
+  return composeRun(agent, worktreePath, ['up', '-d'], true);
+}
+
+export async function dockerStackDown(
+  agent: string,
+  worktreePath: string,
+): Promise<ComposeRunResult> {
+  // `down` doesn't need the file list — project name is sufficient.
+  return composeRun(agent, worktreePath, ['down'], false);
+}
+
+export async function dockerStackRestart(
+  agent: string,
+  worktreePath: string,
+): Promise<ComposeRunResult> {
+  // restart on its own restarts the existing services without
+  // re-resolving the compose files. Fast and surgical.
+  return composeRun(agent, worktreePath, ['restart'], false);
+}
+
+export async function dockerStackLogs(
+  agent: string,
+  worktreePath: string,
+  tail = 200,
+): Promise<ComposeRunResult> {
+  return composeRun(
+    agent,
+    worktreePath,
+    ['logs', `--tail=${tail}`, '--no-color'],
+    false,
+  );
+}

--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -19,6 +19,14 @@ import { listWorktrees } from './worktrees.js';
 import { getActiveSession } from './transcript.js';
 import { getWorktreeGitState } from './git.js';
 import { snapshotProcessState } from './process.js';
+import {
+  getDockerEnv,
+  snapshotDockerState,
+  dockerStackUp,
+  dockerStackDown,
+  dockerStackRestart,
+  dockerStackLogs,
+} from './docker.js';
 import { getAllNotes, setNote } from './notes.js';
 import {
   listRuns,
@@ -68,6 +76,12 @@ export const IPC_CHANNELS = {
   appVersion: 'ranch:app:version',
   appRevealInFinder: 'ranch:app:revealInFinder',
   appOpenExternal: 'ranch:app:openExternal',
+  dockerEnv: 'ranch:docker:env',
+  dockerSnapshot: 'ranch:docker:snapshot',
+  dockerUp: 'ranch:docker:up',
+  dockerDown: 'ranch:docker:down',
+  dockerRestart: 'ranch:docker:restart',
+  dockerLogs: 'ranch:docker:logs',
 } as const;
 
 export function registerIpcHandlers(): void {
@@ -261,4 +275,50 @@ export function registerIpcHandlers(): void {
     if (!/^(https?:|file:)\/\//.test(url)) return;
     await shell.openExternal(url);
   });
+
+  ipcMain.handle(IPC_CHANNELS.dockerEnv, async () => getDockerEnv());
+
+  ipcMain.handle(IPC_CHANNELS.dockerSnapshot, async () => {
+    const config = await loadRanchConfig();
+    const agents: Record<string, string> = {};
+    for (const a of config.agents) agents[a.name] = a.worktree;
+    return snapshotDockerState({ agents });
+  });
+
+  async function resolveAgentWorktree(agent: unknown): Promise<{
+    agent: string;
+    worktreePath: string;
+  }> {
+    if (typeof agent !== 'string' || !agent) {
+      throw new Error('docker call requires an agent name');
+    }
+    const config = await loadRanchConfig();
+    const match = config.agents.find((a) => a.name === agent);
+    if (!match) throw new Error(`Unknown agent: ${agent}`);
+    return { agent, worktreePath: match.worktree };
+  }
+
+  ipcMain.handle(IPC_CHANNELS.dockerUp, async (_event, agent: unknown) => {
+    const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
+    return dockerStackUp(a, worktreePath);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.dockerDown, async (_event, agent: unknown) => {
+    const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
+    return dockerStackDown(a, worktreePath);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.dockerRestart, async (_event, agent: unknown) => {
+    const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
+    return dockerStackRestart(a, worktreePath);
+  });
+
+  ipcMain.handle(
+    IPC_CHANNELS.dockerLogs,
+    async (_event, agent: unknown, tail: unknown) => {
+      const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
+      const t = typeof tail === 'number' ? tail : 200;
+      return dockerStackLogs(a, worktreePath, t);
+    },
+  );
 }

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -50,6 +50,12 @@ const IPC_CHANNELS = {
   appVersion: 'ranch:app:version',
   appRevealInFinder: 'ranch:app:revealInFinder',
   appOpenExternal: 'ranch:app:openExternal',
+  dockerEnv: 'ranch:docker:env',
+  dockerSnapshot: 'ranch:docker:snapshot',
+  dockerUp: 'ranch:docker:up',
+  dockerDown: 'ranch:docker:down',
+  dockerRestart: 'ranch:docker:restart',
+  dockerLogs: 'ranch:docker:logs',
 } as const;
 
 /**
@@ -124,6 +130,15 @@ const api: RanchApi = {
       ipcRenderer.invoke(IPC_CHANNELS.appRevealInFinder, path),
     openExternal: (url) =>
       ipcRenderer.invoke(IPC_CHANNELS.appOpenExternal, url),
+  },
+  docker: {
+    env: () => ipcRenderer.invoke(IPC_CHANNELS.dockerEnv),
+    snapshot: () => ipcRenderer.invoke(IPC_CHANNELS.dockerSnapshot),
+    up: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerUp, agent),
+    down: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerDown, agent),
+    restart: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerRestart, agent),
+    logs: (agent, tail) =>
+      ipcRenderer.invoke(IPC_CHANNELS.dockerLogs, agent, tail),
   },
 };
 

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -9,6 +9,8 @@ import {
 import type {
   AgentNote,
   CCProcessState,
+  DockerContainer,
+  DockerStackSnapshot,
   ProcessSnapshot,
   RunDetail,
   RunRecord,
@@ -26,9 +28,16 @@ const EMPTY_SNAPSHOT: ProcessSnapshot = {
   totalClaudes: 0,
 };
 
+const EMPTY_DOCKER: DockerStackSnapshot = {
+  available: false,
+  perAgent: {},
+  shared: [],
+};
+
 const SESSION_POLL_MS = 4000;
 const PROCESS_POLL_MS = 5000;
 const GIT_POLL_MS = 8000;
+const DOCKER_POLL_MS = 7000;
 const WORKTREE_POLL_MS = 30_000;
 const NOTES_POLL_MS = 15_000;
 
@@ -47,6 +56,8 @@ export function App(): JSX.Element {
   const [terminalEnv, setTerminalEnv] = useState<TerminalEnv | null>(null);
   const [processSnapshot, setProcessSnapshot] =
     useState<ProcessSnapshot>(EMPTY_SNAPSHOT);
+  const [dockerSnapshot, setDockerSnapshot] =
+    useState<DockerStackSnapshot>(EMPTY_DOCKER);
   const [notes, setNotes] = useState<Record<string, AgentNote>>({});
   const [focusedAgent, setFocusedAgent] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
@@ -121,6 +132,25 @@ export function App(): JSX.Element {
     }
     void refresh();
     const handle = setInterval(refresh, PROCESS_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, []);
+
+  // ─── docker snapshot (fleet-wide) ─────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    async function refresh(): Promise<void> {
+      try {
+        const snap = await window.ranch.docker.snapshot();
+        if (!cancelled) setDockerSnapshot(snap);
+      } catch {
+        // docker not running / not installed — empty state surfaces it
+      }
+    }
+    void refresh();
+    const handle = setInterval(refresh, DOCKER_POLL_MS);
     return () => {
       cancelled = true;
       clearInterval(handle);
@@ -218,6 +248,7 @@ export function App(): JSX.Element {
                   key={wt.agent}
                   worktree={wt}
                   processState={processSnapshot.perAgent[wt.agent] ?? null}
+                  dockerContainers={dockerSnapshot.perAgent[wt.agent] ?? []}
                   note={notes[wt.agent] ?? null}
                   terminalEnv={terminalEnv}
                   focused={focusedAgent === wt.agent}
@@ -236,6 +267,10 @@ export function App(): JSX.Element {
                   processState={
                     processSnapshot.perAgent[focusedWorktree.agent] ?? null
                   }
+                  dockerContainers={
+                    dockerSnapshot.perAgent[focusedWorktree.agent] ?? []
+                  }
+                  dockerAvailable={dockerSnapshot.available}
                   note={notes[focusedWorktree.agent] ?? null}
                 />
               ) : (
@@ -923,6 +958,7 @@ function orphanTooltip(snap: ProcessSnapshot): string {
 interface AgentCellProps {
   worktree: WorktreeBasics;
   processState: CCProcessState | null;
+  dockerContainers: DockerContainer[];
   note: AgentNote | null;
   terminalEnv: TerminalEnv | null;
   focused: boolean;
@@ -935,6 +971,7 @@ interface AgentCellProps {
 function AgentCell({
   worktree,
   processState,
+  dockerContainers,
   note,
   terminalEnv,
   focused,
@@ -1057,6 +1094,7 @@ function AgentCell({
         worktree={worktree}
         session={session}
         processState={processState}
+        dockerContainers={dockerContainers}
         git={git}
         note={note}
         onSaveNote={onSaveNote}
@@ -1086,6 +1124,7 @@ function CellHeader({
   worktree,
   session,
   processState,
+  dockerContainers,
   git,
   note,
   onSaveNote,
@@ -1096,6 +1135,7 @@ function CellHeader({
   worktree: WorktreeBasics;
   session: SessionState | null;
   processState: CCProcessState | null;
+  dockerContainers: DockerContainer[];
   git: WorktreeGitState | null;
   note: AgentNote | null;
   onSaveNote: (label: string) => void;
@@ -1109,6 +1149,7 @@ function CellHeader({
         <span className="cell__name">{worktree.agent}</span>
         <SessionPill session={session} processState={processState} />
         <GitInline git={git} session={session} />
+        <DockerBadge containers={dockerContainers} />
         <PortsInline ports={worktree.ports} />
         <SessionMenu
           onSendCtrlC={onSendCtrlC}
@@ -1419,6 +1460,28 @@ function GitInline({
   );
 }
 
+function DockerBadge({
+  containers,
+}: {
+  containers: DockerContainer[];
+}): JSX.Element | null {
+  if (containers.length === 0) return null;
+  const running = containers.filter((c) => c.state === 'running').length;
+  const total = containers.length;
+  const allUp = running === total;
+  const anyUp = running > 0;
+  const cls = allUp
+    ? 'docker-badge docker-badge--up'
+    : anyUp
+      ? 'docker-badge docker-badge--partial'
+      : 'docker-badge docker-badge--down';
+  return (
+    <span className={cls} title={`${running}/${total} containers running`}>
+      🐳 {running}/{total}
+    </span>
+  );
+}
+
 function PortsInline({
   ports,
 }: {
@@ -1455,14 +1518,20 @@ function PortsInline({
 function AgentDetail({
   worktree,
   processState,
+  dockerContainers,
+  dockerAvailable,
   note,
 }: {
   worktree: WorktreeBasics;
   processState: CCProcessState | null;
+  dockerContainers: DockerContainer[];
+  dockerAvailable: boolean;
   note: AgentNote | null;
 }): JSX.Element {
   const [session, setSession] = useState<SessionState | null>(null);
   const [git, setGit] = useState<WorktreeGitState | null>(null);
+  const [dockerBusy, setDockerBusy] = useState<string | null>(null);
+  const [dockerMsg, setDockerMsg] = useState<string | null>(null);
 
   // Sidebar polls its own copies. We refetch on agent change so switching
   // between cells gets fresh data immediately rather than after the next tick.
@@ -1506,6 +1575,16 @@ function AgentDetail({
           Reveal in Finder
         </button>
       </div>
+
+      <DockerSection
+        agent={worktree.agent}
+        containers={dockerContainers}
+        available={dockerAvailable}
+        busy={dockerBusy}
+        msg={dockerMsg}
+        setBusy={setDockerBusy}
+        setMsg={setDockerMsg}
+      />
 
       <DetailSection title="Status">
         <DetailRow label="run state" value={session?.runState ?? '…'} />
@@ -1645,6 +1724,152 @@ function AgentDetail({
       )}
     </div>
   );
+}
+
+function DockerSection({
+  agent,
+  containers,
+  available,
+  busy,
+  msg,
+  setBusy,
+  setMsg,
+}: {
+  agent: string;
+  containers: DockerContainer[];
+  available: boolean;
+  busy: string | null;
+  msg: string | null;
+  setBusy: (v: string | null) => void;
+  setMsg: (v: string | null) => void;
+}): JSX.Element {
+  function flash(text: string): void {
+    setMsg(text);
+    setTimeout(() => setMsg(null), 4000);
+  }
+
+  async function withBusy(
+    label: string,
+    fn: () => Promise<{ ok: boolean; stderr: string; stdout: string }>,
+  ): Promise<void> {
+    if (busy) return;
+    setBusy(label);
+    try {
+      const result = await fn();
+      if (result.ok) {
+        flash(`${label} succeeded`);
+      } else {
+        const tail = (result.stderr || result.stdout || '').trim().slice(-200);
+        flash(`${label} failed: ${tail || '(no output)'}`);
+      }
+    } catch (err) {
+      flash(
+        `${label} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleUp(): Promise<void> {
+    await withBusy('Up', () => window.ranch.docker.up(agent));
+  }
+  async function handleDown(): Promise<void> {
+    if (
+      !window.confirm(
+        `Bring down docker stack for ${agent}?\n\nRunning containers will be stopped and removed.`,
+      )
+    )
+      return;
+    await withBusy('Down', () => window.ranch.docker.down(agent));
+  }
+  async function handleRestart(): Promise<void> {
+    await withBusy('Restart', () => window.ranch.docker.restart(agent));
+  }
+
+  const running = containers.filter((c) => c.state === 'running').length;
+  const total = containers.length;
+
+  return (
+    <DetailSection title={`Docker · ${running}/${total}`}>
+      {!available && (
+        <p className="detail__warn">
+          Docker engine not reachable. Is Docker Desktop running?
+        </p>
+      )}
+      {available && total === 0 && (
+        <p className="detail__empty">
+          No <code>citemed_{agent}</code> containers. Click <strong>Up</strong>{' '}
+          to bring the stack up.
+        </p>
+      )}
+      {total > 0 && (
+        <ul className="docker-services">
+          {containers.map((c) => (
+            <li
+              key={c.id}
+              className={`docker-service docker-service--${c.state}`}
+            >
+              <span className="docker-service__name">
+                {c.service ?? c.name}
+              </span>
+              <span
+                className={`docker-service__state docker-service__state--${c.state}`}
+                title={c.status}
+              >
+                {c.state}
+              </span>
+              {c.ports && (
+                <span className="docker-service__ports" title={c.ports}>
+                  {summarizePortString(c.ports)}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="docker-actions">
+        <button
+          type="button"
+          className="run-action run-action--approve"
+          onClick={handleUp}
+          disabled={!available || busy !== null}
+          title="docker compose up -d (uses .env.agent + docker-compose.agent.yml)"
+        >
+          {busy === 'Up' ? '…' : 'Up'}
+        </button>
+        <button
+          type="button"
+          className="run-action"
+          onClick={handleRestart}
+          disabled={!available || busy !== null || total === 0}
+          title="docker compose restart"
+        >
+          {busy === 'Restart' ? '…' : 'Restart'}
+        </button>
+        <button
+          type="button"
+          className="run-action run-action--stop"
+          onClick={handleDown}
+          disabled={!available || busy !== null || total === 0}
+          title="docker compose down (stops and removes containers)"
+        >
+          {busy === 'Down' ? '…' : 'Down'}
+        </button>
+      </div>
+      {msg && <p className="run-modal__action-msg">{msg}</p>}
+    </DetailSection>
+  );
+}
+
+/**
+ * Boil down docker's `Ports` column to just the host-side bindings —
+ * "0.0.0.0:8003->8000/tcp" → "8003".
+ */
+function summarizePortString(raw: string): string {
+  const matches = raw.matchAll(/0\.0\.0\.0:(\d+)->/g);
+  const ports = Array.from(matches).map((m) => m[1]!);
+  return ports.length > 0 ? ports.join(', ') : raw.slice(0, 30);
 }
 
 function DetailSection({

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -1339,6 +1339,111 @@ body,
   border-color: var(--red);
 }
 
+/* ─── Docker badge (cell header) ──────────────────── */
+
+.docker-badge {
+  font-size: 0.65rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg);
+  color: var(--text-muted);
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  white-space: nowrap;
+  font-weight: 600;
+}
+
+.docker-badge--up {
+  background: rgba(92, 212, 122, 0.14);
+  color: var(--green);
+  border-color: rgba(92, 212, 122, 0.4);
+}
+
+.docker-badge--partial {
+  background: rgba(246, 193, 119, 0.14);
+  color: var(--yellow);
+  border-color: rgba(246, 193, 119, 0.4);
+}
+
+.docker-badge--down {
+  background: var(--bg);
+  color: var(--text-dim);
+}
+
+/* ─── Docker section (sidebar) ─────────────────────── */
+
+.docker-services {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.docker-service {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.45rem;
+  align-items: baseline;
+  font-size: 0.74rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.3rem 0.5rem;
+}
+
+.docker-service__name {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.docker-service__state {
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0 0.4rem;
+  border-radius: 2px;
+  border: 1px solid var(--border-strong);
+}
+
+.docker-service__state--running {
+  background: rgba(92, 212, 122, 0.16);
+  color: var(--green);
+  border-color: rgba(92, 212, 122, 0.4);
+}
+.docker-service__state--exited,
+.docker-service__state--dead {
+  background: rgba(255, 106, 106, 0.12);
+  color: var(--red);
+  border-color: rgba(255, 106, 106, 0.3);
+}
+.docker-service__state--restarting,
+.docker-service__state--paused {
+  background: rgba(246, 193, 119, 0.14);
+  color: var(--yellow);
+  border-color: rgba(246, 193, 119, 0.4);
+}
+
+.docker-service__ports {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 10ch;
+}
+
+.docker-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
 .detail__pr-link {
   color: var(--accent);
   text-decoration: none;

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -187,6 +187,40 @@ export interface SessionState {
   runState: SessionRunState;
 }
 
+// ─── Docker (per-agent compose stacks) ───────────────────────────────────
+
+export interface DockerEnv {
+  dockerAvailable: boolean;
+  dockerPath?: string;
+}
+
+export interface DockerContainer {
+  id: string;
+  name: string;
+  image: string;
+  /** "running", "exited", "restarting", "paused", "created", "dead", … */
+  state: string;
+  /** Human-readable line like "Up 23 hours (healthy)" */
+  status: string;
+  project: string;
+  service?: string;
+  /** Raw Ports column, e.g. "0.0.0.0:8003->8000/tcp" */
+  ports?: string;
+}
+
+export interface DockerStackSnapshot {
+  available: boolean;
+  perAgent: Record<string, DockerContainer[]>;
+  /** citemed_shared stack (postgres, redis, etc.) */
+  shared: DockerContainer[];
+}
+
+export interface ComposeRunResult {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+}
+
 // ─── Notes (operator-owned per-agent labels) ─────────────────────────────
 
 export interface AgentNote {
@@ -366,6 +400,15 @@ export interface RanchApi {
     revealInFinder: (path: string) => Promise<void>;
     /** Open a URL in the user's default browser (or whatever shell handles it). */
     openExternal: (url: string) => Promise<void>;
+  };
+  docker: {
+    env: () => Promise<DockerEnv>;
+    /** Fleet snapshot — one `docker ps` per call, all agents + shared. */
+    snapshot: () => Promise<DockerStackSnapshot>;
+    up: (agent: string) => Promise<ComposeRunResult>;
+    down: (agent: string) => Promise<ComposeRunResult>;
+    restart: (agent: string) => Promise<ComposeRunResult>;
+    logs: (agent: string, tail?: number) => Promise<ComposeRunResult>;
   };
 }
 


### PR DESCRIPTION
## Summary

Brings docker stack management for each ranch hand into the detail sidebar — exactly where you suggested it should live.

## What you'll see

### Cell header (subtle)

A small \`🐳 N/M\` badge appears in each cell's top strip when that agent has docker containers tracked:

- Green: all containers running
- Yellow: partial (some up, some down)
- Dim: all stopped

Hidden entirely when the agent has no associated containers — no clutter for fresh worktrees.

### Detail sidebar (rich)

Click a cell, open the sidebar — first section is now **Docker · N/M** with:

- Service list — name, state badge (running/exited/restarting/paused), host port(s) extracted from the messy \`Ports\` column
- **Up** / **Restart** / **Down** buttons
- Toast feedback on success/failure with trimmed stderr tail when something goes wrong

The lifecycle commands shell out to docker compose with the same flags citemed_web's Makefile uses:

\`\`\`
docker compose --env-file <worktree>/.env.agent
  -f <worktree>/docker-compose.yml
  -f <worktree>/docker-compose.agent.yml
  -p citemed_<agent>
  <up -d | restart | down>
\`\`\`

\`Down\` is destructive — confirms first.

## Implementation notes

- One \`docker ps -a --format json\` per fleet-wide snapshot, polled every 7s. Filtered by \`com.docker.compose.project\` label, accepting both \`citemed_<agent>\` (canonical) and bare \`<agent>\` (your existing \`max\` stack drifted off the prefix).
- \`docker info\` probe gates everything behind a \"Docker Desktop running?\" warning if the daemon is unreachable — empty stack list isn't conflated with stopped daemon.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Cells with running containers show \`🐳 N/M\` in the header
- [ ] Click a cell, open Details sidebar → top section is **Docker** with services + state badges
- [ ] Click **Up** on a stopped stack → containers come up; the cell badge transitions to green
- [ ] Click **Restart** → container states briefly flip then return to running
- [ ] Click **Down** → confirm → containers stop; badge dims
- [ ] Stop Docker Desktop → within ~7s the section shows \"Docker engine not reachable\"
- [ ] Service name + port extracted correctly from real ps output (e.g. service=web, ports=\"8003\")

## What's next

- **Dispatch from UI** — \"+ New automated run\" form
- **Cross-mode link** — \"Open in Interactive\" on a run card
- **Diff preview** in run modal — \`git diff origin/develop...<branch>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)