### PR TITLE
feat(console): + New automated run — dispatch from the UI

### DIFF
--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -36,7 +36,9 @@ import {
   rejectRun,
   noteRun,
   stopRun,
+  dispatchRun,
 } from './runs.js';
+import type { DispatchOptions } from '../shared/types.js';
 import {
   attachTerminal,
   detachTerminal,
@@ -62,6 +64,7 @@ export const IPC_CHANNELS = {
   runsReject: 'ranch:runs:reject',
   runsNote: 'ranch:runs:note',
   runsStop: 'ranch:runs:stop',
+  runsDispatch: 'ranch:runs:dispatch',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -179,6 +182,29 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.runsStop, async (_event, id: unknown) => {
     if (typeof id !== 'number') throw new Error('runs.stop needs id');
     await stopRun(id);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.runsDispatch, async (_event, opts: unknown) => {
+    if (typeof opts !== 'object' || opts === null) {
+      throw new Error('runs.dispatch needs an options object');
+    }
+    const o = opts as Partial<DispatchOptions>;
+    if (typeof o.agent !== 'string' || !o.agent.trim()) {
+      throw new Error('runs.dispatch needs agent');
+    }
+    if (typeof o.ticket !== 'string' || !o.ticket.trim()) {
+      throw new Error('runs.dispatch needs ticket');
+    }
+    if (typeof o.brief !== 'string' || !o.brief.trim()) {
+      throw new Error('runs.dispatch needs brief');
+    }
+    return dispatchRun({
+      agent: o.agent,
+      ticket: o.ticket,
+      brief: o.brief,
+      free: o.free === true,
+      autoApprove: o.autoApprove === true,
+    });
   });
 
   ipcMain.handle(IPC_CHANNELS.terminalEnv, async () => getTerminalEnv());

--- a/console/src/main/runs.ts
+++ b/console/src/main/runs.ts
@@ -92,6 +92,67 @@ export async function stopRun(id: number): Promise<void> {
   await runRanchCli(['stop', String(id)]);
 }
 
+export interface DispatchOptions {
+  agent: string;
+  ticket: string;
+  brief: string;
+  free?: boolean;
+  autoApprove?: boolean;
+}
+
+export interface DispatchResult {
+  ok: boolean;
+  runId?: number;
+  output: string;
+}
+
+/** Parse "Dispatched run #42 (...)" or similar from the CLI's stdout. */
+function extractRunId(output: string): number | undefined {
+  const m = /(?:run\s*#?|#)(\d+)/i.exec(output);
+  if (m) {
+    const id = Number.parseInt(m[1]!, 10);
+    if (Number.isFinite(id) && id > 0) return id;
+  }
+  return undefined;
+}
+
+export async function dispatchRun(
+  opts: DispatchOptions,
+): Promise<DispatchResult> {
+  if (!opts.agent || !opts.ticket || !opts.brief.trim()) {
+    return {
+      ok: false,
+      output: 'agent, ticket, and brief are all required',
+    };
+  }
+  const args = [
+    'dispatch',
+    opts.agent,
+    '--ticket',
+    opts.ticket,
+    '--brief',
+    opts.brief,
+  ];
+  if (opts.free) args.push('--free');
+  if (opts.autoApprove) args.push('--auto-approve');
+
+  try {
+    const { stdout } = await runRanchCli(args);
+    const result: DispatchResult = { ok: true, output: stdout };
+    const runId = extractRunId(stdout);
+    if (runId !== undefined) result.runId = runId;
+    return result;
+  } catch (err) {
+    const stderr =
+      err && typeof err === 'object' && 'stderr' in err
+        ? String((err as { stderr: unknown }).stderr ?? '')
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { ok: false, output: stderr };
+  }
+}
+
 async function query(sql: string): Promise<unknown[]> {
   if (!existsSync(DB_PATH)) return [];
   const { stdout } = await execFile('/usr/bin/sqlite3', [

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -38,6 +38,7 @@ const IPC_CHANNELS = {
   runsReject: 'ranch:runs:reject',
   runsNote: 'ranch:runs:note',
   runsStop: 'ranch:runs:stop',
+  runsDispatch: 'ranch:runs:dispatch',
   terminalEnv: 'ranch:terminal:env',
   terminalAttach: 'ranch:terminal:attach',
   terminalWrite: 'ranch:terminal:write',
@@ -104,6 +105,7 @@ const api: RanchApi = {
       ipcRenderer.invoke(IPC_CHANNELS.runsReject, id, reason),
     note: (id, text) => ipcRenderer.invoke(IPC_CHANNELS.runsNote, id, text),
     stop: (id) => ipcRenderer.invoke(IPC_CHANNELS.runsStop, id),
+    dispatch: (opts) => ipcRenderer.invoke(IPC_CHANNELS.runsDispatch, opts),
   },
   terminal: {
     env: () => ipcRenderer.invoke(IPC_CHANNELS.terminalEnv),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type FormEvent,
   type ReactNode,
 } from 'react';
 import type {
@@ -358,6 +359,17 @@ function AutomatedView(): JSX.Element {
   const [filter, setFilter] = useState<RunFilter>('active');
   const [cleaningUp, setCleaningUp] = useState(false);
   const [cleanupResult, setCleanupResult] = useState<string | null>(null);
+  const [dispatchOpen, setDispatchOpen] = useState(false);
+
+  async function refreshList(): Promise<void> {
+    try {
+      const list = await window.ranch.runs.list(100);
+      setRuns(list);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -447,6 +459,14 @@ function AutomatedView(): JSX.Element {
         <div className="automated__top-row">
           <h2>Automated runs</h2>
           <div className="automated__top-actions">
+            <button
+              type="button"
+              className="automated__dispatch-btn"
+              onClick={() => setDispatchOpen(true)}
+              title="Dispatch a new automated run via ranch dispatch"
+            >
+              + New automated run
+            </button>
             {abandonedCount > 0 && (
               <button
                 type="button"
@@ -565,6 +585,202 @@ function AutomatedView(): JSX.Element {
           onClose={() => setSelectedId(null)}
         />
       )}
+
+      {dispatchOpen && (
+        <DispatchModal
+          onClose={() => setDispatchOpen(false)}
+          onDispatched={() => {
+            setDispatchOpen(false);
+            void refreshList();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ─── Dispatch modal ───────────────────────────────────────────
+
+function DispatchModal({
+  onClose,
+  onDispatched,
+}: {
+  onClose: () => void;
+  onDispatched: (runId?: number) => void;
+}): JSX.Element {
+  const [agents, setAgents] = useState<string[] | null>(null);
+  const [agent, setAgent] = useState<string>('');
+  const [ticket, setTicket] = useState('');
+  const [brief, setBrief] = useState('');
+  const [free, setFree] = useState(false);
+  const [autoApprove, setAutoApprove] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Pull registered agents so the operator picks from a list, not types
+  // a name and risks a typo.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const cfg = await window.ranch.config.get();
+        if (cancelled) return;
+        const names = cfg.agents.map((a) => a.name);
+        setAgents(names);
+        if (names[0]) setAgent(names[0]);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function submit(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    if (busy) return;
+    if (!agent || !ticket.trim() || !brief.trim()) {
+      setError('agent, ticket, and brief are all required');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await window.ranch.runs.dispatch({
+        agent,
+        ticket: ticket.trim(),
+        brief: brief.trim(),
+        free,
+        autoApprove,
+      });
+      if (!result.ok) {
+        const tail = result.output.trim().slice(-400);
+        setError(tail || 'dispatch failed (no output)');
+        return;
+      }
+      onDispatched(result.runId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="run-modal__backdrop" onClick={onClose}>
+      <div className="run-modal" onClick={(e) => e.stopPropagation()}>
+        <header className="run-modal__head">
+          <h3>New automated run</h3>
+          <button
+            type="button"
+            className="run-modal__close"
+            onClick={onClose}
+            disabled={busy}
+          >
+            ✕
+          </button>
+        </header>
+        <form className="run-modal__body dispatch-form" onSubmit={submit}>
+          <label className="dispatch-form__field">
+            <span className="dispatch-form__label">Agent</span>
+            {agents === null ? (
+              <span className="placeholder">loading…</span>
+            ) : agents.length === 0 ? (
+              <span className="placeholder placeholder--error">
+                No agents registered in ~/.ranch/config.toml
+              </span>
+            ) : (
+              <select
+                value={agent}
+                onChange={(e) => setAgent(e.target.value)}
+                disabled={busy}
+                className="dispatch-form__input"
+              >
+                {agents.map((a) => (
+                  <option key={a} value={a}>
+                    {a}
+                  </option>
+                ))}
+              </select>
+            )}
+          </label>
+
+          <label className="dispatch-form__field">
+            <span className="dispatch-form__label">Ticket</span>
+            <input
+              type="text"
+              value={ticket}
+              onChange={(e) => setTicket(e.target.value)}
+              placeholder="ECD-1234"
+              disabled={busy}
+              className="dispatch-form__input"
+              autoFocus
+            />
+          </label>
+
+          <label className="dispatch-form__field">
+            <span className="dispatch-form__label">Brief</span>
+            <textarea
+              value={brief}
+              onChange={(e) => setBrief(e.target.value)}
+              placeholder="What should the agent do? Plain text or markdown."
+              disabled={busy}
+              rows={6}
+              className="dispatch-form__input dispatch-form__input--textarea"
+            />
+          </label>
+
+          <div className="dispatch-form__toggles">
+            <label className="dispatch-form__toggle">
+              <input
+                type="checkbox"
+                checked={free}
+                onChange={(e) => setFree(e.target.checked)}
+                disabled={busy}
+              />
+              <span>
+                <strong>Free mode</strong> — skip the plan→push checkpoint
+                workflow. The brief becomes the whole instruction.
+              </span>
+            </label>
+            <label className="dispatch-form__toggle">
+              <input
+                type="checkbox"
+                checked={autoApprove}
+                onChange={(e) => setAutoApprove(e.target.checked)}
+                disabled={busy}
+              />
+              <span>
+                <strong>Auto-approve</strong> — auto-approve every checkpoint.
+                Use with care; combine with free mode for fully unattended.
+              </span>
+            </label>
+          </div>
+
+          {error && <pre className="dispatch-form__error">{error}</pre>}
+
+          <div className="dispatch-form__buttons">
+            <button
+              type="button"
+              className="run-action"
+              onClick={onClose}
+              disabled={busy}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="run-action run-action--approve"
+              disabled={busy || agents === null || agents.length === 0}
+            >
+              {busy ? 'Dispatching…' : 'Dispatch'}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -1074,6 +1074,26 @@ body,
   gap: 0.5rem;
 }
 
+.automated__dispatch-btn {
+  background: rgba(106, 162, 255, 0.15);
+  color: var(--accent);
+  border: 1px solid rgba(106, 162, 255, 0.4);
+  border-radius: 6px;
+  padding: 0.3rem 0.85rem;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    border-color 0.12s ease,
+    background 0.12s ease;
+}
+
+.automated__dispatch-btn:hover {
+  background: rgba(106, 162, 255, 0.22);
+  border-color: var(--accent);
+}
+
 .automated__cleanup-btn {
   background: var(--bg);
   color: var(--text-muted);
@@ -1442,6 +1462,99 @@ body,
 .docker-actions {
   display: flex;
   gap: 0.4rem;
+}
+
+/* ─── Dispatch form (modal) ─────────────────────────── */
+
+.dispatch-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.dispatch-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.dispatch-form__label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.dispatch-form__input {
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  border-radius: 4px;
+  padding: 0.4rem 0.55rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-family: inherit;
+  outline: none;
+}
+
+.dispatch-form__input:focus {
+  border-color: var(--accent);
+}
+
+.dispatch-form__input--textarea {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  resize: vertical;
+  min-height: 6rem;
+  line-height: 1.5;
+}
+
+.dispatch-form__toggles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dispatch-form__toggle {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem;
+  align-items: start;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.dispatch-form__toggle input {
+  margin-top: 0.2rem;
+}
+
+.dispatch-form__toggle strong {
+  color: var(--text);
+}
+
+.dispatch-form__error {
+  margin: 0;
+  background: rgba(255, 106, 106, 0.08);
+  color: var(--red);
+  border: 1px solid rgba(255, 106, 106, 0.3);
+  border-radius: 4px;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.72rem;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 12rem;
+  overflow-y: auto;
+}
+
+.dispatch-form__buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  margin-top: 0.25rem;
 }
 
 .detail__pr-link {

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -301,6 +301,22 @@ export interface RunDetail extends RunRecord {
   interjections: RunInterjection[];
 }
 
+export interface DispatchOptions {
+  agent: string;
+  ticket: string;
+  brief: string;
+  free?: boolean;
+  autoApprove?: boolean;
+}
+
+export interface DispatchResult {
+  ok: boolean;
+  /** Parsed from CLI stdout, when matchable. */
+  runId?: number;
+  /** stdout on success, stderr on failure. */
+  output: string;
+}
+
 // ─── Terminal (MVP-6) ────────────────────────────────────────────────────
 
 export interface TerminalEnv {
@@ -374,6 +390,7 @@ export interface RanchApi {
     reject: (id: number, reason?: string) => Promise<void>;
     note: (id: number, text: string) => Promise<void>;
     stop: (id: number) => Promise<void>;
+    dispatch: (opts: DispatchOptions) => Promise<DispatchResult>;
   };
   terminal: {
     env: () => Promise<TerminalEnv>;


### PR DESCRIPTION
## Summary

Closes the loop: \"how do I trigger an automated run from the app?\" Adds a **+ New automated run** button in the Automated view header → opens a form modal that calls \`ranch dispatch\` for you.

## Form fields

| Field | Type | Required | Notes |
|---|---|---|---|
| Agent | \`<select>\` of registered agents | yes | Pulled from \`~/.ranch/config.toml\` so you can't typo a name |
| Ticket | text | yes | e.g. \`ECD-1234\` |
| Brief | textarea | yes | Plain text or markdown |
| Free mode | checkbox | no | Skip plan→push checkpoints — brief becomes the whole instruction |
| Auto-approve | checkbox | no | Auto-approve every checkpoint. Combine with Free mode for fully unattended runs |

Submit shells out to:

\`\`\`
ranch dispatch <agent> --ticket <id> --brief <text> [--free] [--auto-approve]
\`\`\`

## UX details

- Form errors stay in the modal — stderr from the CLI is rendered as a code block so you see exactly what went wrong
- Success closes the modal and refreshes the runs list; the new run appears within ~5s
- Best-effort parsing of the run id from CLI stdout, but the list refresh is the actual source of truth
- Modal cancel + close button disabled while dispatching, so you can't double-submit

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Switch to Automated → header shows \"+ New automated run\" button
- [ ] Click → modal opens with Agent dropdown populated (jeffy / arnold / max / kesha), empty ticket + brief
- [ ] Submit with empty fields → error message; no dispatch
- [ ] Fill agent + ticket=TEST-1 + brief=\"hello world\" → submit → modal closes; new run appears in Active list
- [ ] Try a deliberately bad agent name (edit a select with devtools) — error from \`ranch dispatch\` rendered in form
- [ ] Try a real one with --free + --auto-approve → run progresses without checkpoints

## What's next

- **Cross-mode link** — \"Open in Interactive\" on a run card → flips to Interactive tab focused on that agent
- **Diff preview** — \`git diff origin/develop...<branch>\` rendered in the run modal so you can scan changes inline before opening the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)