### PR TITLE
feat(console): Reset (wipe) — clean-slate docker stack recreate

### DIFF
--- a/console/src/main/docker.ts
+++ b/console/src/main/docker.ts
@@ -349,6 +349,59 @@ export async function dockerStackRestart(
   return composeRun(agent, worktreePath, ['restart'], false, existing);
 }
 
+/**
+ * Wipe and recreate an agent's stack. Equivalent to:
+ *
+ *   docker compose -p <project> down -v   (-v removes named volumes,
+ *                                           which is the data wipe)
+ *   docker compose --env-file ... -f ... -p <project> up -d
+ *
+ * Destructive: kills containers AND removes their volumes (Postgres
+ * data, Redis state, anything else volume-backed). The next up
+ * recreates containers with empty volumes.
+ *
+ * Returns the combined output of both phases. If down fails, up is
+ * skipped and the caller sees the down error.
+ */
+export async function dockerStackReset(
+  agent: string,
+  worktreePath: string,
+): Promise<ComposeRunResult> {
+  // Detect existing project name (citemed_<agent> vs bare <agent>) so
+  // the down phase actually finds something to remove.
+  const existing = await findActiveProjectForAgent(agent);
+  if (existing) {
+    const downResult = await composeRun(
+      agent,
+      worktreePath,
+      ['down', '-v'],
+      false,
+      existing,
+    );
+    if (!downResult.ok) {
+      return {
+        ok: false,
+        stdout: downResult.stdout,
+        stderr: `[reset:down] ${downResult.stderr}`,
+      };
+    }
+  }
+  // Up always uses canonical project name — after a reset the operator
+  // wants the cleanly-prefixed stack going forward.
+  const upResult = await composeRun(
+    agent,
+    worktreePath,
+    ['up', '-d'],
+    true,
+    `citemed_${agent}`,
+  );
+  return {
+    ok: upResult.ok,
+    stdout: upResult.stdout,
+    stderr: upResult.ok ? '' : `[reset:up] ${upResult.stderr}`,
+  };
+}
+
 export async function dockerStackLogs(
   agent: string,
   worktreePath: string,

--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -25,6 +25,7 @@ import {
   dockerStackUp,
   dockerStackDown,
   dockerStackRestart,
+  dockerStackReset,
   dockerStackLogs,
 } from './docker.js';
 import { getAllNotes, setNote } from './notes.js';
@@ -84,6 +85,7 @@ export const IPC_CHANNELS = {
   dockerUp: 'ranch:docker:up',
   dockerDown: 'ranch:docker:down',
   dockerRestart: 'ranch:docker:restart',
+  dockerReset: 'ranch:docker:reset',
   dockerLogs: 'ranch:docker:logs',
 } as const;
 
@@ -336,6 +338,11 @@ export function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.dockerRestart, async (_event, agent: unknown) => {
     const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
     return dockerStackRestart(a, worktreePath);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.dockerReset, async (_event, agent: unknown) => {
+    const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
+    return dockerStackReset(a, worktreePath);
   });
 
   ipcMain.handle(

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -56,6 +56,7 @@ const IPC_CHANNELS = {
   dockerUp: 'ranch:docker:up',
   dockerDown: 'ranch:docker:down',
   dockerRestart: 'ranch:docker:restart',
+  dockerReset: 'ranch:docker:reset',
   dockerLogs: 'ranch:docker:logs',
 } as const;
 
@@ -139,6 +140,7 @@ const api: RanchApi = {
     up: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerUp, agent),
     down: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerDown, agent),
     restart: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerRestart, agent),
+    reset: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerReset, agent),
     logs: (agent, tail) =>
       ipcRenderer.invoke(IPC_CHANNELS.dockerLogs, agent, tail),
   },

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -2007,6 +2007,20 @@ function DockerSection({
   async function handleRestart(): Promise<void> {
     await withBusy('Restart', () => window.ranch.docker.restart(agent));
   }
+  async function handleReset(): Promise<void> {
+    if (
+      !window.confirm(
+        `Reset (clean-slate recreate) docker stack for ${agent}?\n\n` +
+          'This is destructive:\n' +
+          '  • all containers stopped and removed\n' +
+          '  • named volumes WIPED — Postgres data, Redis state, etc.\n' +
+          '  • stack recreated empty (you will need to re-run migrations / seed)\n\n' +
+          'Use this when the stack is wedged and a clean restart is what you actually want.',
+      )
+    )
+      return;
+    await withBusy('Reset', () => window.ranch.docker.reset(agent));
+  }
 
   const running = containers.filter((c) => c.state === 'running').length;
   const total = containers.length;
@@ -2076,6 +2090,15 @@ function DockerSection({
           title="docker compose down (stops and removes containers)"
         >
           {busy === 'Down' ? '…' : 'Down'}
+        </button>
+        <button
+          type="button"
+          className="run-action run-action--reset"
+          onClick={handleReset}
+          disabled={!available || busy !== null}
+          title="down -v + up — wipes volumes (destroys Postgres/Redis data) and recreates fresh"
+        >
+          {busy === 'Reset' ? '…' : 'Reset (wipe)'}
         </button>
       </div>
       {msg && <p className="run-modal__action-msg">{msg}</p>}

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -1407,6 +1407,16 @@ body,
   border-color: var(--red);
 }
 
+.run-action--reset {
+  background: rgba(246, 193, 119, 0.1);
+  color: var(--yellow);
+  border-color: rgba(246, 193, 119, 0.3);
+}
+.run-action--reset:hover:not(:disabled) {
+  background: rgba(246, 193, 119, 0.18);
+  border-color: var(--yellow);
+}
+
 /* ─── Docker badge (cell header) ──────────────────── */
 
 .docker-badge {

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -426,6 +426,8 @@ export interface RanchApi {
     up: (agent: string) => Promise<ComposeRunResult>;
     down: (agent: string) => Promise<ComposeRunResult>;
     restart: (agent: string) => Promise<ComposeRunResult>;
+    /** Down with -v (wipes volumes) then Up — clean-slate recreate. */
+    reset: (agent: string) => Promise<ComposeRunResult>;
     logs: (agent: string, tail?: number) => Promise<ComposeRunResult>;
   };
 }


### PR DESCRIPTION
## Summary

Adds a **Reset (wipe)** button to each agent's docker section in the sidebar — clean-slate recreate when the stack is wedged and Down + Up isn't enough.

## What it does

Two-phase:

1. \`docker compose -p <project> down -v\` — removes containers AND named volumes (Postgres data, Redis state, anything volume-backed). Uses the *actually-running* project name (\`max\` vs \`citemed_max\` drift handled).
2. \`docker compose --env-file ... -f ... -p citemed_<agent> up -d\` — recreates from the agent's compose files. Always uses canonical project name; after Reset the stack lands on the prefixed name regardless of past drift.

## UX

- Yellow button styling (warns without screaming)
- Native \`confirm()\` dialog spells out the consequences:
  - all containers stopped + removed
  - named volumes WIPED — DB rows, cache, ephemeral state gone
  - stack recreated empty (operator runs migrations / seed afterwards)
- Toast under the buttons reports success or trimmed stderr tail

## When to use vs Down + Up

- **Down + Up** preserves volumes. The DB rows you had stay. Use for normal restart.
- **Reset (wipe)** destroys data. Use when state is the problem (corrupt schema, bad migration, polluted Redis, etc.) and you want truly fresh.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Open detail sidebar on an agent with a running stack → Docker section now shows four buttons: Up · Restart · Down · Reset (wipe)
- [ ] Click Reset → confirm dialog explains exactly what happens
- [ ] Cancel → no-op
- [ ] Confirm → containers cycle (down then up); after a few seconds badge returns to green and services list repopulates
- [ ] If you had DB rows before, they're gone (run a SELECT to verify)

## What's next

Per the earlier plan: \"Add new ranchhand\" — the bigger admin op for registering a new agent (worktree creation, port allocation, .env.agent generation, schema setup). Probably wraps citemed_web's \`make init-agent\`. Want me to draft a spec or just build it?

🤖 Generated with [Claude Code](https://claude.com/claude-code)