### PR TITLE
feat(console): per-agent docker compose config + transparent file paths

### DIFF
--- a/console/src/main/config.ts
+++ b/console/src/main/config.ts
@@ -18,6 +18,7 @@ interface AgentSection {
   worktree?: unknown;
   description?: unknown;
   ports?: unknown;
+  docker?: unknown;
 }
 
 function parsePortsBlock(raw: unknown): WorktreePorts | undefined {
@@ -28,6 +29,26 @@ function parsePortsBlock(raw: unknown): WorktreePorts | undefined {
     if (typeof v === 'number' && Number.isFinite(v) && v > 0 && v < 65536) {
       out[key] = v;
     }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function parseDockerBlock(raw: unknown): AgentConfig['docker'] | undefined {
+  if (!isObject(raw)) return undefined;
+  const out: NonNullable<AgentConfig['docker']> = {};
+  // Accept both kebab and snake key names for forgiveness.
+  const filesRaw =
+    raw['compose_files'] ?? raw['composeFiles'] ?? raw['compose-files'];
+  if (Array.isArray(filesRaw)) {
+    const files = filesRaw.filter((s): s is string => typeof s === 'string');
+    if (files.length > 0) out.composeFiles = files;
+  }
+  const envFile = raw['env_file'] ?? raw['envFile'] ?? raw['env-file'];
+  if (typeof envFile === 'string' && envFile.length > 0) out.envFile = envFile;
+  const project =
+    raw['project_name'] ?? raw['projectName'] ?? raw['project-name'];
+  if (typeof project === 'string' && project.length > 0) {
+    out.projectName = project;
   }
   return Object.keys(out).length > 0 ? out : undefined;
 }
@@ -61,6 +82,8 @@ function parseAgents(raw: unknown): AgentConfig[] {
     }
     const ports = parsePortsBlock(section.ports);
     if (ports !== undefined) agent.ports = ports;
+    const docker = parseDockerBlock(section.docker);
+    if (docker !== undefined) agent.docker = docker;
     agents.push(agent);
   }
   return agents;

--- a/console/src/main/docker.ts
+++ b/console/src/main/docker.ts
@@ -19,6 +19,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import type {
+  AgentDockerConfig,
   DockerContainer,
   DockerEnv,
   DockerStackSnapshot,
@@ -49,6 +50,39 @@ async function findDocker(): Promise<string | null> {
     cachedDockerPath = null;
     return null;
   }
+}
+
+/**
+ * Introspect what compose files + project name we'd actually use for
+ * an agent. Surfaced in the sidebar so the operator sees exactly what
+ * docker compose calls are being made — and notices if a path is missing.
+ */
+export interface ResolvedAgentDocker {
+  projectName: string;
+  composeFiles: string[];
+  envFile: string | null;
+  /** True if at least one configured compose file is missing on disk. */
+  missingFiles: string[];
+}
+
+export function resolveAgentDocker(
+  agent: string,
+  worktreePath: string,
+  dockerConfig?: AgentDockerConfig,
+): ResolvedAgentDocker {
+  const projectName = dockerConfig?.projectName ?? `citemed_${agent}`;
+  const wanted = dockerConfig?.composeFiles ?? DEFAULT_COMPOSE_FILES;
+  const composeFiles: string[] = [];
+  const missingFiles: string[] = [];
+  for (const name of wanted) {
+    const p = join(worktreePath, name);
+    if (existsSync(p)) composeFiles.push(p);
+    else missingFiles.push(p);
+  }
+  const envFileName = dockerConfig?.envFile ?? DEFAULT_ENV_FILE;
+  const envPath = join(worktreePath, envFileName);
+  const envFile = existsSync(envPath) ? envPath : null;
+  return { projectName, composeFiles, envFile, missingFiles };
 }
 
 export async function getDockerEnv(): Promise<DockerEnv> {
@@ -226,20 +260,42 @@ export async function snapshotDockerState(
 
 // ─── Lifecycle ───────────────────────────────────────────────
 
-interface ComposeFiles {
-  composeFile: string;
-  agentComposeFile: string;
-  envFile: string;
+/** What we'll actually pass to `docker compose -f <…>` after resolution. */
+export interface ResolvedComposeConfig {
+  /** Absolute paths, in order, of compose files that exist. */
+  composeFiles: string[];
+  /** Absolute path to .env-style file, if it exists. */
+  envFile: string | null;
 }
 
-function resolveComposeFiles(worktreePath: string): ComposeFiles | null {
-  const composeFile = join(worktreePath, 'docker-compose.yml');
-  const agentComposeFile = join(worktreePath, 'docker-compose.agent.yml');
-  const envFile = join(worktreePath, '.env.agent');
-  // We need at least the base compose file. agent override + env are
-  // expected for citemed_web but soft-fail on simpler projects.
-  if (!existsSync(composeFile)) return null;
-  return { composeFile, agentComposeFile, envFile };
+const DEFAULT_COMPOSE_FILES = [
+  'docker-compose.yml',
+  'docker-compose.agent.yml',
+];
+const DEFAULT_ENV_FILE = '.env.agent';
+
+/**
+ * Resolve which compose files + env file to use for an agent. Per-agent
+ * `docker` block in ~/.ranch/config.toml wins; otherwise we fall back
+ * to citemed_web's convention. Files that don't exist on disk are
+ * silently dropped from the list — operator sees what we actually used
+ * via the sidebar's "Compose files" caption.
+ */
+export function resolveComposeFiles(
+  worktreePath: string,
+  config?: AgentDockerConfig,
+): ResolvedComposeConfig | null {
+  const fileNames = config?.composeFiles ?? DEFAULT_COMPOSE_FILES;
+  const composeFiles = fileNames
+    .map((name) => join(worktreePath, name))
+    .filter((p) => existsSync(p));
+  if (composeFiles.length === 0) return null;
+
+  const envFileName = config?.envFile ?? DEFAULT_ENV_FILE;
+  const envPath = join(worktreePath, envFileName);
+  const envFile = existsSync(envPath) ? envPath : null;
+
+  return { composeFiles, envFile };
 }
 
 interface ComposeRunResult {
@@ -254,29 +310,30 @@ async function composeRun(
   args: string[],
   needsFiles: boolean,
   projectOverride?: string,
+  dockerConfig?: AgentDockerConfig,
 ): Promise<ComposeRunResult> {
   const dockerPath = await findDocker();
   if (!dockerPath) {
     return { ok: false, stdout: '', stderr: 'docker not installed' };
   }
-  const project = projectOverride ?? `citemed_${agent}`;
+  const project =
+    projectOverride ?? dockerConfig?.projectName ?? `citemed_${agent}`;
   const composeArgs: string[] = ['compose'];
 
   if (needsFiles) {
-    const files = resolveComposeFiles(worktreePath);
+    const files = resolveComposeFiles(worktreePath, dockerConfig);
     if (!files) {
       return {
         ok: false,
         stdout: '',
-        stderr: `no docker-compose.yml found at ${worktreePath}`,
+        stderr: `no compose files found at ${worktreePath}. Configure via ~/.ranch/config.toml: [agents.<name>.docker].compose_files`,
       };
     }
-    if (existsSync(files.envFile)) {
+    if (files.envFile) {
       composeArgs.push('--env-file', files.envFile);
     }
-    composeArgs.push('-f', files.composeFile);
-    if (existsSync(files.agentComposeFile)) {
-      composeArgs.push('-f', files.agentComposeFile);
+    for (const f of files.composeFiles) {
+      composeArgs.push('-f', f);
     }
   }
 
@@ -303,6 +360,7 @@ async function composeRun(
 export async function dockerStackUp(
   agent: string,
   worktreePath: string,
+  dockerConfig?: AgentDockerConfig,
 ): Promise<ComposeRunResult> {
   // For up: prefer existing project name if there's already a stack
   // running for this agent. Avoids creating a duplicate (e.g. canonical
@@ -314,12 +372,14 @@ export async function dockerStackUp(
     ['up', '-d'],
     true,
     existing ?? undefined,
+    dockerConfig,
   );
 }
 
 export async function dockerStackDown(
   agent: string,
   worktreePath: string,
+  dockerConfig?: AgentDockerConfig,
 ): Promise<ComposeRunResult> {
   // Detect the actual project so we don't issue a no-op `down` against
   // the wrong project name.
@@ -331,12 +391,20 @@ export async function dockerStackDown(
       stderr: '',
     };
   }
-  return composeRun(agent, worktreePath, ['down'], false, existing);
+  return composeRun(
+    agent,
+    worktreePath,
+    ['down'],
+    false,
+    existing,
+    dockerConfig,
+  );
 }
 
 export async function dockerStackRestart(
   agent: string,
   worktreePath: string,
+  dockerConfig?: AgentDockerConfig,
 ): Promise<ComposeRunResult> {
   const existing = await findActiveProjectForAgent(agent);
   if (!existing) {
@@ -346,7 +414,14 @@ export async function dockerStackRestart(
       stderr: 'no active stack to restart — bring it Up first',
     };
   }
-  return composeRun(agent, worktreePath, ['restart'], false, existing);
+  return composeRun(
+    agent,
+    worktreePath,
+    ['restart'],
+    false,
+    existing,
+    dockerConfig,
+  );
 }
 
 /**
@@ -366,9 +441,8 @@ export async function dockerStackRestart(
 export async function dockerStackReset(
   agent: string,
   worktreePath: string,
+  dockerConfig?: AgentDockerConfig,
 ): Promise<ComposeRunResult> {
-  // Detect existing project name (citemed_<agent> vs bare <agent>) so
-  // the down phase actually finds something to remove.
   const existing = await findActiveProjectForAgent(agent);
   if (existing) {
     const downResult = await composeRun(
@@ -377,6 +451,7 @@ export async function dockerStackReset(
       ['down', '-v'],
       false,
       existing,
+      dockerConfig,
     );
     if (!downResult.ok) {
       return {
@@ -386,14 +461,16 @@ export async function dockerStackReset(
       };
     }
   }
-  // Up always uses canonical project name — after a reset the operator
-  // wants the cleanly-prefixed stack going forward.
+  // Up uses the configured project name (or canonical) — after a reset
+  // the operator wants the cleanly-named stack going forward.
+  const project = dockerConfig?.projectName ?? `citemed_${agent}`;
   const upResult = await composeRun(
     agent,
     worktreePath,
     ['up', '-d'],
     true,
-    `citemed_${agent}`,
+    project,
+    dockerConfig,
   );
   return {
     ok: upResult.ok,
@@ -406,6 +483,7 @@ export async function dockerStackLogs(
   agent: string,
   worktreePath: string,
   tail = 200,
+  dockerConfig?: AgentDockerConfig,
 ): Promise<ComposeRunResult> {
   const existing = await findActiveProjectForAgent(agent);
   return composeRun(
@@ -414,5 +492,6 @@ export async function dockerStackLogs(
     ['logs', `--tail=${tail}`, '--no-color'],
     false,
     existing ?? undefined,
+    dockerConfig,
   );
 }

--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -27,6 +27,7 @@ import {
   dockerStackRestart,
   dockerStackReset,
   dockerStackLogs,
+  resolveAgentDocker,
 } from './docker.js';
 import { getAllNotes, setNote } from './notes.js';
 import {
@@ -39,7 +40,7 @@ import {
   stopRun,
   dispatchRun,
 } from './runs.js';
-import type { DispatchOptions } from '../shared/types.js';
+import type { AgentConfig, DispatchOptions } from '../shared/types.js';
 import {
   attachTerminal,
   detachTerminal,
@@ -82,6 +83,7 @@ export const IPC_CHANNELS = {
   appOpenExternal: 'ranch:app:openExternal',
   dockerEnv: 'ranch:docker:env',
   dockerSnapshot: 'ranch:docker:snapshot',
+  dockerResolve: 'ranch:docker:resolve',
   dockerUp: 'ranch:docker:up',
   dockerDown: 'ranch:docker:down',
   dockerRestart: 'ranch:docker:restart',
@@ -315,6 +317,7 @@ export function registerIpcHandlers(): void {
   async function resolveAgentWorktree(agent: unknown): Promise<{
     agent: string;
     worktreePath: string;
+    dockerConfig: AgentConfig['docker'];
   }> {
     if (typeof agent !== 'string' || !agent) {
       throw new Error('docker call requires an agent name');
@@ -322,35 +325,68 @@ export function registerIpcHandlers(): void {
     const config = await loadRanchConfig();
     const match = config.agents.find((a) => a.name === agent);
     if (!match) throw new Error(`Unknown agent: ${agent}`);
-    return { agent, worktreePath: match.worktree };
+    return {
+      agent,
+      worktreePath: match.worktree,
+      dockerConfig: match.docker,
+    };
   }
 
+  ipcMain.handle(IPC_CHANNELS.dockerResolve, async (_event, agent: unknown) => {
+    const {
+      agent: a,
+      worktreePath,
+      dockerConfig,
+    } = await resolveAgentWorktree(agent);
+    return resolveAgentDocker(a, worktreePath, dockerConfig);
+  });
+
   ipcMain.handle(IPC_CHANNELS.dockerUp, async (_event, agent: unknown) => {
-    const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
-    return dockerStackUp(a, worktreePath);
+    const {
+      agent: a,
+      worktreePath,
+      dockerConfig,
+    } = await resolveAgentWorktree(agent);
+    return dockerStackUp(a, worktreePath, dockerConfig);
   });
 
   ipcMain.handle(IPC_CHANNELS.dockerDown, async (_event, agent: unknown) => {
-    const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
-    return dockerStackDown(a, worktreePath);
+    const {
+      agent: a,
+      worktreePath,
+      dockerConfig,
+    } = await resolveAgentWorktree(agent);
+    return dockerStackDown(a, worktreePath, dockerConfig);
   });
 
   ipcMain.handle(IPC_CHANNELS.dockerRestart, async (_event, agent: unknown) => {
-    const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
-    return dockerStackRestart(a, worktreePath);
+    const {
+      agent: a,
+      worktreePath,
+      dockerConfig,
+    } = await resolveAgentWorktree(agent);
+    return dockerStackRestart(a, worktreePath, dockerConfig);
   });
 
   ipcMain.handle(IPC_CHANNELS.dockerReset, async (_event, agent: unknown) => {
-    const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
-    return dockerStackReset(a, worktreePath);
+    const {
+      agent: a,
+      worktreePath,
+      dockerConfig,
+    } = await resolveAgentWorktree(agent);
+    return dockerStackReset(a, worktreePath, dockerConfig);
   });
 
   ipcMain.handle(
     IPC_CHANNELS.dockerLogs,
     async (_event, agent: unknown, tail: unknown) => {
-      const { agent: a, worktreePath } = await resolveAgentWorktree(agent);
+      const {
+        agent: a,
+        worktreePath,
+        dockerConfig,
+      } = await resolveAgentWorktree(agent);
       const t = typeof tail === 'number' ? tail : 200;
-      return dockerStackLogs(a, worktreePath, t);
+      return dockerStackLogs(a, worktreePath, t, dockerConfig);
     },
   );
 }

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -53,6 +53,7 @@ const IPC_CHANNELS = {
   appOpenExternal: 'ranch:app:openExternal',
   dockerEnv: 'ranch:docker:env',
   dockerSnapshot: 'ranch:docker:snapshot',
+  dockerResolve: 'ranch:docker:resolve',
   dockerUp: 'ranch:docker:up',
   dockerDown: 'ranch:docker:down',
   dockerRestart: 'ranch:docker:restart',
@@ -137,6 +138,7 @@ const api: RanchApi = {
   docker: {
     env: () => ipcRenderer.invoke(IPC_CHANNELS.dockerEnv),
     snapshot: () => ipcRenderer.invoke(IPC_CHANNELS.dockerSnapshot),
+    resolve: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerResolve, agent),
     up: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerUp, agent),
     down: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerDown, agent),
     restart: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerRestart, agent),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -13,6 +13,7 @@ import type {
   DockerContainer,
   DockerStackSnapshot,
   ProcessSnapshot,
+  ResolvedAgentDocker,
   RunDetail,
   RunRecord,
   RunStatus,
@@ -1964,6 +1965,24 @@ function DockerSection({
   setBusy: (v: string | null) => void;
   setMsg: (v: string | null) => void;
 }): JSX.Element {
+  const [resolved, setResolved] = useState<ResolvedAgentDocker | null>(null);
+
+  // Pull the resolved compose config so the operator sees what files
+  // ranch actually called docker compose with — and notices missing ones.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const r = await window.ranch.docker.resolve(agent);
+        if (!cancelled) setResolved(r);
+      } catch {
+        // ignore — section just won't show the caption
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agent]);
   function flash(text: string): void {
     setMsg(text);
     setTimeout(() => setMsg(null), 4000);
@@ -2102,8 +2121,60 @@ function DockerSection({
         </button>
       </div>
       {msg && <p className="run-modal__action-msg">{msg}</p>}
+      {resolved && (
+        <div className="docker-config">
+          <p className="docker-config__line">
+            <span className="docker-config__label">project</span>
+            <code>{resolved.projectName}</code>
+          </p>
+          <p className="docker-config__line">
+            <span className="docker-config__label">files</span>
+            <span className="docker-config__paths">
+              {resolved.composeFiles.length === 0 ? (
+                <em>none found</em>
+              ) : (
+                resolved.composeFiles.map((p) => (
+                  <code key={p} title={p}>
+                    {shortenPath(p)}
+                  </code>
+                ))
+              )}
+            </span>
+          </p>
+          {resolved.envFile && (
+            <p className="docker-config__line">
+              <span className="docker-config__label">env</span>
+              <code title={resolved.envFile}>
+                {shortenPath(resolved.envFile)}
+              </code>
+            </p>
+          )}
+          {resolved.missingFiles.length > 0 && (
+            <p className="docker-config__warn">
+              ⚠ configured but missing:{' '}
+              {resolved.missingFiles.map((p) => (
+                <code key={p} title={p}>
+                  {shortenPath(p)}
+                </code>
+              ))}
+            </p>
+          )}
+          <p className="docker-config__hint">
+            Override per-agent in <code>~/.ranch/config.toml</code> →{' '}
+            <code>[agents.{agent}.docker]</code>
+          </p>
+        </div>
+      )}
     </DetailSection>
   );
+}
+
+function shortenPath(p: string): string {
+  // Show just the last two segments (worktree dir + file name) so the
+  // caption is readable. Hover tooltip shows the full path.
+  const parts = p.split('/').filter(Boolean);
+  if (parts.length <= 2) return p;
+  return '…/' + parts.slice(-2).join('/');
 }
 
 /**

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -1522,6 +1522,63 @@ body,
   gap: 0.4rem;
 }
 
+.docker-config {
+  margin-top: 0.4rem;
+  padding: 0.45rem 0.55rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.7rem;
+}
+
+.docker-config__line {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 4rem 1fr;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.docker-config__label {
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.62rem;
+}
+
+.docker-config__paths {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.docker-config code {
+  background: var(--bg-elevated);
+  padding: 0 0.3rem;
+  border-radius: 2px;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 0.92em;
+  color: var(--text);
+}
+
+.docker-config__warn {
+  margin: 0.1rem 0 0;
+  color: var(--yellow);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.docker-config__hint {
+  margin: 0.15rem 0 0;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
 /* ─── Dispatch form (modal) ─────────────────────────── */
 
 .dispatch-form {

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -22,6 +22,25 @@ export interface AgentConfig {
    * these and warns if .env.agent disagrees.
    */
   ports?: WorktreePorts;
+  /**
+   * Per-agent docker compose configuration. Optional — if absent we
+   * default to the citemed_web convention:
+   *   compose_files = ["docker-compose.yml", "docker-compose.agent.yml"]
+   *   env_file      = ".env.agent"
+   * Paths are relative to the worktree root.
+   */
+  docker?: AgentDockerConfig;
+}
+
+export interface AgentDockerConfig {
+  composeFiles?: string[];
+  envFile?: string;
+  /**
+   * Override the compose `-p` project name. Defaults to `citemed_<agent>`.
+   * Useful when an agent's stack has historically used a different name
+   * and you want to pin to that.
+   */
+  projectName?: string;
 }
 
 export interface ProjectConfig {
@@ -213,6 +232,16 @@ export interface DockerStackSnapshot {
   perAgent: Record<string, DockerContainer[]>;
   /** citemed_shared stack (postgres, redis, etc.) */
   shared: DockerContainer[];
+}
+
+/** What ranch will actually pass to `docker compose` for an agent. */
+export interface ResolvedAgentDocker {
+  projectName: string;
+  /** Absolute paths of compose files that exist on disk. */
+  composeFiles: string[];
+  envFile: string | null;
+  /** Configured paths that did NOT resolve — surfaced as warnings. */
+  missingFiles: string[];
 }
 
 export interface ComposeRunResult {
@@ -423,6 +452,8 @@ export interface RanchApi {
     env: () => Promise<DockerEnv>;
     /** Fleet snapshot — one `docker ps` per call, all agents + shared. */
     snapshot: () => Promise<DockerStackSnapshot>;
+    /** What compose files + project name ranch will use for this agent. */
+    resolve: (agent: string) => Promise<ResolvedAgentDocker>;
     up: (agent: string) => Promise<ComposeRunResult>;
     down: (agent: string) => Promise<ComposeRunResult>;
     restart: (agent: string) => Promise<ComposeRunResult>;


### PR DESCRIPTION
## Summary

Two related fixes to your question \"what compose file are we actually reading?\":

### 1. Per-agent docker configuration

Adds an optional \`docker\` block to each agent in \`~/.ranch/config.toml\`:

\`\`\`toml
[agents.max]
worktree = \"/Users/.../max\"
ports = { django = 8003, vite = 3003 }

[agents.max.docker]
compose_files = [\"docker-compose.yml\", \"docker-compose.agent.yml\"]
env_file      = \".env.agent\"
project_name  = \"citemed_max\"   # optional, defaults to citemed_<agent>
\`\`\`

When absent, defaults to citemed_web's convention so existing setups keep working. All five lifecycle ops (up / down / restart / reset / logs) honor the override.

### 2. Transparency in the sidebar

The Docker section now shows a small caption with the resolved configuration so you see exactly what \`docker compose\` was called with:

\`\`\`
project  citemed_max
files    …/max/docker-compose.yml
         …/max/docker-compose.agent.yml
env      …/max/.env.agent
\`\`\`

Plus a hint pointing at the config block for overrides. Configured-but-missing files show up as a yellow warning so misconfiguration is loud.

Hover any path → tooltip with the absolute path.

## Why this matters for your setup

Each ranch hand stack is **web + celery + celery-beat** (defined in `docker-compose.agent.yml`). Shared **postgres + redis** live in `citemed_shared`, which the user manages separately via `make infra-up`. We're already reading the shared stack in the snapshot but don't surface it in the UI yet — that's the next gap (a fleet-wide Shared Infra panel).

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Open Detail sidebar for max → Docker section shows project name + compose files + env path with shortened display + hover tooltip for full path
- [ ] Edit \`~/.ranch/config.toml\` to override max's docker block (e.g. add a third compose file or change project name)
- [ ] Restart pnpm dev (config is loaded on each call) → caption reflects the override
- [ ] If you point at a non-existent file in compose_files, it shows up under \"⚠ configured but missing\"

## What's next on the docker track

- **Shared Infra panel** — surface citemed_shared (postgres, redis) status + lifecycle controls in the header or as a fleet-wide section. Currently invisible in the UI even though we have the data.
- **Add new ranchhand** — register agent + worktree + ports + .env.agent + run migrations from the UI (wraps citemed_web's \`make init-agent\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)