### PR TITLE
feat(console): shared infra pill — manage citemed_shared from the header

### DIFF
--- a/console/src/main/docker.ts
+++ b/console/src/main/docker.ts
@@ -495,3 +495,94 @@ export async function dockerStackLogs(
     dockerConfig,
   );
 }
+
+// ─── Shared infra (citemed_shared: postgres, redis) ─────────────────
+
+const SHARED_PROJECT = 'citemed_shared';
+const SHARED_COMPOSE_FILE = 'docker-compose.shared.yml';
+
+/**
+ * Find a worktree that has the shared compose file, so lifecycle ops
+ * have a directory to run from. All registered worktrees come from the
+ * same repo so any of them works; we just need to pick one that's
+ * actually checked out.
+ */
+function pickSharedWorktree(worktreePaths: string[]): string | null {
+  for (const p of worktreePaths) {
+    if (existsSync(join(p, SHARED_COMPOSE_FILE))) return p;
+  }
+  return null;
+}
+
+async function sharedComposeRun(
+  worktreePaths: string[],
+  args: string[],
+  needsFiles: boolean,
+): Promise<ComposeRunResult> {
+  const dockerPath = await findDocker();
+  if (!dockerPath) {
+    return { ok: false, stdout: '', stderr: 'docker not installed' };
+  }
+  const worktree = pickSharedWorktree(worktreePaths);
+  const composeArgs: string[] = ['compose'];
+  if (needsFiles) {
+    if (!worktree) {
+      return {
+        ok: false,
+        stdout: '',
+        stderr: `${SHARED_COMPOSE_FILE} not found in any registered worktree`,
+      };
+    }
+    composeArgs.push('-f', join(worktree, SHARED_COMPOSE_FILE));
+  }
+  composeArgs.push('-p', SHARED_PROJECT, ...args);
+  try {
+    const { stdout, stderr } = await execFile(dockerPath, composeArgs, {
+      cwd: worktree ?? process.cwd(),
+      maxBuffer: 4 * 1024 * 1024,
+      timeout: 120_000,
+    });
+    return { ok: true, stdout, stderr };
+  } catch (err) {
+    const stderr =
+      err && typeof err === 'object' && 'stderr' in err
+        ? String((err as { stderr: unknown }).stderr ?? '')
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { ok: false, stdout: '', stderr };
+  }
+}
+
+export async function dockerSharedUp(
+  worktreePaths: string[],
+): Promise<ComposeRunResult> {
+  return sharedComposeRun(worktreePaths, ['up', '-d'], true);
+}
+
+export async function dockerSharedDown(
+  worktreePaths: string[],
+): Promise<ComposeRunResult> {
+  return sharedComposeRun(worktreePaths, ['down'], false);
+}
+
+export async function dockerSharedRestart(
+  worktreePaths: string[],
+): Promise<ComposeRunResult> {
+  return sharedComposeRun(worktreePaths, ['restart'], false);
+}
+
+export interface ResolvedSharedDocker {
+  projectName: string;
+  composeFile: string | null;
+}
+
+export function resolveSharedDocker(
+  worktreePaths: string[],
+): ResolvedSharedDocker {
+  const worktree = pickSharedWorktree(worktreePaths);
+  return {
+    projectName: SHARED_PROJECT,
+    composeFile: worktree ? join(worktree, SHARED_COMPOSE_FILE) : null,
+  };
+}

--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -28,6 +28,10 @@ import {
   dockerStackReset,
   dockerStackLogs,
   resolveAgentDocker,
+  dockerSharedUp,
+  dockerSharedDown,
+  dockerSharedRestart,
+  resolveSharedDocker,
 } from './docker.js';
 import { getAllNotes, setNote } from './notes.js';
 import {
@@ -89,6 +93,10 @@ export const IPC_CHANNELS = {
   dockerRestart: 'ranch:docker:restart',
   dockerReset: 'ranch:docker:reset',
   dockerLogs: 'ranch:docker:logs',
+  dockerSharedResolve: 'ranch:docker:sharedResolve',
+  dockerSharedUp: 'ranch:docker:sharedUp',
+  dockerSharedDown: 'ranch:docker:sharedDown',
+  dockerSharedRestart: 'ranch:docker:sharedRestart',
 } as const;
 
 export function registerIpcHandlers(): void {
@@ -389,4 +397,25 @@ export function registerIpcHandlers(): void {
       return dockerStackLogs(a, worktreePath, t, dockerConfig);
     },
   );
+
+  async function allWorktreePaths(): Promise<string[]> {
+    const config = await loadRanchConfig();
+    return config.agents.map((a) => a.worktree);
+  }
+
+  ipcMain.handle(IPC_CHANNELS.dockerSharedResolve, async () => {
+    return resolveSharedDocker(await allWorktreePaths());
+  });
+
+  ipcMain.handle(IPC_CHANNELS.dockerSharedUp, async () => {
+    return dockerSharedUp(await allWorktreePaths());
+  });
+
+  ipcMain.handle(IPC_CHANNELS.dockerSharedDown, async () => {
+    return dockerSharedDown(await allWorktreePaths());
+  });
+
+  ipcMain.handle(IPC_CHANNELS.dockerSharedRestart, async () => {
+    return dockerSharedRestart(await allWorktreePaths());
+  });
 }

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -59,6 +59,10 @@ const IPC_CHANNELS = {
   dockerRestart: 'ranch:docker:restart',
   dockerReset: 'ranch:docker:reset',
   dockerLogs: 'ranch:docker:logs',
+  dockerSharedResolve: 'ranch:docker:sharedResolve',
+  dockerSharedUp: 'ranch:docker:sharedUp',
+  dockerSharedDown: 'ranch:docker:sharedDown',
+  dockerSharedRestart: 'ranch:docker:sharedRestart',
 } as const;
 
 /**
@@ -145,6 +149,10 @@ const api: RanchApi = {
     reset: (agent) => ipcRenderer.invoke(IPC_CHANNELS.dockerReset, agent),
     logs: (agent, tail) =>
       ipcRenderer.invoke(IPC_CHANNELS.dockerLogs, agent, tail),
+    sharedResolve: () => ipcRenderer.invoke(IPC_CHANNELS.dockerSharedResolve),
+    sharedUp: () => ipcRenderer.invoke(IPC_CHANNELS.dockerSharedUp),
+    sharedDown: () => ipcRenderer.invoke(IPC_CHANNELS.dockerSharedDown),
+    sharedRestart: () => ipcRenderer.invoke(IPC_CHANNELS.dockerSharedRestart),
   },
 };
 

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -17,6 +17,7 @@ import type {
   RunDetail,
   RunRecord,
   RunStatus,
+  ResolvedSharedDocker,
   SessionState,
   TerminalEnv,
   WorktreeBasics,
@@ -215,6 +216,9 @@ export function App(): JSX.Element {
           {state.appVersion ? `v${state.appVersion}` : ''}
         </span>
         <FleetWarnings snapshot={processSnapshot} />
+        {mode === 'interactive' && (
+          <SharedInfraPill containers={dockerSnapshot.shared} />
+        )}
         {mode === 'interactive' &&
           terminalEnv &&
           !terminalEnv.tmuxAvailable && (
@@ -285,6 +289,176 @@ export function App(): JSX.Element {
         </div>
       ) : (
         <AutomatedView />
+      )}
+    </div>
+  );
+}
+
+// ─── Shared infra pill (postgres + redis) ────────────────────
+
+function SharedInfraPill({
+  containers,
+}: {
+  containers: DockerContainer[];
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [resolved, setResolved] = useState<ResolvedSharedDocker | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent): void {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  // Pull resolved compose path lazily when the popover opens.
+  useEffect(() => {
+    if (!open) return;
+    void window.ranch.docker.sharedResolve().then(setResolved);
+  }, [open]);
+
+  function flash(text: string): void {
+    setMsg(text);
+    setTimeout(() => setMsg(null), 4000);
+  }
+
+  async function withBusy(
+    label: string,
+    fn: () => Promise<{ ok: boolean; stderr: string; stdout: string }>,
+  ): Promise<void> {
+    if (busy) return;
+    setBusy(label);
+    try {
+      const result = await fn();
+      if (result.ok) flash(`${label} succeeded`);
+      else
+        flash(
+          `${label} failed: ${(result.stderr || result.stdout || '').slice(-200) || '(no output)'}`,
+        );
+    } catch (err) {
+      flash(
+        `${label} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const running = containers.filter((c) => c.state === 'running').length;
+  const total = containers.length;
+  const pillCls =
+    total === 0
+      ? 'shared-pill shared-pill--none'
+      : running === total
+        ? 'shared-pill shared-pill--up'
+        : running === 0
+          ? 'shared-pill shared-pill--down'
+          : 'shared-pill shared-pill--partial';
+
+  return (
+    <div className="shared-pill__wrap" ref={ref}>
+      <button
+        type="button"
+        className={pillCls}
+        onClick={() => setOpen((v) => !v)}
+        title="citemed_shared (postgres + redis)"
+      >
+        shared 🐳 {running}/{total}
+      </button>
+      {open && (
+        <div className="shared-popover">
+          <header className="shared-popover__head">
+            <span className="shared-popover__title">citemed_shared</span>
+            {resolved?.composeFile && (
+              <code
+                className="shared-popover__file"
+                title={resolved.composeFile}
+              >
+                {(() => {
+                  const parts = resolved.composeFile.split('/').filter(Boolean);
+                  return parts.length <= 2
+                    ? resolved.composeFile
+                    : '…/' + parts.slice(-2).join('/');
+                })()}
+              </code>
+            )}
+          </header>
+          {total === 0 ? (
+            <p className="shared-popover__empty">
+              No shared containers. Click <strong>Up</strong> to bring postgres
+              + redis up.
+            </p>
+          ) : (
+            <ul className="docker-services">
+              {containers.map((c) => (
+                <li
+                  key={c.id}
+                  className={`docker-service docker-service--${c.state}`}
+                >
+                  <span className="docker-service__name">
+                    {c.service ?? c.name}
+                  </span>
+                  <span
+                    className={`docker-service__state docker-service__state--${c.state}`}
+                    title={c.status}
+                  >
+                    {c.state}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="docker-actions">
+            <button
+              type="button"
+              className="run-action run-action--approve"
+              onClick={() =>
+                withBusy('Up', () => window.ranch.docker.sharedUp())
+              }
+              disabled={busy !== null}
+              title="docker compose -f docker-compose.shared.yml -p citemed_shared up -d"
+            >
+              {busy === 'Up' ? '…' : 'Up'}
+            </button>
+            <button
+              type="button"
+              className="run-action"
+              onClick={() =>
+                withBusy('Restart', () => window.ranch.docker.sharedRestart())
+              }
+              disabled={busy !== null || total === 0}
+              title="docker compose -p citemed_shared restart"
+            >
+              {busy === 'Restart' ? '…' : 'Restart'}
+            </button>
+            <button
+              type="button"
+              className="run-action run-action--stop"
+              onClick={() => {
+                if (
+                  !window.confirm(
+                    'Bring down citemed_shared (postgres + redis)?\n\nEvery ranch hand stack relies on these. Their connections will fail until you bring shared back up.',
+                  )
+                )
+                  return;
+                void withBusy('Down', () => window.ranch.docker.sharedDown());
+              }}
+              disabled={busy !== null || total === 0}
+              title="docker compose -p citemed_shared down"
+            >
+              {busy === 'Down' ? '…' : 'Down'}
+            </button>
+          </div>
+          {msg && <p className="run-modal__action-msg">{msg}</p>}
+        </div>
       )}
     </div>
   );

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -72,6 +72,105 @@ body,
   margin-left: auto;
 }
 
+/* ─── Shared infra pill (header) ────────────────────── */
+
+.shared-pill__wrap {
+  position: relative;
+}
+
+.shared-pill {
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  letter-spacing: 0.02em;
+  transition:
+    border-color 0.12s ease,
+    background 0.12s ease;
+}
+
+.shared-pill:hover {
+  border-color: var(--accent);
+}
+
+.shared-pill--up {
+  background: rgba(92, 212, 122, 0.14);
+  color: var(--green);
+  border-color: rgba(92, 212, 122, 0.4);
+}
+
+.shared-pill--partial {
+  background: rgba(246, 193, 119, 0.14);
+  color: var(--yellow);
+  border-color: rgba(246, 193, 119, 0.4);
+}
+
+.shared-pill--down {
+  background: rgba(255, 106, 106, 0.12);
+  color: var(--red);
+  border-color: rgba(255, 106, 106, 0.3);
+}
+
+.shared-pill--none {
+  background: var(--bg);
+  color: var(--text-dim);
+}
+
+.shared-popover {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  padding: 0.7rem 0.8rem;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.5);
+  min-width: 320px;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.shared-popover__head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.shared-popover__title {
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  font-weight: 700;
+  color: var(--accent);
+  font-size: 0.82rem;
+}
+
+.shared-popover__file {
+  background: var(--bg);
+  padding: 0 0.3rem;
+  border-radius: 2px;
+  font-size: 0.68rem;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  color: var(--text-dim);
+  border: 1px solid var(--border);
+  align-self: flex-start;
+}
+
+.shared-popover__empty {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
 /* ─── Mode tabs ──────────────────────────────────────── */
 
 .mode-tabs {

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -244,6 +244,13 @@ export interface ResolvedAgentDocker {
   missingFiles: string[];
 }
 
+/** Resolution for the shared (postgres + redis) stack. */
+export interface ResolvedSharedDocker {
+  projectName: string;
+  /** Absolute path; null when no registered worktree contains the file. */
+  composeFile: string | null;
+}
+
 export interface ComposeRunResult {
   ok: boolean;
   stdout: string;
@@ -460,6 +467,11 @@ export interface RanchApi {
     /** Down with -v (wipes volumes) then Up — clean-slate recreate. */
     reset: (agent: string) => Promise<ComposeRunResult>;
     logs: (agent: string, tail?: number) => Promise<ComposeRunResult>;
+    /** citemed_shared (postgres, redis) — fleet-wide, not per-agent. */
+    sharedResolve: () => Promise<ResolvedSharedDocker>;
+    sharedUp: () => Promise<ComposeRunResult>;
+    sharedDown: () => Promise<ComposeRunResult>;
+    sharedRestart: () => Promise<ComposeRunResult>;
   };
 }
 


### PR DESCRIPTION
## Summary

Surfaces \`citemed_shared\` (postgres + redis) — the stack every ranch hand depends on — in the header where you can see and manage it at a glance. Until now we were reading it in the docker snapshot but never showing it, which meant a stopped postgres looked like 4 broken agents instead of one root cause.

## What you'll see

A colored pill in the header next to the orphan-claude warning:

\`\`\`
shared 🐳 2/2     ← green when all up
shared 🐳 1/2     ← yellow when partial
shared 🐳 0/2     ← red when all down
\`\`\`

Click → popover drops down with:
- Service list (postgres, redis with state badges)
- Resolved compose file path (so you know which worktree it picked the file from)
- **Up · Restart · Down** buttons (Down requires confirm — every ranch hand will lose connections)

## Implementation

\`docker compose -f <worktree>/docker-compose.shared.yml -p citemed_shared <action>\`

Compose file lookup: walks registered agents and picks the first whose worktree has \`docker-compose.shared.yml\` (any of them should — they're git worktrees of the same repo). If none have it, the popover surfaces a clear error.

No new docker ps calls — the existing fleet snapshot already returned \`shared\` containers; this PR just renders them.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Header shows \`shared 🐳 N/M\` pill with appropriate color
- [ ] Click pill → popover appears with postgres + redis listed and state badges
- [ ] Click outside → popover closes
- [ ] Click Up on a stopped shared stack → containers come up; pill flips to green within ~7s
- [ ] Click Down → confirm dialog warns about ranch hands losing connections
- [ ] Confirm → containers go down; pill flips to red

## What's next on the docker track

- **Add new ranchhand** — the bigger admin op (worktree + ports + .env.agent + migrations). Probably wraps citemed_web's \`make init-agent\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)