### PR TITLE
feat(console): + Add ranchhand — register a new agent from the UI

### DIFF
--- a/console/src/main/config.ts
+++ b/console/src/main/config.ts
@@ -1,8 +1,12 @@
-import { readFile } from 'node:fs/promises';
+import { execFile as execFileCb } from 'node:child_process';
+import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { promisify } from 'node:util';
 import toml from '@iarna/toml';
+
+const execFile = promisify(execFileCb);
 import type {
   AgentConfig,
   ProjectConfig,
@@ -128,5 +132,189 @@ export async function loadRanchConfig(): Promise<RanchConfig> {
     configPath: CONFIG_PATH,
     projectsPath: PROJECTS_PATH,
     ranchDir: RANCH_DIR,
+  };
+}
+
+// ─── Add agent (write side) ────────────────────────────────────
+
+export interface AddAgentInput {
+  /** New agent name (e.g. "stevie"). Must be unique. */
+  name: string;
+  /** Worktree path. If omitted, defaults to $(HOME)/code/citemed/<name>. */
+  worktree?: string;
+  description?: string;
+  /** Optional canonical port hints (these go into the ports block). */
+  djangoPort?: number;
+  vitePort?: number;
+  /**
+   * If true, ranch shells out to `make init-agent AGENT=<name>` from
+   * citemed_web's Makefile. Creates the git worktree, generates
+   * .env.agent, runs migrations. Requires the agent name to already be
+   * in the Makefile's AGENTS list — currently a manual edit step.
+   */
+  runMakeInitAgent?: boolean;
+}
+
+export interface AddAgentResult {
+  ok: boolean;
+  /** Combined stdout/stderr from `make init-agent` if runMakeInitAgent. */
+  output: string;
+  /** The agent block that was appended to ~/.ranch/config.toml. */
+  configEntry?: string;
+}
+
+/** Locate any worktree we know about that contains a Makefile (citemed_web). */
+async function findCitemedWebMakefile(): Promise<string | null> {
+  const file = await readToml(CONFIG_PATH);
+  const agents = parseAgents(file);
+  for (const a of agents) {
+    const mf = join(a.worktree, 'Makefile');
+    if (existsSync(mf)) return a.worktree;
+  }
+  return null;
+}
+
+function defaultWorktreePath(name: string): string {
+  return join(homedir(), 'code', 'citemed', name);
+}
+
+function escapeTomlString(s: string): string {
+  // For our purposes the values are paths and short text — escape only
+  // backslash and double-quote, fine for basic strings.
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function buildAgentTomlBlock(input: AddAgentInput, worktree: string): string {
+  const lines = [`[agents.${input.name}]`];
+  lines.push(`worktree = "${escapeTomlString(worktree)}"`);
+  if (input.description) {
+    lines.push(`description = "${escapeTomlString(input.description)}"`);
+  }
+  if (input.djangoPort !== undefined || input.vitePort !== undefined) {
+    const parts: string[] = [];
+    if (input.djangoPort !== undefined)
+      parts.push(`django = ${input.djangoPort}`);
+    if (input.vitePort !== undefined) parts.push(`vite = ${input.vitePort}`);
+    lines.push(`ports = { ${parts.join(', ')} }`);
+  }
+  return lines.join('\n');
+}
+
+async function appendToConfigFile(block: string): Promise<void> {
+  const dir = dirname(CONFIG_PATH);
+  if (!existsSync(dir)) await mkdir(dir, { recursive: true });
+  const existing = existsSync(CONFIG_PATH)
+    ? await readFile(CONFIG_PATH, 'utf8')
+    : '';
+  // Ensure a separating blank line, regardless of whether existing
+  // file ends with newline or not.
+  const sep = existing.endsWith('\n\n')
+    ? ''
+    : existing.endsWith('\n')
+      ? '\n'
+      : '\n\n';
+  const next = existing + sep + block + '\n';
+  const tmp = `${CONFIG_PATH}.${process.pid}.tmp`;
+  await writeFile(tmp, next, 'utf8');
+  await rename(tmp, CONFIG_PATH);
+}
+
+/**
+ * Read just the ports out of a freshly-created .env.agent. Used after
+ * `make init-agent` to capture the canonical ports it allocated.
+ */
+async function readEnvAgentPorts(
+  worktree: string,
+): Promise<{ django?: number; vite?: number }> {
+  const path = join(worktree, '.env.agent');
+  if (!existsSync(path)) return {};
+  const raw = await readFile(path, 'utf8');
+  const out: { django?: number; vite?: number } = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const m = /^([A-Z_]+)=(.+)$/.exec(line.trim());
+    if (!m) continue;
+    const [, key, value] = m;
+    const n = Number.parseInt(value!, 10);
+    if (!Number.isFinite(n)) continue;
+    if (key === 'DJANGO_PORT') out.django = n;
+    if (key === 'VITE_PORT') out.vite = n;
+  }
+  return out;
+}
+
+export async function addAgent(input: AddAgentInput): Promise<AddAgentResult> {
+  const trimmedName = input.name.trim();
+  if (!/^[a-z][a-z0-9_-]*$/.test(trimmedName)) {
+    return {
+      ok: false,
+      output:
+        'Agent name must be lowercase letters/digits/hyphens, starting with a letter.',
+    };
+  }
+  // Reject duplicates.
+  const config = await loadRanchConfig();
+  if (config.agents.some((a) => a.name === trimmedName)) {
+    return { ok: false, output: `Agent '${trimmedName}' already exists.` };
+  }
+
+  const worktree = (input.worktree ?? defaultWorktreePath(trimmedName)).trim();
+
+  let output = '';
+  let djangoPort = input.djangoPort;
+  let vitePort = input.vitePort;
+
+  if (input.runMakeInitAgent) {
+    const makefileDir = await findCitemedWebMakefile();
+    if (!makefileDir) {
+      return {
+        ok: false,
+        output:
+          'No Makefile found in any registered worktree. Either run `make init-agent` manually, or untoggle the option and add the config entry only.',
+      };
+    }
+    try {
+      const { stdout, stderr } = await execFile('make', [
+        '-C',
+        makefileDir,
+        'init-agent',
+        `AGENT=${trimmedName}`,
+      ]);
+      output = stdout + stderr;
+    } catch (err) {
+      const stderr =
+        err && typeof err === 'object' && 'stderr' in err
+          ? String((err as { stderr: unknown }).stderr ?? '')
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      return {
+        ok: false,
+        output: stderr,
+      };
+    }
+    // Pick up ports the Makefile allocated.
+    const detected = await readEnvAgentPorts(worktree);
+    if (detected.django !== undefined && djangoPort === undefined)
+      djangoPort = detected.django;
+    if (detected.vite !== undefined && vitePort === undefined)
+      vitePort = detected.vite;
+  }
+
+  const block = buildAgentTomlBlock(
+    {
+      ...input,
+      name: trimmedName,
+      worktree,
+      ...(djangoPort !== undefined ? { djangoPort } : {}),
+      ...(vitePort !== undefined ? { vitePort } : {}),
+    },
+    worktree,
+  );
+  await appendToConfigFile(block);
+
+  return {
+    ok: true,
+    output,
+    configEntry: block,
   };
 }

--- a/console/src/main/ipc.ts
+++ b/console/src/main/ipc.ts
@@ -14,7 +14,7 @@
  */
 
 import { app, ipcMain, shell } from 'electron';
-import { loadRanchConfig } from './config.js';
+import { loadRanchConfig, addAgent } from './config.js';
 import { listWorktrees } from './worktrees.js';
 import { getActiveSession } from './transcript.js';
 import { getWorktreeGitState } from './git.js';
@@ -57,6 +57,7 @@ import {
 
 export const IPC_CHANNELS = {
   configGet: 'ranch:config:get',
+  configAddAgent: 'ranch:config:addAgent',
   worktreesList: 'ranch:worktrees:list',
   worktreesSession: 'ranch:worktrees:session',
   worktreesGit: 'ranch:worktrees:git',
@@ -101,6 +102,30 @@ export const IPC_CHANNELS = {
 
 export function registerIpcHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.configGet, async () => loadRanchConfig());
+
+  ipcMain.handle(IPC_CHANNELS.configAddAgent, async (_event, raw: unknown) => {
+    if (typeof raw !== 'object' || raw === null) {
+      throw new Error('config.addAgent needs an input object');
+    }
+    const i = raw as Record<string, unknown>;
+    if (typeof i['name'] !== 'string' || !i['name'].trim()) {
+      throw new Error('config.addAgent needs a name');
+    }
+    return addAgent({
+      name: i['name'],
+      ...(typeof i['worktree'] === 'string' && i['worktree']
+        ? { worktree: i['worktree'] }
+        : {}),
+      ...(typeof i['description'] === 'string' && i['description']
+        ? { description: i['description'] }
+        : {}),
+      ...(typeof i['djangoPort'] === 'number'
+        ? { djangoPort: i['djangoPort'] }
+        : {}),
+      ...(typeof i['vitePort'] === 'number' ? { vitePort: i['vitePort'] } : {}),
+      runMakeInitAgent: i['runMakeInitAgent'] === true,
+    });
+  });
   ipcMain.handle(IPC_CHANNELS.worktreesList, async () => listWorktrees());
 
   ipcMain.handle(

--- a/console/src/preload/index.ts
+++ b/console/src/preload/index.ts
@@ -25,6 +25,7 @@ import type {
 
 const IPC_CHANNELS = {
   configGet: 'ranch:config:get',
+  configAddAgent: 'ranch:config:addAgent',
   worktreesList: 'ranch:worktrees:list',
   worktreesSession: 'ranch:worktrees:session',
   worktreesGit: 'ranch:worktrees:git',
@@ -86,6 +87,7 @@ function subscribe<T>(
 const api: RanchApi = {
   config: {
     get: () => ipcRenderer.invoke(IPC_CHANNELS.configGet),
+    addAgent: (input) => ipcRenderer.invoke(IPC_CHANNELS.configAddAgent, input),
   },
   worktrees: {
     list: () => ipcRenderer.invoke(IPC_CHANNELS.worktreesList),

--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -65,6 +65,7 @@ export function App(): JSX.Element {
   const [focusedAgent, setFocusedAgent] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
   const [mode, setMode] = useState<'interactive' | 'automated'>('interactive');
+  const [addAgentOpen, setAddAgentOpen] = useState(false);
   // Per-agent generation counter — bumping it forces the Terminal
   // component to remount, which triggers a fresh tmux attach. Used by
   // the "Restart Claude" action.
@@ -229,6 +230,16 @@ export function App(): JSX.Element {
         {mode === 'interactive' && (
           <button
             type="button"
+            className="sidebar-toggle"
+            onClick={() => setAddAgentOpen(true)}
+            title="Register a new ranch hand and optionally bootstrap its worktree"
+          >
+            + Add ranchhand
+          </button>
+        )}
+        {mode === 'interactive' && (
+          <button
+            type="button"
             className={`sidebar-toggle${sidebarOpen ? ' sidebar-toggle--open' : ''}`}
             onClick={() => setSidebarOpen((v) => !v)}
             title={sidebarOpen ? 'Hide detail sidebar' : 'Show detail sidebar'}
@@ -237,6 +248,17 @@ export function App(): JSX.Element {
           </button>
         )}
       </header>
+      {addAgentOpen && (
+        <AddAgentModal
+          onClose={() => setAddAgentOpen(false)}
+          onAdded={() => {
+            setAddAgentOpen(false);
+            void window.ranch.worktrees.list().then((worktrees) => {
+              setState((prev) => ({ ...prev, worktrees }));
+            });
+          }}
+        />
+      )}
       {mode === 'interactive' ? (
         <div className={`app__body${sidebarOpen ? ' app__body--sidebar' : ''}`}>
           <main className="app__grid">
@@ -290,6 +312,184 @@ export function App(): JSX.Element {
       ) : (
         <AutomatedView />
       )}
+    </div>
+  );
+}
+
+// ─── Add ranchhand modal ─────────────────────────────────────
+
+function AddAgentModal({
+  onClose,
+  onAdded,
+}: {
+  onClose: () => void;
+  onAdded: (name: string) => void;
+}): JSX.Element {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [worktree, setWorktree] = useState('');
+  const [djangoPort, setDjangoPort] = useState('');
+  const [vitePort, setVitePort] = useState('');
+  const [runMake, setRunMake] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [output, setOutput] = useState<string | null>(null);
+
+  async function submit(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    if (busy) return;
+    if (!name.trim()) {
+      setError('Name is required');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setOutput(null);
+    try {
+      const dj = djangoPort.trim() ? Number.parseInt(djangoPort, 10) : NaN;
+      const vt = vitePort.trim() ? Number.parseInt(vitePort, 10) : NaN;
+      const result = await window.ranch.config.addAgent({
+        name: name.trim(),
+        ...(worktree.trim() ? { worktree: worktree.trim() } : {}),
+        ...(description.trim() ? { description: description.trim() } : {}),
+        ...(Number.isFinite(dj) ? { djangoPort: dj } : {}),
+        ...(Number.isFinite(vt) ? { vitePort: vt } : {}),
+        runMakeInitAgent: runMake,
+      });
+      if (!result.ok) {
+        setError(result.output);
+        return;
+      }
+      setOutput(result.output);
+      // Brief pause so the operator sees the success state, then close.
+      setTimeout(() => onAdded(name.trim()), 400);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="run-modal__backdrop" onClick={onClose}>
+      <div className="run-modal" onClick={(e) => e.stopPropagation()}>
+        <header className="run-modal__head">
+          <h3>Add ranchhand</h3>
+          <button
+            type="button"
+            className="run-modal__close"
+            onClick={onClose}
+            disabled={busy}
+          >
+            ✕
+          </button>
+        </header>
+        <form className="run-modal__body dispatch-form" onSubmit={submit}>
+          <label className="dispatch-form__field">
+            <span className="dispatch-form__label">Name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="stevie"
+              disabled={busy}
+              className="dispatch-form__input"
+              autoFocus
+            />
+          </label>
+
+          <label className="dispatch-form__field">
+            <span className="dispatch-form__label">Description (optional)</span>
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Ranch hand #5"
+              disabled={busy}
+              className="dispatch-form__input"
+            />
+          </label>
+
+          <label className="dispatch-form__field">
+            <span className="dispatch-form__label">
+              Worktree path (optional — defaults to ~/code/citemed/&lt;name&gt;)
+            </span>
+            <input
+              type="text"
+              value={worktree}
+              onChange={(e) => setWorktree(e.target.value)}
+              placeholder=""
+              disabled={busy}
+              className="dispatch-form__input"
+            />
+          </label>
+
+          <div className="dispatch-form__field">
+            <span className="dispatch-form__label">
+              Canonical ports (optional — set if not running make init-agent)
+            </span>
+            <div className="add-agent__ports">
+              <input
+                type="number"
+                value={djangoPort}
+                onChange={(e) => setDjangoPort(e.target.value)}
+                placeholder="Django (e.g. 8005)"
+                disabled={busy}
+                className="dispatch-form__input"
+              />
+              <input
+                type="number"
+                value={vitePort}
+                onChange={(e) => setVitePort(e.target.value)}
+                placeholder="Vite (e.g. 3005)"
+                disabled={busy}
+                className="dispatch-form__input"
+              />
+            </div>
+          </div>
+
+          <label className="dispatch-form__toggle">
+            <input
+              type="checkbox"
+              checked={runMake}
+              onChange={(e) => setRunMake(e.target.checked)}
+              disabled={busy}
+            />
+            <span>
+              <strong>Run make init-agent</strong> — bootstrap the worktree,
+              generate <code>.env.agent</code>, run migrations. Requires the
+              agent name to already be in citemed_web&apos;s Makefile{' '}
+              <code>AGENTS</code> list. Untoggle if you just want to register an
+              already-existing worktree in ranch&apos;s config.
+            </span>
+          </label>
+
+          {error && <pre className="dispatch-form__error">{error}</pre>}
+          {output && (
+            <pre className="dispatch-form__error dispatch-form__output">
+              {output.trim().slice(-1200)}
+            </pre>
+          )}
+
+          <div className="dispatch-form__buttons">
+            <button
+              type="button"
+              className="run-action"
+              onClick={onClose}
+              disabled={busy}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="run-action run-action--approve"
+              disabled={busy}
+            >
+              {busy ? 'Adding…' : 'Add ranchhand'}
+            </button>
+          </div>
+        </form>
+      </div>
     </div>
   );
 }

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -1771,6 +1771,18 @@ body,
   margin-top: 0.25rem;
 }
 
+.dispatch-form__output {
+  background: rgba(92, 212, 122, 0.06);
+  color: var(--text-muted);
+  border-color: rgba(92, 212, 122, 0.3);
+}
+
+.add-agent__ports {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
 .detail__pr-link {
   color: var(--accent);
   text-decoration: none;

--- a/console/src/shared/types.ts
+++ b/console/src/shared/types.ts
@@ -397,9 +397,26 @@ export type Unsubscribe = () => void;
 
 // ─── IPC surface ─────────────────────────────────────────────────────────
 
+export interface AddAgentInput {
+  name: string;
+  worktree?: string;
+  description?: string;
+  djangoPort?: number;
+  vitePort?: number;
+  runMakeInitAgent?: boolean;
+}
+
+export interface AddAgentResult {
+  ok: boolean;
+  /** Combined stdout/stderr from `make init-agent`, or an error message. */
+  output: string;
+  configEntry?: string;
+}
+
 export interface RanchApi {
   config: {
     get: () => Promise<RanchConfig>;
+    addAgent: (input: AddAgentInput) => Promise<AddAgentResult>;
   };
   worktrees: {
     list: () => Promise<WorktreeBasics[]>;


### PR DESCRIPTION
## Summary

Closes the loop on agent setup. Header gains a **+ Add ranchhand** button that opens a form modal for registering a new agent without dropping to terminal.

## Form fields

| Field | Required | Default |
|---|---|---|
| **Name** | yes | — |
| Description | no | — |
| Worktree path | no | \`~/code/citemed/<name>\` |
| Canonical Django/Vite ports | no | inherit from \`make init-agent\` if running it |
| **Run \`make init-agent\`** toggle | — | ON |

## What submit does

1. **Validate** — name must be lowercase letters/digits/hyphens, unique against existing config
2. **(if Run make is on)** Shell out to \`make -C <citemed_web_worktree> init-agent AGENT=<name>\` — same command you'd run by hand. Creates the git worktree, generates \`.env.agent\` with allocated ports, runs migrations.
3. **Read back ports** — pulls Django/Vite ports from the freshly-created \`.env.agent\` so the canonical port hints are accurate
4. **Append \`[agents.<name>]\` block to \`~/.ranch/config.toml\`** — atomic write to tmp + rename. Existing comments and formatting are preserved because we never re-serialize the rest of the file, just append.
5. **Refresh the worktree list** so the new card appears in the grid immediately.

Make output is shown inline when present (success or failure), trimmed to the last 1200 chars so chatty migrations don't blow up the modal.

## Important caveat (documented in the form)

\`make init-agent\` requires the agent name to already exist in citemed_web's Makefile \`AGENTS\` list (and its port lookup tables). That's still a manual edit — modifying citemed_web's Makefile is outside ranch's scope since it's the application repo. Workflow:

1. Edit citemed_web/Makefile: add new name to \`AGENTS\` and to the port lookup expressions
2. Click **+ Add ranchhand** in the console
3. Fill form, run

Untoggle the \`Run make\` checkbox if you just want to register a worktree that already exists (e.g. you bootstrapped it elsewhere).

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Header shows new \"+ Add ranchhand\" button
- [ ] Click → modal opens with Name field focused
- [ ] Submit empty → validation error
- [ ] Try a duplicate name (e.g. \"max\") → \"already exists\" error
- [ ] Try a name without editing Makefile first, with Run make on → make output shows \"Unknown agent\" error
- [ ] Untoggle Run make, submit with name=\"test1\" → config gets a new \`[agents.test1]\` entry; new (empty) card appears in grid
- [ ] After registering, edit \`~/.ranch/config.toml\` → existing entries (with comments / port blocks) are preserved unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)