### PR TITLE
feat(console): cross-mode link — Open in Interactive from Automated runs

### DIFF
--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -310,7 +310,13 @@ export function App(): JSX.Element {
           )}
         </div>
       ) : (
-        <AutomatedView />
+        <AutomatedView
+          onOpenInInteractive={(agent) => {
+            setMode('interactive');
+            setFocusedAgent(agent);
+            setSidebarOpen(true);
+          }}
+        />
       )}
     </div>
   );
@@ -727,7 +733,11 @@ const ACTIVE_STATUSES: RunStatus[] = [
 
 type RunFilter = 'active' | 'all';
 
-function AutomatedView(): JSX.Element {
+function AutomatedView({
+  onOpenInInteractive,
+}: {
+  onOpenInInteractive: (agent: string) => void;
+}): JSX.Element {
   const [runs, setRuns] = useState<RunRecord[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<number | null>(null);
@@ -949,6 +959,7 @@ function AutomatedView(): JSX.Element {
               run={run}
               selected={selectedId === run.id}
               onSelect={() => setSelectedId(run.id)}
+              onOpenInInteractive={onOpenInInteractive}
             />
           ))}
         </div>
@@ -958,6 +969,7 @@ function AutomatedView(): JSX.Element {
         <RunDetailModal
           runId={selectedId}
           onClose={() => setSelectedId(null)}
+          onOpenInInteractive={onOpenInInteractive}
         />
       )}
 
@@ -1165,10 +1177,12 @@ function RunCard({
   run,
   selected,
   onSelect,
+  onOpenInInteractive,
 }: {
   run: RunRecord;
   selected: boolean;
   onSelect: () => void;
+  onOpenInInteractive: (agent: string) => void;
 }): JSX.Element {
   const ageRef = run.endedAt ?? run.startedAt;
   const ageStr = relativeAge(ageRef);
@@ -1229,6 +1243,17 @@ function RunCard({
         {actionHint && (
           <span className="run-card__action-hint">{actionHint}</span>
         )}
+        <button
+          type="button"
+          className="run-card__open-interactive"
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpenInInteractive(run.agent);
+          }}
+          title={`Switch to Interactive view focused on ${run.agent}`}
+        >
+          → {run.agent}
+        </button>
       </footer>
     </article>
   );
@@ -1269,9 +1294,11 @@ function statusLabel(status: RunStatus): string {
 function RunDetailModal({
   runId,
   onClose,
+  onOpenInInteractive,
 }: {
   runId: number;
   onClose: () => void;
+  onOpenInInteractive: (agent: string) => void;
 }): JSX.Element {
   const [detail, setDetail] = useState<RunDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -1387,9 +1414,28 @@ function RunDetailModal({
       <div className="run-modal" onClick={(e) => e.stopPropagation()}>
         <header className="run-modal__head">
           <h3>Run #{runId}</h3>
-          <button type="button" className="run-modal__close" onClick={onClose}>
-            ✕
-          </button>
+          <div className="run-modal__head-actions">
+            {detail && (
+              <button
+                type="button"
+                className="run-modal__open-interactive"
+                onClick={() => {
+                  onOpenInInteractive(detail.agent);
+                  onClose();
+                }}
+                title={`Switch to Interactive view focused on ${detail.agent}`}
+              >
+                → Open in Interactive
+              </button>
+            )}
+            <button
+              type="button"
+              className="run-modal__close"
+              onClick={onClose}
+            >
+              ✕
+            </button>
+          </div>
         </header>
         {error && (
           <p className="placeholder placeholder--error">Error: {error}</p>

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -1359,6 +1359,52 @@ body,
   text-decoration: underline;
 }
 
+.run-card__open-interactive {
+  background: none;
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+  padding: 0.05rem 0.45rem;
+  border-radius: 3px;
+  font: inherit;
+  font-size: 0.65rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  transition:
+    color 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.run-card__open-interactive:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.run-modal__head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.run-modal__open-interactive {
+  background: rgba(106, 162, 255, 0.12);
+  color: var(--accent);
+  border: 1px solid rgba(106, 162, 255, 0.4);
+  padding: 0.25rem 0.7rem;
+  border-radius: 4px;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: 'SF Mono', Menlo, Consolas, monospace;
+  transition: background 0.12s ease;
+}
+
+.run-modal__open-interactive:hover {
+  background: rgba(106, 162, 255, 0.2);
+  border-color: var(--accent);
+}
+
 /* Run detail modal */
 
 .run-modal__backdrop {


### PR DESCRIPTION
## Summary

Closes the loop you asked about earlier: \"how do I dip into an automated run that needs review.\" Each run now has a one-click jump to the agent's interactive view.

## What you'll see

**Run card** (in the Active/All grid):

\`\`\`
┌────────────────────────────────────┐
│ max  ECD-1234  needs approval  #54 │
│ Add /healthz endpoint…             │
│ started 2m ago    PR ↗   → max     │ ← new button
└────────────────────────────────────┘
\`\`\`

Small \"→ <agent>\" button in the card footer.

**Run detail modal** (when you click into a run): bigger primary-styled button in the header — \"→ Open in Interactive.\"

Either click flips the top-level mode tab from **Automated** to **Interactive**, focuses that agent's cell (blue accent border), and opens the Details sidebar — so you land on the deepest context immediately and can see the live terminal, git state, todos, docker, etc.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Switch to Automated, find any run for an agent that's also in Interactive
- [ ] Click the \"→ <agent>\" button in the card footer → mode flips to Interactive, that agent's cell has a blue border, sidebar is open showing the agent's deep info
- [ ] Click into the run modal first → \"→ Open in Interactive\" button in header → modal closes, mode flips, sidebar opens
- [ ] Repeat for a run on a different agent → interactive view focuses the right cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)