### PR TITLE
fix(console): Reconnect/Restart Claude no-op'd on first click (off-by-one)

### DIFF
--- a/console/src/renderer/App.tsx
+++ b/console/src/renderer/App.tsx
@@ -73,6 +73,10 @@ export function App(): JSX.Element {
     Record<string, number>
   >({});
 
+  // Bump triggers a Terminal remount via the [agent, generation] deps.
+  // The matching default in the AgentCell render is `?? 0` so the very
+  // first bump goes 0 → 1 (a real change) — without that alignment the
+  // first Reconnect/Restart click no-ops because both ends compute 1.
   const bumpTerminalGeneration = useCallback((agent: string) => {
     setTerminalGenerations((prev) => ({
       ...prev,
@@ -280,7 +284,7 @@ export function App(): JSX.Element {
                   note={notes[wt.agent] ?? null}
                   terminalEnv={terminalEnv}
                   focused={focusedAgent === wt.agent}
-                  generation={terminalGenerations[wt.agent] ?? 1}
+                  generation={terminalGenerations[wt.agent] ?? 0}
                   onFocus={() => setFocusedAgent(wt.agent)}
                   onSaveNote={(label) => saveNote(wt.agent, label)}
                   onBumpGeneration={() => bumpTerminalGeneration(wt.agent)}


### PR DESCRIPTION
## Summary

Fixes the bug you reported: \"Reconnect button is not wired up or really clickable.\"

## Root cause

Off-by-one in the generation counter that drives Terminal remounts:

\`\`\`tsx
// App render:
<Terminal generation={terminalGenerations[wt.agent] ?? 1} />

// App bump helper:
setTerminalGenerations((prev) => ({
  ...prev,
  [agent]: (prev[agent] ?? 0) + 1,
}));
\`\`\`

On the **very first bump**:
- Before: state[agent] is undefined → render shows **1**
- After: state[agent] is 1 → render shows **1**

Same value before and after → useEffect dep \`[agent, generation]\` sees no change → no remount → no re-attach. Reconnect (and Restart Claude!) silently no-op'd on the first click.

You mentioned Restart Claude works — likely you had hit the menu earlier in the session, so the counter was already past 1 by the time you tested it, and subsequent bumps did differ.

## Fix

Aligned the defaults: render now uses \`?? 0\`. First bump goes 0 → 1, which the effect picks up cleanly. Both Reconnect and Restart Claude share this plumbing and now work from the first click.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Click \"Open Claude\" on a fresh worktree to land in the terminal
- [ ] Kebab menu → \"Kill session\" → confirm → Session ended overlay appears
- [ ] **First click on Reconnect** — fresh tmux session spawns immediately, claude relaunches
- [ ] Repeat for Restart Claude on a different worktree (use the menu directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)