### PR TITLE
fix(docker): default to docker-compose.agent.yml only (drop the .yml layer)

### DIFF
--- a/console/src/main/docker.ts
+++ b/console/src/main/docker.ts
@@ -268,10 +268,14 @@ export interface ResolvedComposeConfig {
   envFile: string | null;
 }
 
-const DEFAULT_COMPOSE_FILES = [
-  'docker-compose.yml',
-  'docker-compose.agent.yml',
-];
+// Per-agent stacks are self-contained in docker-compose.agent.yml — its
+// own header literally documents `docker compose -f docker-compose.agent.yml
+// -p citemed_$AGENT_NAME up -d`. Including docker-compose.yml as well
+// (the Makefile's habit) merges the full app stack on top, which
+// duplicates services and competes with citemed_shared. Default is just
+// the agent file. Anyone who needs the override layer can opt in via
+// the per-agent docker.compose_files block in ~/.ranch/config.toml.
+const DEFAULT_COMPOSE_FILES = ['docker-compose.agent.yml'];
 const DEFAULT_ENV_FILE = '.env.agent';
 
 /**


### PR DESCRIPTION
## Summary

You noticed: ranch was reading both \`docker-compose.yml\` AND \`docker-compose.agent.yml\` when only the agent file should drive per-agent stacks.

## Why this was wrong

\`docker-compose.agent.yml\`'s own header literally says:

\`\`\`
docker compose -f docker-compose.agent.yml -p citemed_\$AGENT_NAME up -d
\`\`\`

It's self-contained. Layering \`docker-compose.yml\` on top merges the full app stack (which redefines postgres/redis) and competes with \`citemed_shared\`. The Makefile's habit of using both was probably never necessary.

## Fix

Default is now just \`['docker-compose.agent.yml']\`. Anyone who needs the merged-layer behavior can opt in via the per-agent override:

\`\`\`toml
[agents.foo.docker]
compose_files = [\"docker-compose.yml\", \"docker-compose.agent.yml\"]
\`\`\`

The sidebar Docker section will reflect the new resolved file list immediately — should now show only one compose file (instead of two) for each agent that uses defaults.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] Open Detail sidebar for any agent → Docker section shows files: just \`…/<agent>/docker-compose.agent.yml\`
- [ ] Up / Down / Restart still work (project name match logic unchanged)
- [ ] Reset still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)