### PR TITLE
fix(console): terminal scroll silently broken (CSS overrides + tiny defaults)

### DIFF
--- a/console/src/renderer/Terminal.tsx
+++ b/console/src/renderer/Terminal.tsx
@@ -64,6 +64,14 @@ export function Terminal({
       lineHeight: 1.2,
       cursorBlink: true,
       allowProposedApi: true,
+      // Scroll tuning. Defaults are tiny: 1000 lines of history and a
+      // wheel multiplier of 1, which feels broken on a trackpad.
+      scrollback: 10_000,
+      scrollSensitivity: 3,
+      fastScrollSensitivity: 8,
+      // When the user types, jump back to the bottom — matches every
+      // other terminal app's behavior.
+      scrollOnUserInput: true,
       theme: {
         background: '#0f1115',
         foreground: '#e6e9ef',

--- a/console/src/renderer/styles.css
+++ b/console/src/renderer/styles.css
@@ -660,13 +660,30 @@ body,
 .terminal__pane {
   flex: 1;
   min-height: 0;
-  padding: 0.4rem;
+  /* xterm.js sizes itself via FitAddon; we just need to give it a
+     correctly-sized flex container with a small inset. Avoid imposing
+     height:100% on its inner elements — that broke the scrollback
+     viewport's overflow handling and silently disabled wheel scroll. */
+  position: relative;
 }
 
-.terminal__pane .xterm,
-.terminal__pane .xterm-viewport,
-.terminal__pane .xterm-screen {
-  height: 100% !important;
+/* Scrollbar styling — give xterm's viewport a visible, dark scrollbar
+   so it's obvious that scrollback is reachable. */
+.terminal__pane .xterm-viewport {
+  overflow-y: auto !important;
+}
+
+.terminal__pane .xterm-viewport::-webkit-scrollbar {
+  width: 8px;
+}
+
+.terminal__pane .xterm-viewport::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 4px;
+}
+
+.terminal__pane .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: var(--text-dim);
 }
 
 .terminal__overlay {


### PR DESCRIPTION
## Summary

You couldn't scroll the embedded terminals — real bug, two causes.

## Root cause

### 1. CSS overrides forced all xterm internals to 100% height

\`\`\`css
.terminal__pane .xterm,
.terminal__pane .xterm-viewport,
.terminal__pane .xterm-screen {
  height: 100% !important;
}
\`\`\`

I added these early on to make sure xterm filled its container. But xterm.js has internal layout: \`.xterm\` is the outer wrapper, \`.xterm-viewport\` is the **scrollable** element with overflow:auto, and \`.xterm-screen\` is the **visible** area inside it. Forcing them all to 100% meant the screen always equaled the viewport — no overflow, nothing to scroll. Wheel events had nowhere to go.

The FitAddon was already sizing things correctly from the flex parent. The overrides were a fix for an imagined problem.

### 2. Defaults too conservative

| Option | Was | Now |
|---|---|---|
| \`scrollback\` | 1000 | 10000 |
| \`scrollSensitivity\` | 1 | 3 |
| \`fastScrollSensitivity\` | 5 | 8 |
| \`scrollOnUserInput\` | (default false) | true |

A trackpad's tiny deltas felt unresponsive at sensitivity 1. \`scrollOnUserInput\` matches every other terminal app — typing snaps you back to the bottom.

Plus styled the viewport scrollbar so it's visible against the dark theme; without that, even when scroll worked you couldn't see you had history.

## Verification

All green: typecheck, lint, format, build.

## Test plan

- [ ] Pull, restart \`pnpm dev\`
- [ ] In a terminal, run \`for i in {1..200}; do echo \"line \$i\"; done\` to fill scrollback
- [ ] Two-finger scroll up on trackpad → scrolls smoothly
- [ ] Mouse wheel up → scrolls
- [ ] Shift + wheel → scrolls fast
- [ ] Type a key → snaps back to bottom
- [ ] Visible dark scrollbar on the right of the terminal pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)