### PR TITLE
H1: record_state MCP tool + dossier schema (#71)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -369,6 +369,39 @@ The existing memory/lessons system becomes a console feature, not a separate CLI
 
 ---
 
+## Phase H — Pilot loop (self-driving fleet)
+
+> **Tracked in epic #70** (sub-issues #71–#81). H1 in flight.
+
+The leap past "autonomous execution given a brief" to "agents that pull their own work and only interrupt me when they need to." Each agent runs a continuous loop: find work → triage → scope → plan → resolve design → develop → self-judge → local-verify → labs-deploy → PR. Humans get pulled in only at calibrated decision points.
+
+The unlocking primitive is the **dossier** — a structured agent self-report (current plan, what was just done, current phase, blocker if parked, options if waiting on a decision). The console renders the dossier per agent instead of forcing the operator to scroll the transcript. Combined with **interactive takeover** (pause SDK run → `claude --resume` in the same session → hand back to orchestrator) and **lossless parking** (sdk_session_id + dossier preserve full state), this inverts the operator role: instead of driving four sessions, you triage attention across four agents.
+
+The "polling now, webhooks later" call: each agent's pilot daemon polls every ~30s for unblocked parked work or new triage candidates. Webhooks (Jira/Slack/BB) are deferred until the polling loop proves out.
+
+### Issues
+
+- H1 (#71) — Dossier schema + `record_state` MCP tool [in flight]
+- H2 (#72) — Dossier persistence + console rendering
+- H3 (#73) — Interactive takeover (pause → `claude --resume` → orchestrated resume)
+- H4 (#74) — `ranch triage` — rank assigned Jira tickets
+- H5 (#75) — `ranch scope <ticket>` — context bundle
+- H6 (#76) — `ranch propose <ticket>` — bounded plan + acceptance criteria
+- H7 (#77) — `ranch design <ticket>` — figma frame discovery
+- H8 (#78) — Self-judge integration loop
+- H9 (#79) — Ethan-labs deploy handoff
+- H10 (#80) — PR draft with testing instructions + labs link + Qase MCP
+- H11 (#81) — Agent scheduler — proactive multi-ticket loop
+
+### Open design questions
+
+- Confidence policy per stage per agent (which stages auto-proceed)
+- Viability scoring weights for triage
+- Figma discovery confidence thresholds for auto-pick
+- Multi-worktree-per-agent semantics (today 1:1; pilot scheduler may need to revisit)
+
+---
+
 ## Phase G — Production hardening (deferred)
 
 When the console proves out, these become real concerns. Not before.

--- a/ranch/runner/messages.py
+++ b/ranch/runner/messages.py
@@ -35,6 +35,56 @@ class DecisionLogInput(BaseModel):
     rationale: str
 
 
+# ─── Dossier: structured agent self-report (Phase H1) ────────────────────────
+
+
+DossierState = Literal[
+    "researching",
+    "planning",
+    "coding",
+    "testing",
+    "judging",
+    "parked",
+]
+
+
+class PlanStep(BaseModel):
+    step: str
+    status: Literal["pending", "in_progress", "done"]
+    notes: Optional[str] = None
+
+
+class DossierOption(BaseModel):
+    """One choice surfaced to the human when the agent parks needing a decision."""
+
+    label: str
+    description: str
+
+
+class RecordStateInput(BaseModel):
+    """Payload the agent sends when calling mcp__ranch__record_state.
+
+    The dossier is the agent's structured self-report of where it is right now.
+    The console renders it as the primary view of the run (replacing the need
+    to scroll the transcript). See ROADMAP Phase H1.
+    """
+
+    plan: list[PlanStep]
+    just_did: str
+    state: DossierState
+    blocker: Optional[str] = None
+    options: Optional[list[DossierOption]] = None
+    files_touched: list[str] = []
+    ticket: Optional[str] = None
+
+    @field_validator("just_did")
+    @classmethod
+    def just_did_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("just_did must not be empty")
+        return v
+
+
 # ─── Outbound: ranch → agent ──────────────────────────────────────────────────
 
 

--- a/ranch/runner/orchestrator.py
+++ b/ranch/runner/orchestrator.py
@@ -128,6 +128,7 @@ class Orchestrator:
             allowed_tools=[
                 "Read", "Write", "Edit", "Bash", "Grep", "Glob",
                 "mcp__ranch__record_checkpoint", "mcp__ranch__log_decision",
+                "mcp__ranch__record_state",
             ],
             hooks={"PostToolUse": [make_checkpoint_hook(self)]},
             permission_mode="acceptEdits",

--- a/ranch/runner/prompts.py
+++ b/ranch/runner/prompts.py
@@ -38,6 +38,23 @@ When you receive `HUMAN DECISION ... APPROVED`:
 When you receive `HUMAN DECISION ... REJECTED`:
 - Read the reason, fix the issue, and re-record the same checkpoint when you're done.
 
+## Keeping your dossier current
+
+Call `record_state(plan, just_did, state, ...)` to update your dossier — the
+structured snapshot of where you are right now. The console renders this as
+the primary view of your run, so the human can glance at it instead of
+reading your transcript.
+
+Call it at these moments:
+- Right after finalizing your plan (state=`planning`, plan steps populated)
+- After each plan step transitions to `done` (state=`coding` or `testing`)
+- When entering a new phase (e.g. coding → testing → judging)
+- Before parking at any checkpoint (state=`parked`, blocker populated, options listed)
+- Whenever your understanding shifts materially (new blocker discovered, scope change)
+
+Be terse — `just_did` is one or two sentences in plain English, not raw tool calls.
+Don't update on every tool use; that's noise. Aim for ~one update per natural beat.
+
 ## Rules
 
 - Never push, open a PR, or create a branch without a `pre_push` approval.
@@ -81,6 +98,11 @@ Your instructions are in the user message. Do exactly what's asked — no assume
 - Use `record_checkpoint(kind="custom", summary=...)` any time you want the human to review
   something before you continue. This is optional but encouraged at natural stopping points.
 - Log non-trivial decisions with `log_decision`.
+- Use `record_state(plan, just_did, state, ...)` to keep your dossier current — a structured
+  snapshot of where you are. The console renders this so the human can glance at your progress
+  without reading the transcript. Call it at natural beats: after framing your approach, when
+  switching phases, before parking. `just_did` is one or two sentences in plain English. Don't
+  update on every tool use; that's noise.
 - If you are stuck or uncertain, say so in plain text and wait for the human.
 - Be concise — the human is watching the stream live.
 """

--- a/ranch/runner/tools.py
+++ b/ranch/runner/tools.py
@@ -36,6 +36,63 @@ DECISION_INPUT_SCHEMA = {
     "required": ["decision", "rationale"],
 }
 
+STATE_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "plan": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "step": {"type": "string"},
+                    "status": {
+                        "type": "string",
+                        "enum": ["pending", "in_progress", "done"],
+                    },
+                    "notes": {"type": "string"},
+                },
+                "required": ["step", "status"],
+            },
+            "description": "Ordered plan steps with current status.",
+        },
+        "just_did": {
+            "type": "string",
+            "description": "One or two sentences summarizing your most recent action, in plain English (not raw tool calls).",
+        },
+        "state": {
+            "type": "string",
+            "enum": ["researching", "planning", "coding", "testing", "judging", "parked"],
+            "description": "What phase are you in right now.",
+        },
+        "blocker": {
+            "type": "string",
+            "description": "If state=parked, what's blocking you. Otherwise omit.",
+        },
+        "options": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "label": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+                "required": ["label", "description"],
+            },
+            "description": "If parked and human needs to decide, the choices to surface.",
+        },
+        "files_touched": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Files modified so far this run.",
+        },
+        "ticket": {
+            "type": "string",
+            "description": "Ticket identifier (e.g. ECD-1234), if known.",
+        },
+    },
+    "required": ["plan", "just_did", "state"],
+}
+
 
 @tool("record_checkpoint", "Record a checkpoint. Use when you've finished planning, tests pass, or before pushing.", CHECKPOINT_INPUT_SCHEMA)
 async def record_checkpoint(args: dict) -> dict:
@@ -49,8 +106,19 @@ async def log_decision(args: dict) -> dict:
     return {"content": [{"type": "text", "text": "Decision logged."}]}
 
 
+@tool(
+    "record_state",
+    "Update your dossier — a structured self-report of where you are right now (plan, what you just did, phase, any blocker). Call this when finalizing a plan, completing a plan step, switching phases, or before parking.",
+    STATE_INPUT_SCHEMA,
+)
+async def record_state(args: dict) -> dict:
+    # H2 will wire the orchestrator to capture this payload and persist it.
+    # For now the tool just acknowledges so the agent's tool result is clean.
+    return {"content": [{"type": "text", "text": "Dossier updated."}]}
+
+
 ranch_mcp = create_sdk_mcp_server(
     name="ranch",
     version="0.1.0",
-    tools=[record_checkpoint, log_decision],
+    tools=[record_checkpoint, log_decision, record_state],
 )

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -5,8 +5,11 @@ from pydantic import ValidationError
 from ranch.runner.messages import (
     CheckpointInput,
     DecisionLogInput,
+    DossierOption,
     HumanDecision,
     HumanNote,
+    PlanStep,
+    RecordStateInput,
 )
 
 
@@ -143,3 +146,79 @@ def test_human_note_empty_content_allowed():
     # Empty notes are allowed — agent sees an empty note is fine
     note = HumanNote(content="")
     assert note.content == ""
+
+
+# ─── RecordStateInput / dossier (Phase H1) ───────────────────────
+
+
+def _minimal_state(**overrides):
+    base = {
+        "plan": [{"step": "Read the ticket", "status": "done"}],
+        "just_did": "Finished reading the ticket and the linked epic.",
+        "state": "planning",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_record_state_minimal_valid():
+    payload = RecordStateInput.model_validate(_minimal_state())
+    assert payload.state == "planning"
+    assert payload.plan[0].status == "done"
+    assert payload.blocker is None
+    assert payload.options is None
+    assert payload.files_touched == []
+
+
+def test_record_state_full_parked_with_options():
+    data = _minimal_state(
+        state="parked",
+        blocker="Plan approval needed — see options.",
+        options=[
+            {"label": "approve", "description": "Proceed with the proposed plan."},
+            {"label": "split", "description": "Split into ECD-1234a and ECD-1234b."},
+        ],
+        files_touched=["foo.py", "bar.py"],
+        ticket="ECD-1234",
+    )
+    payload = RecordStateInput.model_validate(data)
+    assert payload.state == "parked"
+    assert payload.options is not None
+    assert len(payload.options) == 2
+    assert payload.options[0].label == "approve"
+    assert payload.ticket == "ECD-1234"
+
+
+def test_record_state_rejects_bad_state():
+    with pytest.raises(ValidationError):
+        RecordStateInput.model_validate(_minimal_state(state="not_a_real_state"))
+
+
+def test_record_state_rejects_bad_plan_status():
+    with pytest.raises(ValidationError):
+        RecordStateInput.model_validate(
+            _minimal_state(plan=[{"step": "Do thing", "status": "halfway"}])
+        )
+
+
+def test_record_state_rejects_empty_just_did():
+    with pytest.raises(ValidationError, match="just_did must not be empty"):
+        RecordStateInput.model_validate(_minimal_state(just_did="   "))
+
+
+def test_record_state_requires_required_fields():
+    with pytest.raises(ValidationError):
+        RecordStateInput.model_validate({"plan": [], "just_did": "x"})  # missing state
+
+
+def test_plan_step_notes_optional():
+    step = PlanStep(step="Wire MCP tool", status="in_progress")
+    assert step.notes is None
+    step2 = PlanStep(step="Wire MCP tool", status="in_progress", notes="schema first")
+    assert step2.notes == "schema first"
+
+
+def test_dossier_option_requires_both_fields():
+    DossierOption(label="approve", description="Go ahead.")
+    with pytest.raises(ValidationError):
+        DossierOption(label="approve")  # missing description


### PR DESCRIPTION
## Summary

First piece of Phase H (Pilot loop, epic #70): adds the `record_state` in-process MCP tool and the Pydantic dossier schema that every later H-issue will emit into.

The dossier is the agent's structured self-report of where it is right now — plan with progress, what it just did, current phase, blocker + options if parked. The console (H2) will render this as the primary per-agent view so the operator doesn't have to scroll a 5-page transcript to know what's going on.

## Changes

- `ranch/runner/messages.py` — `PlanStep`, `DossierOption`, `RecordStateInput` Pydantic models with `just_did` non-empty validator
- `ranch/runner/tools.py` — `record_state` `@tool` + JSON schema; registered with `ranch_mcp`
- `ranch/runner/orchestrator.py` — `mcp__ranch__record_state` added to `allowed_tools` in both `run()` and `resume_run()` paths
- `ranch/runner/prompts.py` — when-to-call guidance added to both `SYSTEM_PROMPT` and `SYSTEM_PROMPT_FREE`
- `tests/test_messages.py` — 8 new tests covering minimal-valid, full-parked-with-options, enum validation, empty-just_did rejection, required-field enforcement
- `ROADMAP.md` — new Phase H section linking the epic + sub-issues

The tool body just acknowledges for now; H2 (#72) wires the orchestrator's PostToolUse hook to capture the payload and persist it.

## Test plan

- [x] `pytest tests/test_messages.py` — 26 pass (18 existing + 8 new)
- [x] `pytest` (full suite) — 135 pass
- [ ] Verify in a real run that the agent receives the tool in its allowlist and a `record_state` call returns "Dossier updated." (manual smoke after merge — no orchestrator behavior change in this PR)

## Notes for review

- Tool body is intentionally a no-op echo; persistence/render are H2's scope. Wanted to land the schema + plumbing first so the rest of the loop can depend on it.
- `record_state` is intentionally non-blocking and non-checkpointing — it's a state report, not a decision point. Approval semantics stay in `record_checkpoint`.

Closes #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)