### PR TITLE
H2a: persist record_state payloads as Dossier rows (#72)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -381,8 +381,8 @@ The "polling now, webhooks later" call: each agent's pilot daemon polls every ~3
 
 ### Issues
 
-- H1 (#71) — Dossier schema + `record_state` MCP tool [in flight]
-- H2 (#72) — Dossier persistence + console rendering
+- H1 (#71) — Dossier schema + `record_state` MCP tool [PR #82]
+- H2 (#72) — Dossier persistence + console rendering [H2a backend in flight; H2b console rendering follows]
 - H3 (#73) — Interactive takeover (pause → `claude --resume` → orchestrated resume)
 - H4 (#74) — `ranch triage` — rank assigned Jira tickets
 - H5 (#75) — `ranch scope <ticket>` — context bundle

--- a/ranch/cli.py
+++ b/ranch/cli.py
@@ -466,6 +466,61 @@ def log_cmd(run_id):
         click.echo(run.log_path)
 
 
+@cli.command("dossier")
+@click.argument("run_id", type=int)
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON instead of rendered text.")
+def dossier_cmd(run_id, as_json):
+    """Show the latest dossier (agent self-report) for a run."""
+    import json as _json
+    from .models import Dossier, Run
+
+    with db_session() as db:
+        run = db.query(Run).filter_by(id=run_id).one_or_none()
+        if not run:
+            console.print(f"[red]Run #{run_id} not found[/red]")
+            raise click.Abort()
+        latest = (
+            db.query(Dossier)
+            .filter_by(run_id=run_id)
+            .order_by(Dossier.created_at.desc())
+            .first()
+        )
+        if not latest:
+            if as_json:
+                click.echo("null")
+            else:
+                console.print(f"[yellow]Run #{run_id} has no dossier yet.[/yellow]")
+            return
+        payload = _json.loads(latest.payload_json)
+
+    if as_json:
+        click.echo(_json.dumps(payload, indent=2))
+        return
+
+    console.print(f"[bold]Run #{run_id}[/bold]  [dim]{run.agent} / {run.ticket or 'ad-hoc'}[/dim]")
+    console.print(f"State: [cyan]{payload['state']}[/cyan]")
+    console.print(f"Just did: {payload['just_did']}")
+    if payload.get("blocker"):
+        console.print(f"[yellow]Blocker:[/yellow] {payload['blocker']}")
+    plan = payload.get("plan") or []
+    if plan:
+        console.print("\n[bold]Plan[/bold]")
+        for step in plan:
+            mark = {"done": "✓", "in_progress": "▸", "pending": "·"}.get(step["status"], "·")
+            color = {"done": "green", "in_progress": "yellow", "pending": "dim"}.get(step["status"], "white")
+            console.print(f"  [{color}]{mark}[/{color}] {step['step']}")
+            if step.get("notes"):
+                console.print(f"      [dim]{step['notes']}[/dim]")
+    options = payload.get("options") or []
+    if options:
+        console.print("\n[bold]Options[/bold]")
+        for opt in options:
+            console.print(f"  • [bold]{opt['label']}[/bold] — {opt['description']}")
+    files = payload.get("files_touched") or []
+    if files:
+        console.print(f"\n[dim]Files touched ({len(files)}): {', '.join(files[:8])}{'...' if len(files) > 8 else ''}[/dim]")
+
+
 @cli.command()
 @click.option("--limit", default=20, help="Max rows to show")
 def feedback(limit):

--- a/ranch/models.py
+++ b/ranch/models.py
@@ -225,3 +225,19 @@ class Interjection(Base):
     processed_at  = Column(DateTime, nullable=True, index=True)
 
     run = relationship("Run", back_populates="interjections")
+
+
+class Dossier(Base):
+    """Agent self-report — structured snapshot of where the run is right now.
+
+    One row per `record_state` call. Latest-wins for the "current state" query
+    (`ORDER BY created_at DESC LIMIT 1`); older rows are retained so the timeline
+    view (Phase E3) can replay how the run evolved. See ROADMAP Phase H2.
+    """
+    __tablename__ = "dossiers"
+
+    id           = Column(Integer, primary_key=True, autoincrement=True)
+    run_id       = Column(Integer, ForeignKey("runs.id"), index=True)
+    state        = Column(String, index=True)         # denormalized for "show parked runs" filtering
+    payload_json = Column(Text)                       # full RecordStateInput as JSON
+    created_at   = Column(DateTime, default=utcnow, index=True)

--- a/ranch/runner/dossier.py
+++ b/ranch/runner/dossier.py
@@ -1,0 +1,43 @@
+"""Dossier persistence via PostToolUse hook.
+
+Captures `record_state` payloads emitted by the agent (Phase H1 tool) and
+writes them as `Dossier` rows. Unlike the checkpoint hook, this hook is
+non-blocking — dossier updates are informational, never approval gates.
+"""
+from __future__ import annotations
+
+from claude_code_sdk import HookMatcher
+from claude_code_sdk.types import HookContext
+from pydantic import ValidationError
+
+from ranch.runner.messages import RecordStateInput
+
+STATE_TOOL = "mcp__ranch__record_state"
+
+
+def make_dossier_hook(orchestrator) -> HookMatcher:
+    """Return a HookMatcher that fires on record_state tool calls."""
+
+    async def on_post_tool_use(
+        input_data: dict,
+        tool_use_id: str | None,
+        context: HookContext,
+    ) -> dict:
+        tool_name = input_data.get("tool_name", "")
+        if tool_name != STATE_TOOL:
+            return {}
+
+        try:
+            dossier = RecordStateInput.model_validate(input_data.get("tool_input") or {})
+        except ValidationError as exc:
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": f"record_state validation error: {exc}",
+                }
+            }
+
+        await orchestrator.on_state(dossier)
+        return {}
+
+    return HookMatcher(matcher=STATE_TOOL, hooks=[on_post_tool_use])

--- a/ranch/runner/orchestrator.py
+++ b/ranch/runner/orchestrator.py
@@ -12,9 +12,10 @@ from rich.console import Console
 from rich.rule import Rule
 
 from ranch.db import db_session
-from ranch.models import Run, Checkpoint, Interjection
+from ranch.models import Run, Checkpoint, Dossier, Interjection
 from ranch.runner.checkpoints import make_checkpoint_hook, APPROVAL_REQUIRED
-from ranch.runner.messages import HumanDecision, HumanNote
+from ranch.runner.dossier import make_dossier_hook
+from ranch.runner.messages import HumanDecision, HumanNote, RecordStateInput
 from ranch.runner.prompts import SYSTEM_PROMPT, SYSTEM_PROMPT_FREE, initial_user_prompt
 from ranch.runner.state import transition
 from ranch.runner.tools import ranch_mcp
@@ -88,6 +89,22 @@ class Orchestrator:
     def requires_approval(self, kind: str) -> bool:
         return kind in APPROVAL_REQUIRED
 
+    # ─── Dossier callback (called from PostToolUse hook) ─────────────
+
+    async def on_state(self, dossier: RecordStateInput) -> None:
+        """Persist a dossier snapshot. Non-blocking — purely informational."""
+        with db_session() as db:
+            row = Dossier(
+                run_id=self.run_id,
+                state=dossier.state,
+                payload_json=dossier.model_dump_json(),
+            )
+            db.add(row)
+
+        console.print(
+            f"[dim cyan]→ dossier: state={dossier.state} just_did={dossier.just_did[:80]}[/dim cyan]"
+        )
+
     # ─── Main run loop ───────────────────────────────────────────────
 
     async def run(self) -> None:
@@ -130,7 +147,7 @@ class Orchestrator:
                 "mcp__ranch__record_checkpoint", "mcp__ranch__log_decision",
                 "mcp__ranch__record_state",
             ],
-            hooks={"PostToolUse": [make_checkpoint_hook(self)]},
+            hooks={"PostToolUse": [make_checkpoint_hook(self), make_dossier_hook(self)]},
             permission_mode="acceptEdits",
         )
 
@@ -402,7 +419,7 @@ async def resume_run(run_id: int) -> None:
             "Read", "Write", "Edit", "Bash", "Grep", "Glob",
             "mcp__ranch__record_checkpoint", "mcp__ranch__log_decision",
         ],
-        hooks={"PostToolUse": [make_checkpoint_hook(orch)]},
+        hooks={"PostToolUse": [make_checkpoint_hook(orch), make_dossier_hook(orch)]},
         permission_mode="acceptEdits",
         resume=sdk_session_id,
     )

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -1,0 +1,149 @@
+"""Tests for the dossier hook + persistence (Phase H2a).
+
+Covers:
+- make_dossier_hook ignores non-record_state tools
+- make_dossier_hook validates input via RecordStateInput
+- make_dossier_hook is non-blocking (no approval gate)
+- Orchestrator.on_state writes a Dossier row
+- Multiple calls accumulate (history preserved); latest-wins query works
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ranch.db import db_session, init_db
+from ranch.models import Dossier, Run
+from ranch.runner.dossier import STATE_TOOL, make_dossier_hook
+from ranch.runner.messages import RecordStateInput
+from ranch.runner.orchestrator import Orchestrator
+
+
+def _valid_input(**overrides) -> dict:
+    base = {
+        "plan": [{"step": "Read the ticket", "status": "done"}],
+        "just_did": "Finished reading the ticket and the linked epic.",
+        "state": "planning",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_run(ticket: str = "TEST-DOSS") -> int:
+    init_db()
+    with db_session() as db:
+        run = Run(agent="max", ticket=ticket, cwd="/tmp", initial_prompt="brief", state="planning")
+        db.add(run)
+        db.flush()
+        return run.id
+
+
+# ─── make_dossier_hook ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dossier_hook_ignores_non_state_tools():
+    orch = MagicMock()
+    orch.on_state = AsyncMock()
+    hook_fn = make_dossier_hook(orch).hooks[0]
+
+    result = await hook_fn({"tool_name": "Bash", "tool_input": {}}, "tid", MagicMock())
+
+    orch.on_state.assert_not_called()
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_dossier_hook_calls_on_state_with_validated_payload():
+    orch = MagicMock()
+    orch.on_state = AsyncMock()
+    hook_fn = make_dossier_hook(orch).hooks[0]
+
+    result = await hook_fn(
+        {"tool_name": STATE_TOOL, "tool_input": _valid_input()},
+        "tid",
+        MagicMock(),
+    )
+
+    orch.on_state.assert_called_once()
+    passed = orch.on_state.call_args[0][0]
+    assert isinstance(passed, RecordStateInput)
+    assert passed.state == "planning"
+    assert result == {}  # non-blocking — no approval gate
+
+
+@pytest.mark.asyncio
+async def test_dossier_hook_validation_error_returns_context():
+    orch = MagicMock()
+    orch.on_state = AsyncMock()
+    hook_fn = make_dossier_hook(orch).hooks[0]
+
+    result = await hook_fn(
+        {"tool_name": STATE_TOOL, "tool_input": {"plan": [], "state": "bogus", "just_did": "x"}},
+        "tid",
+        MagicMock(),
+    )
+
+    orch.on_state.assert_not_called()
+    ctx = result["hookSpecificOutput"]["additionalContext"]
+    assert "record_state validation error" in ctx
+
+
+# ─── Orchestrator.on_state persistence ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_state_persists_dossier_row():
+    run_id = _make_run()
+    orch = Orchestrator("max", Path("/tmp"), "TEST-DOSS", "brief")
+    orch.run_id = run_id
+
+    dossier = RecordStateInput.model_validate(_valid_input(state="coding"))
+    await orch.on_state(dossier)
+
+    with db_session() as db:
+        rows = db.query(Dossier).filter_by(run_id=run_id).all()
+        assert len(rows) == 1
+        assert rows[0].state == "coding"
+        payload = json.loads(rows[0].payload_json)
+        assert payload["just_did"] == "Finished reading the ticket and the linked epic."
+
+
+@pytest.mark.asyncio
+async def test_on_state_accumulates_history_and_latest_wins():
+    run_id = _make_run()
+    orch = Orchestrator("max", Path("/tmp"), "TEST-DOSS-2", "brief")
+    orch.run_id = run_id
+
+    # Three sequential updates simulating phase transitions.
+    await orch.on_state(RecordStateInput.model_validate(_valid_input(state="planning", just_did="Drew up the plan.")))
+    await asyncio.sleep(0.01)  # ensure created_at ordering is monotonic on SQLite
+    await orch.on_state(RecordStateInput.model_validate(_valid_input(state="coding", just_did="Wrote the failing test.")))
+    await asyncio.sleep(0.01)
+    await orch.on_state(RecordStateInput.model_validate(_valid_input(
+        state="parked",
+        just_did="Tests green, ready for review.",
+        blocker="Waiting on pre_push approval.",
+        options=[{"label": "approve", "description": "Proceed."}],
+    )))
+
+    with db_session() as db:
+        all_rows = db.query(Dossier).filter_by(run_id=run_id).order_by(Dossier.created_at.asc()).all()
+        assert len(all_rows) == 3
+        # History preserved in chronological order
+        assert [r.state for r in all_rows] == ["planning", "coding", "parked"]
+
+        latest = (
+            db.query(Dossier)
+            .filter_by(run_id=run_id)
+            .order_by(Dossier.created_at.desc())
+            .first()
+        )
+        assert latest.state == "parked"
+        payload = json.loads(latest.payload_json)
+        assert payload["blocker"] == "Waiting on pre_push approval."
+        assert payload["options"][0]["label"] == "approve"


### PR DESCRIPTION
## Summary

Backend half of Phase H2 (#72). Captures `record_state` payloads (introduced by H1) and writes them as `Dossier` rows so the console (H2b) can render them as the per-agent card.

**Stacked on top of #82 (H1).** Set the base to `feature/h1-record-state-mcp-tool` so the diff stays scoped to H2a. Once #82 merges to main, this PR auto-rebases.

## Changes

- `ranch/models.py` — new `Dossier` SQLAlchemy model: `id`, `run_id` (FK), `state` (denormalized for filtering), `payload_json` (full `RecordStateInput`), `created_at`. One row per call — history kept for E3 timeline; latest-wins query gives current state.
- `ranch/runner/dossier.py` — `make_dossier_hook(orchestrator)` PostToolUse hook. Validates payload via `RecordStateInput`; on success calls `orchestrator.on_state(dossier)`. Returns `{}` (non-blocking — dossier updates are informational, never approval gates).
- `ranch/runner/orchestrator.py` — new `Orchestrator.on_state` method persists the row + logs a one-line cyan trace. Hook registered in both `run()` and `resume_run()` paths.
- `ranch/cli.py` — new `ranch dossier <run_id> [--json]` command. Renders plan with status marks, blocker, options, files touched — or emits raw JSON for machine consumption (H11 scheduler will use this).
- `tests/test_dossier.py` — 5 new tests: hook ignores non-state tools, validates input, returns context on validation error; `on_state` persists row; multiple calls accumulate (history) and latest-wins query works.

## Test plan

- [x] `pytest tests/test_dossier.py` — 5 pass
- [x] `pytest` (full) — 140 pass (135 existing + 5 new)
- [x] Smoke test of `ranch dossier <id>` against a real DB row — renders cleanly with state, plan checklist, blocker, options, files touched

## Why split H2

H2 originally bundles backend persistence + console rendering. Splitting into H2a (this PR, Python only) and H2b (console TS/React) was a deliberate call: there's in-flight uncommitted work on `console/src/main/pty.ts` and `console/src/renderer/Terminal.tsx` (the memory-leak fix). Layering H2b's render work onto that risks tangling unrelated changes. Backend ships independently; the H2 issue stays open until H2b lands.

## Smoke test render

For a parked run with two plan steps and two options:

```
Run #57  max / ECD-9999
State: parked
Just did: Wired up the MCP tool.
Blocker: Need plan approval.

Plan
  ✓ Plan it
  ▸ Build it

Options
  • approve — Proceed with the plan.
  • reject — Send feedback.

Files touched (2): a.py, b.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)