### PR TITLE
H4: ranch triage — rank assigned Jira tickets by viability (#74)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -384,7 +384,7 @@ The "polling now, webhooks later" call: each agent's pilot daemon polls every ~3
 - H1 (#71) — Dossier schema + `record_state` MCP tool [PR #82]
 - H2 (#72) — Dossier persistence + console rendering [H2a backend in flight; H2b console rendering follows]
 - H3 (#73) — Interactive takeover (pause → `claude --resume` → orchestrated resume)
-- H4 (#74) — `ranch triage` — rank assigned Jira tickets
+- H4 (#74) — `ranch triage` — rank assigned Jira tickets [in flight]
 - H5 (#75) — `ranch scope <ticket>` — context bundle
 - H6 (#76) — `ranch propose <ticket>` — bounded plan + acceptance criteria
 - H7 (#77) — `ranch design <ticket>` — figma frame discovery

--- a/USAGE.md
+++ b/USAGE.md
@@ -97,6 +97,39 @@ ranch runs --agent max      # filter by agent
 ranch resume 3              # resume run #3 by SDK session ID
 ```
 
+## Triage assigned Jira tickets (Phase H4)
+
+Rank your assigned Jira tickets by viability (status, design presence, AC clarity, priority, age) so the ranch hand (or you) can pick what to work on next.
+
+```bash
+ranch triage                         # top 10 viable tickets across all projects
+ranch triage --project ECD           # filter to one Jira project
+ranch triage --agent max --top 5     # exclude tickets max is already in flight on
+ranch triage --json                  # machine-readable, consumed by the ranch hand scheduler
+```
+
+One-time setup in `~/.ranch/config.toml`:
+
+```toml
+[jira]
+url = "https://yourorg.atlassian.net"
+email = "you@example.com"
+```
+
+Then export your API token (create at https://id.atlassian.com/manage-profile/security/api-tokens):
+
+```bash
+export RANCH_JIRA_API_TOKEN="…"
+```
+
+Scoring axes (higher is more viable):
+- **Status**: +30 in-progress, +20 to-do, 0 if blocked / waiting-for-design / on-hold
+- **Design link**: +20 if a figma.com URL is in the description or comments
+- **AC clarity**: +15 if "Acceptance Criteria" header or numbered should/must items
+- **Priority**: Highest +15, High +10, Medium +5, Low 0, Lowest -5
+- **Age**: log-bounded, max +10 (older tickets get a small boost so nothing rots)
+- **In-flight penalty**: -1000 (excluded) if this agent already has a non-terminal run on the ticket
+
 ## Dossier view (agent self-report — Phase H)
 
 While a run is happening, the agent emits structured dossier updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "claude-code-sdk>=0.0.14",
     "python-dotenv>=1.0",
     "anyio>=4.0",
+    "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/ranch/cli.py
+++ b/ranch/cli.py
@@ -599,6 +599,93 @@ def dossier_cmd(run_id, as_json, watch, interval):
             pass
 
 
+@cli.command("triage")
+@click.option("--agent", default=None, help="Exclude tickets already in flight for this agent (default: anyone).")
+@click.option("--project", default=None, help="Filter to a single Jira project key (e.g. ECD).")
+@click.option("--top", "top_n", default=10, type=int, help="Show only the top N candidates.")
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON suitable for scripting (e.g. by the ranch hand scheduler).")
+def triage_cmd(agent, project, top_n, as_json):
+    """Rank assigned Jira tickets by viability (Phase H4)."""
+    import json as _json
+    from .triage import (
+        JiraClient,
+        JiraConfig,
+        JiraConfigError,
+        in_flight_ticket_keys_for_agent,
+        triage,
+    )
+
+    try:
+        cfg = JiraConfig.load()
+    except JiraConfigError as e:
+        console.print(f"[red]{e}[/red]")
+        raise click.Abort()
+
+    in_flight = in_flight_ticket_keys_for_agent(agent)
+
+    try:
+        with JiraClient(cfg) as client:
+            tickets = client.list_assigned_to_me(project=project)
+    except Exception as e:
+        console.print(f"[red]Jira request failed:[/red] {e}")
+        raise click.Abort()
+
+    ranked = triage(tickets, in_flight)
+    top = ranked[:top_n]
+
+    if as_json:
+        out = [
+            {
+                "key": t.key,
+                "summary": t.summary,
+                "status": t.status,
+                "priority": t.priority,
+                "has_figma_link": t.has_figma_link,
+                "score": {
+                    "total": s.total,
+                    "status": s.status,
+                    "design_present": s.design_present,
+                    "ac_clarity": s.ac_clarity,
+                    "priority": s.priority,
+                    "age": s.age,
+                },
+            }
+            for t, s in top
+        ]
+        click.echo(_json.dumps(out, indent=2))
+        return
+
+    if not top:
+        console.print("[yellow]No viable tickets found.[/yellow]")
+        if in_flight:
+            console.print(f"[dim]({len(in_flight)} ticket(s) excluded as already in flight: {', '.join(sorted(in_flight))})[/dim]")
+        return
+
+    table = Table(title=f"Triage — top {len(top)} of {len(ranked)}", show_header=True)
+    table.add_column("Rank", style="dim", width=4)
+    table.add_column("Key", style="bold cyan")
+    table.add_column("Status")
+    table.add_column("Pri", width=8)
+    table.add_column("Figma", justify="center", width=5)
+    table.add_column("AC", justify="center", width=4)
+    table.add_column("Score", justify="right", width=6)
+    table.add_column("Summary")
+    for i, (t, s) in enumerate(top, 1):
+        table.add_row(
+            str(i),
+            t.key,
+            t.status,
+            t.priority or "—",
+            "✓" if t.has_figma_link else "—",
+            "✓" if s.ac_clarity > 0 else "—",
+            f"{s.total:.0f}",
+            t.summary[:60] + ("…" if len(t.summary) > 60 else ""),
+        )
+    console.print(table)
+    if in_flight:
+        console.print(f"[dim]Excluded {len(in_flight)} ticket(s) already in flight: {', '.join(sorted(in_flight))}[/dim]")
+
+
 @cli.command("fleet")
 @click.option("--all", "show_all", is_flag=True, help="Include completed/stopped/error runs.")
 @click.option("--watch", "watch", is_flag=True, help="Refresh in place every --interval seconds.")

--- a/ranch/triage.py
+++ b/ranch/triage.py
@@ -1,0 +1,355 @@
+"""H4 — `ranch triage`: rank assigned Jira tickets by viability.
+
+Pure logic + a thin Jira REST client behind an interface so tests can
+mock without touching the network.
+
+Phase H4 of the Ranch hand epic (#70). Used by the hand's scheduler (#81)
+to pick what to work on next.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Protocol
+
+import httpx
+import tomllib
+
+from .config import CONFIG_FILE
+
+FIGMA_URL_RE = re.compile(r"https?://(?:www\.)?figma\.com/[^\s)>\]]+", re.IGNORECASE)
+TICKET_ID_RE = re.compile(r"[A-Z]+-\d+")
+
+# Status categories Jira Cloud exposes. Atlassian groups all workflow statuses
+# into one of these three: "new" (TODO), "indeterminate" (in progress / review),
+# "done" (terminal).
+_VIABLE_CATEGORIES = {"new", "indeterminate"}
+
+# Priority → points. Matches the default Jira priority ladder; unknown values
+# fall through to 0.
+_PRIORITY_SCORE = {
+    "highest": 15,
+    "high": 10,
+    "medium": 5,
+    "low": 0,
+    "lowest": -5,
+}
+
+
+# ─── Config ────────────────────────────────────────────────────────
+
+
+@dataclass
+class JiraConfig:
+    """Jira connection config, loaded from ~/.ranch/config.toml + env."""
+
+    url: str  # e.g. "https://citemed.atlassian.net"
+    email: str
+    api_token: str  # from RANCH_JIRA_API_TOKEN env var
+
+    @classmethod
+    def load(cls) -> "JiraConfig":
+        if not CONFIG_FILE.exists():
+            raise JiraConfigError(
+                f"No config at {CONFIG_FILE}. Run `ranch init` first."
+            )
+        with open(CONFIG_FILE, "rb") as f:
+            data = tomllib.load(f)
+        jira = data.get("jira")
+        if not jira:
+            raise JiraConfigError(
+                "No [jira] section in ~/.ranch/config.toml. Add:\n"
+                "    [jira]\n"
+                '    url = "https://yourorg.atlassian.net"\n'
+                '    email = "you@example.com"\n'
+                "Then set RANCH_JIRA_API_TOKEN to your API token "
+                "(create one at https://id.atlassian.com/manage-profile/security/api-tokens)."
+            )
+        token = os.environ.get("RANCH_JIRA_API_TOKEN", "").strip()
+        if not token:
+            raise JiraConfigError(
+                "RANCH_JIRA_API_TOKEN env var is unset or empty. "
+                "Create a token at https://id.atlassian.com/manage-profile/security/api-tokens"
+            )
+        url = str(jira.get("url", "")).rstrip("/")
+        email = str(jira.get("email", "")).strip()
+        if not url or not email:
+            raise JiraConfigError("[jira] section is missing `url` or `email`.")
+        return cls(url=url, email=email, api_token=token)
+
+
+class JiraConfigError(RuntimeError):
+    """Raised when Jira config is missing or invalid. Surface to the user."""
+
+
+# ─── Domain types ──────────────────────────────────────────────────
+
+
+@dataclass
+class JiraTicket:
+    """A normalized view of a Jira issue — agnostic to API shape so scoring
+    logic doesn't have to care about ADF / field structures."""
+
+    key: str
+    summary: str
+    status: str  # workflow status name e.g. "In Progress"
+    status_category: str  # "new" | "indeterminate" | "done"
+    priority: str | None  # "High" | None
+    created: datetime
+    updated: datetime
+    description: str  # plain-text extraction
+    comments: list[str] = field(default_factory=list)  # plain-text bodies
+    labels: list[str] = field(default_factory=list)
+    assignee_email: str | None = None
+    has_figma_link: bool = False  # derived during extraction
+
+    @property
+    def age_days(self) -> float:
+        return (datetime.now(timezone.utc) - self.created).total_seconds() / 86400
+
+
+@dataclass
+class ViabilityScore:
+    """Total + per-axis breakdown. Higher is more viable."""
+
+    total: float
+    status: float
+    design_present: float
+    ac_clarity: float
+    priority: float
+    age: float
+    in_flight_penalty: float = 0.0  # -1000 means "drop entirely"
+
+    @property
+    def dropped(self) -> bool:
+        return self.in_flight_penalty <= -1000
+
+
+# ─── Scoring (pure functions) ──────────────────────────────────────
+
+
+def _has_acceptance_criteria(text: str) -> bool:
+    """Heuristic — looks for explicit AC sections or numbered should/must lists."""
+    lowered = text.lower()
+    if "acceptance criteria" in lowered or re.search(r"\bac\s*:", lowered):
+        return True
+    # numbered "should/must" lines (e.g. "1. user should see X")
+    return bool(re.search(r"^\s*\d+[.)]\s.+\b(should|must)\b", text, re.IGNORECASE | re.MULTILINE))
+
+
+def score_ticket(
+    ticket: JiraTicket,
+    in_flight_ticket_keys: set[str],
+) -> ViabilityScore:
+    """Score a single ticket. Pure function — no I/O.
+
+    Axes:
+    - status: +30 for in-progress / ready-for-dev, +20 for to-do, 0 if blocked
+    - design_present: +20 if a figma link is found anywhere
+    - ac_clarity: +15 if description has explicit acceptance criteria
+    - priority: per ladder (Highest +15 → Lowest -5)
+    - age: log-bounded, max +10
+    - in_flight_penalty: -1000 if this agent already has a non-terminal run on it
+    """
+    if ticket.key in in_flight_ticket_keys:
+        return ViabilityScore(
+            total=-1000.0,
+            status=0, design_present=0, ac_clarity=0, priority=0, age=0,
+            in_flight_penalty=-1000.0,
+        )
+
+    # Status — penalize anything that suggests the ticket isn't actionable
+    status_lower = ticket.status.lower()
+    if any(b in status_lower for b in ("blocked", "waiting", "on hold", "needs design", "needs info")):
+        status_score = 0.0
+    elif ticket.status_category == "indeterminate":  # in-progress, in-review, etc.
+        status_score = 30.0
+    elif ticket.status_category == "new":  # to-do, open, backlog
+        status_score = 20.0
+    else:
+        status_score = 0.0
+
+    design_score = 20.0 if ticket.has_figma_link else 0.0
+    ac_score = 15.0 if _has_acceptance_criteria(ticket.description) else 0.0
+
+    priority_score = _PRIORITY_SCORE.get((ticket.priority or "").lower(), 0)
+
+    # Age — slight boost as tickets get older to prevent forever-pending.
+    # Bounded: 7 days → ~5pts, 30 days → ~10pts.
+    age = ticket.age_days
+    if age <= 0:
+        age_score = 0.0
+    else:
+        # log-ish curve: 1d=2, 7d=5, 30d=10
+        import math
+        age_score = min(10.0, math.log1p(age) * 2.5)
+
+    total = status_score + design_score + ac_score + priority_score + age_score
+    return ViabilityScore(
+        total=total,
+        status=status_score,
+        design_present=design_score,
+        ac_clarity=ac_score,
+        priority=priority_score,
+        age=age_score,
+    )
+
+
+def triage(
+    tickets: Iterable[JiraTicket],
+    in_flight_ticket_keys: set[str],
+) -> list[tuple[JiraTicket, ViabilityScore]]:
+    """Rank tickets by viability, descending. Dropped tickets (in-flight) excluded.
+
+    Pure function — no I/O. Caller fetches tickets from somewhere (real Jira or
+    a stub) and feeds them in.
+    """
+    scored = [(t, score_ticket(t, in_flight_ticket_keys)) for t in tickets]
+    scored = [s for s in scored if not s[1].dropped]
+    scored.sort(key=lambda pair: pair[1].total, reverse=True)
+    return scored
+
+
+# ─── Jira client ───────────────────────────────────────────────────
+
+
+def _adf_to_text(node) -> str:
+    """Walk an Atlassian Document Format tree and extract plain text.
+
+    Jira Cloud returns description as ADF JSON. We don't render formatting —
+    we just want the text for keyword/regex scanning.
+    """
+    if node is None:
+        return ""
+    if isinstance(node, str):
+        return node
+    if isinstance(node, list):
+        return "\n".join(_adf_to_text(n) for n in node)
+    if isinstance(node, dict):
+        kind = node.get("type")
+        if kind == "text":
+            return node.get("text", "")
+        # Recurse into children
+        return _adf_to_text(node.get("content", []))
+    return ""
+
+
+def _normalize_ticket(issue: dict) -> JiraTicket:
+    """Map a Jira REST `issue` dict to our JiraTicket dataclass."""
+    fields = issue.get("fields") or {}
+    status = fields.get("status") or {}
+    status_cat = (status.get("statusCategory") or {}).get("key", "")
+    priority = fields.get("priority") or {}
+    assignee = fields.get("assignee") or {}
+
+    description = _adf_to_text(fields.get("description"))
+    comments_block = (fields.get("comment") or {}).get("comments") or []
+    comments = [_adf_to_text(c.get("body")) for c in comments_block]
+
+    haystack = description + "\n" + "\n".join(comments)
+    has_figma = bool(FIGMA_URL_RE.search(haystack))
+
+    created = _parse_jira_dt(fields.get("created"))
+    updated = _parse_jira_dt(fields.get("updated"))
+
+    return JiraTicket(
+        key=issue["key"],
+        summary=fields.get("summary", ""),
+        status=status.get("name", ""),
+        status_category=status_cat,
+        priority=priority.get("name") if priority else None,
+        created=created,
+        updated=updated,
+        description=description,
+        comments=comments,
+        labels=fields.get("labels") or [],
+        assignee_email=assignee.get("emailAddress"),
+        has_figma_link=has_figma,
+    )
+
+
+def _parse_jira_dt(s: str | None) -> datetime:
+    """Parse Jira's ISO-with-offset timestamps. Falls back to epoch on missing."""
+    if not s:
+        return datetime.fromtimestamp(0, tz=timezone.utc)
+    # Jira returns e.g. "2026-04-18T12:34:56.789+0000" — datetime.fromisoformat
+    # accepts +00:00 but not +0000, so normalize.
+    if re.search(r"[+-]\d{4}$", s):
+        s = s[:-5] + s[-5:-2] + ":" + s[-2:]
+    return datetime.fromisoformat(s).astimezone(timezone.utc)
+
+
+class JiraSource(Protocol):
+    """Minimal interface — lets tests swap in a fake source."""
+
+    def list_assigned_to_me(self, *, project: str | None = None) -> list[JiraTicket]: ...
+
+
+class JiraClient:
+    """Live Jira REST client. Auth via Basic (email + API token)."""
+
+    def __init__(self, config: JiraConfig, *, timeout: float = 15.0):
+        self._cfg = config
+        self._client = httpx.Client(
+            base_url=config.url,
+            auth=(config.email, config.api_token),
+            timeout=timeout,
+            headers={"Accept": "application/json"},
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "JiraClient":
+        return self
+
+    def __exit__(self, *args) -> None:
+        self.close()
+
+    def list_assigned_to_me(self, *, project: str | None = None) -> list[JiraTicket]:
+        """Return all open tickets currently assigned to the authenticated user."""
+        jql_parts = ["assignee = currentUser()", "statusCategory != Done"]
+        if project:
+            jql_parts.append(f"project = {project}")
+        jql = " AND ".join(jql_parts) + " ORDER BY priority DESC, updated DESC"
+
+        # Jira Cloud's /rest/api/3/search/jql is the documented endpoint.
+        # We pull a generous set of fields so scoring is fully informed without
+        # follow-up calls.
+        params = {
+            "jql": jql,
+            "fields": "summary,status,priority,created,updated,description,comment,labels,assignee",
+            "maxResults": 100,
+        }
+        resp = self._client.get("/rest/api/3/search", params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        return [_normalize_ticket(issue) for issue in data.get("issues", [])]
+
+
+# ─── In-flight detection (from ranch's own DB) ─────────────────────
+
+
+def in_flight_ticket_keys_for_agent(agent: str | None = None) -> set[str]:
+    """Return ticket keys this agent (or anyone, if agent is None) already has
+    an active run on. Used to exclude double-pick during triage."""
+    from .db import db_session
+    from .models import Run
+
+    terminal = {"completed", "stopped", "error"}
+    keys: set[str] = set()
+    with db_session() as db:
+        q = db.query(Run.ticket).filter(~Run.state.in_(terminal))
+        if agent:
+            q = q.filter(Run.agent == agent)
+        for (ticket,) in q.all():
+            if ticket:
+                # Normalize whatever's stored to a Jira-style key
+                m = TICKET_ID_RE.search(ticket)
+                if m:
+                    keys.add(m.group(0))
+                else:
+                    keys.add(ticket)
+    return keys

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -1,0 +1,354 @@
+"""Tests for the triage scorer and the Jira normalization helpers.
+
+The live JiraClient is exercised via mocked HTTP responses so tests stay
+hermetic — no network needed.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+
+from ranch.db import db_session, init_db
+from ranch.models import Run
+from ranch.triage import (
+    JiraConfig,
+    JiraClient,
+    JiraTicket,
+    _adf_to_text,
+    _normalize_ticket,
+    in_flight_ticket_keys_for_agent,
+    score_ticket,
+    triage,
+)
+
+
+def _ticket(**overrides) -> JiraTicket:
+    base = dict(
+        key="ECD-100",
+        summary="Add /healthz endpoint",
+        status="In Progress",
+        status_category="indeterminate",
+        priority="Medium",
+        created=datetime.now(timezone.utc) - timedelta(days=3),
+        updated=datetime.now(timezone.utc),
+        description="Add a healthz endpoint per the design.",
+        comments=[],
+        labels=[],
+        has_figma_link=False,
+    )
+    base.update(overrides)
+    return JiraTicket(**base)
+
+
+# ─── score_ticket ──────────────────────────────────────────────────
+
+
+def test_status_in_progress_scores_30():
+    t = _ticket(status="In Progress", status_category="indeterminate")
+    s = score_ticket(t, set())
+    assert s.status == 30
+
+
+def test_status_todo_scores_20():
+    t = _ticket(status="To Do", status_category="new")
+    s = score_ticket(t, set())
+    assert s.status == 20
+
+
+def test_status_blocked_keyword_zeros_status():
+    t = _ticket(status="Blocked", status_category="indeterminate")
+    s = score_ticket(t, set())
+    assert s.status == 0
+
+
+def test_status_waiting_for_design_zeros_status():
+    t = _ticket(status="Needs Design", status_category="new")
+    s = score_ticket(t, set())
+    assert s.status == 0
+
+
+def test_figma_link_present_adds_20():
+    t = _ticket(has_figma_link=True)
+    s = score_ticket(t, set())
+    assert s.design_present == 20
+
+
+def test_figma_link_absent_zeroes_design():
+    t = _ticket(has_figma_link=False)
+    s = score_ticket(t, set())
+    assert s.design_present == 0
+
+
+def test_ac_explicit_header_recognized():
+    t = _ticket(description="## Acceptance Criteria\n- foo\n- bar")
+    s = score_ticket(t, set())
+    assert s.ac_clarity == 15
+
+
+def test_ac_numbered_should_recognized():
+    t = _ticket(description="1. User should be able to click submit.\n2. The toast should fire.")
+    s = score_ticket(t, set())
+    assert s.ac_clarity == 15
+
+
+def test_ac_missing_scores_zero():
+    t = _ticket(description="Just a vague description.")
+    s = score_ticket(t, set())
+    assert s.ac_clarity == 0
+
+
+@pytest.mark.parametrize("priority,expected", [
+    ("Highest", 15),
+    ("High", 10),
+    ("Medium", 5),
+    ("Low", 0),
+    ("Lowest", -5),
+    (None, 0),
+    ("Unknown", 0),
+])
+def test_priority_ladder(priority, expected):
+    t = _ticket(priority=priority)
+    s = score_ticket(t, set())
+    assert s.priority == expected
+
+
+def test_age_grows_with_time_but_bounded():
+    one_day = _ticket(created=datetime.now(timezone.utc) - timedelta(days=1))
+    week = _ticket(created=datetime.now(timezone.utc) - timedelta(days=7))
+    month = _ticket(created=datetime.now(timezone.utc) - timedelta(days=30))
+    year = _ticket(created=datetime.now(timezone.utc) - timedelta(days=365))
+
+    s1 = score_ticket(one_day, set()).age
+    s7 = score_ticket(week, set()).age
+    s30 = score_ticket(month, set()).age
+    s365 = score_ticket(year, set()).age
+
+    # Monotonically non-decreasing
+    assert s1 <= s7 <= s30 <= s365
+    # Bounded at 10
+    assert s365 <= 10.0
+
+
+def test_in_flight_drops_to_negative_thousand():
+    t = _ticket(key="ECD-999")
+    s = score_ticket(t, {"ECD-999"})
+    assert s.dropped is True
+    assert s.total == -1000
+
+
+def test_total_is_sum_of_axes():
+    t = _ticket(
+        priority="High",
+        has_figma_link=True,
+        description="## Acceptance Criteria\n1. x",
+        status="In Progress",
+        status_category="indeterminate",
+        created=datetime.now(timezone.utc) - timedelta(days=2),
+    )
+    s = score_ticket(t, set())
+    expected = s.status + s.design_present + s.ac_clarity + s.priority + s.age
+    assert s.total == pytest.approx(expected)
+
+
+# ─── triage (ranking) ──────────────────────────────────────────────
+
+
+def test_triage_excludes_in_flight_and_ranks_descending():
+    tickets = [
+        _ticket(key="ECD-1", priority="Low", has_figma_link=False, description="vague"),
+        _ticket(key="ECD-2", priority="Highest", has_figma_link=True,
+                description="## Acceptance Criteria\n1. should"),
+        _ticket(key="ECD-3", priority="Medium", has_figma_link=True,
+                description="## Acceptance Criteria\n1. should"),
+        _ticket(key="ECD-DROP", priority="Highest", has_figma_link=True,
+                description="## Acceptance Criteria\n1. should"),
+    ]
+    ranked = triage(tickets, {"ECD-DROP"})
+    keys = [t.key for t, _ in ranked]
+    assert "ECD-DROP" not in keys
+    assert keys == ["ECD-2", "ECD-3", "ECD-1"]
+
+
+def test_triage_empty_input_returns_empty():
+    assert triage([], set()) == []
+
+
+# ─── ADF extraction ────────────────────────────────────────────────
+
+
+def test_adf_to_text_walks_paragraph_tree():
+    doc = {
+        "type": "doc",
+        "content": [
+            {"type": "paragraph", "content": [
+                {"type": "text", "text": "Hello "},
+                {"type": "text", "text": "world"},
+            ]},
+            {"type": "paragraph", "content": [{"type": "text", "text": "Line 2"}]},
+        ],
+    }
+    assert "Hello " in _adf_to_text(doc)
+    assert "world" in _adf_to_text(doc)
+    assert "Line 2" in _adf_to_text(doc)
+
+
+def test_adf_to_text_handles_none():
+    assert _adf_to_text(None) == ""
+
+
+def test_adf_to_text_handles_string():
+    assert _adf_to_text("plain") == "plain"
+
+
+# ─── Jira normalization ────────────────────────────────────────────
+
+
+def test_normalize_ticket_extracts_all_fields():
+    issue = {
+        "key": "ECD-1234",
+        "fields": {
+            "summary": "Add /foo endpoint",
+            "status": {"name": "In Progress", "statusCategory": {"key": "indeterminate"}},
+            "priority": {"name": "High"},
+            "created": "2026-04-01T10:00:00.000+0000",
+            "updated": "2026-04-15T10:00:00.000+0000",
+            "labels": ["backend", "api"],
+            "assignee": {"emailAddress": "max@example.com"},
+            "description": {
+                "type": "doc",
+                "content": [{"type": "paragraph", "content": [{"type": "text", "text": "See https://figma.com/file/abc"}]}],
+            },
+            "comment": {
+                "comments": [
+                    {"body": {"type": "doc", "content": [
+                        {"type": "paragraph", "content": [{"type": "text", "text": "Looks good"}]},
+                    ]}},
+                ],
+            },
+        },
+    }
+    t = _normalize_ticket(issue)
+    assert t.key == "ECD-1234"
+    assert t.summary == "Add /foo endpoint"
+    assert t.status == "In Progress"
+    assert t.status_category == "indeterminate"
+    assert t.priority == "High"
+    assert "figma.com/file/abc" in t.description
+    assert t.has_figma_link is True
+    assert t.labels == ["backend", "api"]
+    assert t.assignee_email == "max@example.com"
+    assert t.created.year == 2026
+
+
+def test_normalize_ticket_handles_missing_fields():
+    issue = {"key": "ECD-1", "fields": {}}
+    t = _normalize_ticket(issue)
+    assert t.key == "ECD-1"
+    assert t.summary == ""
+    assert t.priority is None
+    assert t.has_figma_link is False
+
+
+def test_figma_link_detected_only_in_comments():
+    """A figma link in a comment (not description) still counts."""
+    issue = {
+        "key": "ECD-X",
+        "fields": {
+            "description": {"type": "doc", "content": []},
+            "comment": {"comments": [{"body": {"type": "doc", "content": [
+                {"type": "paragraph", "content": [
+                    {"type": "text", "text": "Design at https://figma.com/file/xyz"},
+                ]},
+            ]}}]},
+        },
+    }
+    t = _normalize_ticket(issue)
+    assert t.has_figma_link is True
+
+
+# ─── In-flight detection ───────────────────────────────────────────
+
+
+def test_in_flight_ticket_keys_extracts_jira_keys():
+    init_db()
+    with db_session() as db:
+        # Various ticket formats and states
+        db.add_all([
+            Run(agent="max", ticket="ECD-100", cwd="/tmp", initial_prompt="x", state="planning"),
+            Run(agent="max", ticket="feature/ECD-200-foo", cwd="/tmp", initial_prompt="x", state="in_development"),
+            Run(agent="max", ticket="ECD-300", cwd="/tmp", initial_prompt="x", state="completed"),
+            Run(agent="jeffy", ticket="ECD-400", cwd="/tmp", initial_prompt="x", state="planning"),
+        ])
+
+    keys = in_flight_ticket_keys_for_agent("max")
+    assert keys == {"ECD-100", "ECD-200"}  # 300 is completed (terminal), 400 is jeffy's
+
+
+def test_in_flight_ticket_keys_no_agent_filter_returns_all():
+    init_db()
+    with db_session() as db:
+        db.add_all([
+            Run(agent="max", ticket="ECD-1", cwd="/tmp", initial_prompt="x", state="planning"),
+            Run(agent="jeffy", ticket="ECD-2", cwd="/tmp", initial_prompt="x", state="planning"),
+        ])
+    keys = in_flight_ticket_keys_for_agent(None)
+    assert keys == {"ECD-1", "ECD-2"}
+
+
+# ─── JiraClient with mocked transport ──────────────────────────────
+
+
+def _mock_transport(responder):
+    """Build an httpx MockTransport that calls `responder(request)` for every request."""
+    return httpx.MockTransport(responder)
+
+
+def test_jira_client_builds_jql_and_normalizes_response():
+    captured = {}
+
+    def responder(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["jql"] = request.url.params.get("jql")
+        return httpx.Response(200, json={
+            "issues": [
+                {"key": "ECD-1", "fields": {"summary": "First", "status": {"name": "To Do", "statusCategory": {"key": "new"}}, "priority": None, "created": "2026-04-01T00:00:00.000+0000", "updated": "2026-04-01T00:00:00.000+0000", "description": {"type": "doc", "content": []}, "comment": {"comments": []}}},
+                {"key": "ECD-2", "fields": {"summary": "Second", "status": {"name": "In Progress", "statusCategory": {"key": "indeterminate"}}, "priority": {"name": "High"}, "created": "2026-04-02T00:00:00.000+0000", "updated": "2026-04-02T00:00:00.000+0000", "description": {"type": "doc", "content": []}, "comment": {"comments": []}}},
+            ]
+        })
+
+    cfg = JiraConfig(url="https://example.atlassian.net", email="me@example.com", api_token="tok")
+    client = JiraClient(cfg)
+    client._client = httpx.Client(
+        base_url=cfg.url, auth=(cfg.email, cfg.api_token), transport=_mock_transport(responder),
+    )
+    try:
+        tickets = client.list_assigned_to_me(project="ECD")
+    finally:
+        client.close()
+
+    assert len(tickets) == 2
+    assert tickets[0].key == "ECD-1"
+    assert tickets[1].priority == "High"
+
+    assert captured["url"].startswith("https://example.atlassian.net/rest/api/3/search")
+    assert "assignee = currentUser()" in captured["jql"]
+    assert "statusCategory != Done" in captured["jql"]
+    assert "project = ECD" in captured["jql"]
+
+
+def test_jira_client_raises_on_4xx():
+    def responder(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"errorMessages": ["unauth"]})
+
+    cfg = JiraConfig(url="https://example.atlassian.net", email="me@example.com", api_token="bad")
+    client = JiraClient(cfg)
+    client._client = httpx.Client(
+        base_url=cfg.url, auth=(cfg.email, cfg.api_token), transport=_mock_transport(responder),
+    )
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            client.list_assigned_to_me()
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary

First triage stage of the ranch hand loop (#81). The hand calls `ranch triage --json` to pick its next ticket: query Jira for assigned tickets, score each, exclude anything already in flight, return ranked candidates. Stacked on top of #84.

## What you can do after this lands

```bash
# Configure Jira once
cat >> ~/.ranch/config.toml <<EOT
[jira]
url = "https://citemed.atlassian.net"
email = "edrower@citemed.com"
EOT
export RANCH_JIRA_API_TOKEN="…"

# Pick what to work on next
ranch triage                         # top 10 across all projects
ranch triage --project ECD           # one project
ranch triage --agent max --top 5     # exclude tickets max is already in flight on
ranch triage --json                  # machine-readable, consumed by the ranch hand
```

## Architecture

- **`ranch/triage.py`** — pure scoring + Jira client behind a `JiraSource` protocol. Scorer is a pure function with no I/O; tests cover each axis deterministically. Client uses httpx + Basic auth (email + API token); ADF extraction walks the document tree for plain text (Jira Cloud returns descriptions as Atlassian Document Format JSON).
- **Scoring axes**:
  - Status: +30 in-progress, +20 to-do, 0 if blocked / waiting-for-design / on-hold
  - Design link: +20 if a figma.com URL is in description or comments
  - AC clarity: +15 for "Acceptance Criteria" header or numbered should/must list (regex heuristic; LLM-judged AC clarity is a future enhancement noted on the H4 ticket)
  - Priority: Highest +15 → Lowest -5
  - Age: log-bounded, max +10
  - **In-flight penalty: -1000** (excluded entirely) if this agent already has a non-terminal Run row on the ticket. Reads Run rows directly — Ranch is the source of truth for what's in flight, not Jira.

- **`ranch triage` CLI** — rich table by default, `--json` for the scheduler. `--agent` scopes the in-flight check; `--project` filters JQL; `--top` caps output.

## Test plan

- [x] 31 new tests covering: each scoring axis with edge cases (blocked, waiting-for-design, missing priority, varying ages), ranking determinism, ADF tree extraction, Jira REST normalization (full + missing fields), figma detection in comments only, in-flight detection from Run rows with agent filtering, mocked-transport JiraClient (request shape + JQL composition + error propagation)
- [x] Full suite: 176 passed
- [ ] Live run against real Jira — deferred to you once `RANCH_JIRA_API_TOKEN` is in your env. Hermetic mock-based tests should cover the request/response plumbing, but real-data quirks (custom fields, statusCategory mappings in your workflow) can surface only against your actual Atlassian instance.

## Notes for review

- I left the scorer constants hardcoded for now (status weights, priority ladder). Once H11 (ranch hand) learns from outcomes, these become per-hand tunables — but premature configurability now would just be churn.
- The mock-transport pattern for httpx is the cleanest way to test the client without a `requests-mock`-style dep — preserves Basic auth handling, URL composition, and response parsing.
- I avoided shelling out to the Atlassian MCP (which would require spinning up a claude subprocess per query) — direct REST is fast and synchronous, which the scheduler needs.

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)