### PR TITLE
H5: ranch scope — pre-flight context bundle (#75)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -385,7 +385,7 @@ The "polling now, webhooks later" call: each agent's pilot daemon polls every ~3
 - H2 (#72) — Dossier persistence + console rendering [H2a backend in flight; H2b console rendering follows]
 - H3 (#73) — Interactive takeover (pause → `claude --resume` → orchestrated resume)
 - H4 (#74) — `ranch triage` — rank assigned Jira tickets [in flight]
-- H5 (#75) — `ranch scope <ticket>` — context bundle
+- H5 (#75) — `ranch scope <ticket>` — context bundle [in flight]
 - H6 (#76) — `ranch propose <ticket>` — bounded plan + acceptance criteria
 - H7 (#77) — `ranch design <ticket>` — figma frame discovery
 - H8 (#78) — Self-judge integration loop

--- a/USAGE.md
+++ b/USAGE.md
@@ -97,6 +97,26 @@ ranch runs --agent max      # filter by agent
 ranch resume 3              # resume run #3 by SDK session ID
 ```
 
+## Scope a ticket (Phase H5)
+
+Build a pre-flight context bundle for a ticket — epic, sister tickets, open PRs, design links, Confluence refs. The ranch hand calls this before planning so the agent starts with the full picture instead of discovering it tool-call by tool-call.
+
+```bash
+ranch scope ECD-1234                 # print bundle to stdout (markdown)
+ranch scope ECD-1234 --save          # also persist to ~/.ranch/scopes/ECD-1234.md
+ranch scope ECD-1234 --json          # JSON for the ranch hand scheduler
+ranch scope ECD-1234 --cwd /path/to/worktree  # use a specific repo for `bb pr list`
+```
+
+The bundle includes:
+- Ticket itself: status, priority, assignee, labels, full description
+- Parent epic (if any), plus all sister tickets in the same epic
+- Open Bitbucket PRs whose branch or title references this ticket, any sister, or the epic
+- All figma.com URLs found in the ticket or epic
+- All Confluence wiki URLs found in the ticket or epic
+
+PR discovery is best-effort via `bb` — if `bb` is missing or auth fails, that section is empty rather than aborting the bundle.
+
 ## Triage assigned Jira tickets (Phase H4)
 
 Rank your assigned Jira tickets by viability (status, design presence, AC clarity, priority, age) so the ranch hand (or you) can pick what to work on next.

--- a/ranch/cli.py
+++ b/ranch/cli.py
@@ -599,6 +599,42 @@ def dossier_cmd(run_id, as_json, watch, interval):
             pass
 
 
+@cli.command("scope")
+@click.argument("ticket_key", type=str)
+@click.option("--save", is_flag=True, help="Persist the bundle to ~/.ranch/scopes/<key>.md for downstream consumption by `ranch propose` / `ranch run`.")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of markdown (for the ranch hand scheduler).")
+@click.option("--cwd", default=None, type=click.Path(exists=True, file_okay=False, resolve_path=True), help="Worktree to use for `bb pr list` discovery. Default: current directory.")
+def scope_cmd(ticket_key, save, as_json, cwd):
+    """Build a context bundle (epic + sisters + PRs + design links) for a ticket."""
+    import json as _json
+    from pathlib import Path as _Path
+    from .scope import build_scope, render_scope_markdown, save_scope
+    from .triage import JiraClient, JiraConfig, JiraConfigError
+
+    try:
+        cfg = JiraConfig.load()
+    except JiraConfigError as e:
+        console.print(f"[red]{e}[/red]")
+        raise click.Abort()
+
+    work_cwd = _Path(cwd) if cwd else _Path.cwd()
+    try:
+        with JiraClient(cfg) as client:
+            scope = build_scope(ticket_key, jira=client, cwd=work_cwd)
+    except Exception as e:
+        console.print(f"[red]Failed to build scope:[/red] {e}")
+        raise click.Abort()
+
+    if as_json:
+        click.echo(_json.dumps(scope.to_dict(), indent=2))
+    else:
+        click.echo(render_scope_markdown(scope))
+
+    if save:
+        path = save_scope(scope)
+        console.print(f"[dim]Saved → {path}[/dim]")
+
+
 @cli.command("triage")
 @click.option("--agent", default=None, help="Exclude tickets already in flight for this agent (default: anyone).")
 @click.option("--project", default=None, help="Filter to a single Jira project key (e.g. ECD).")

--- a/ranch/scope.py
+++ b/ranch/scope.py
@@ -1,0 +1,308 @@
+"""H5 — `ranch scope <ticket>`: build the agent's pre-flight context bundle.
+
+A "scope" is everything the agent should know before it starts planning a
+ticket: the ticket itself, its epic, sister tickets in the same epic,
+any open PRs touching the epic, design links, and Confluence references.
+
+The bundle is rendered to markdown and written to `~/.ranch/scopes/<key>.md`
+so subsequent `ranch propose` / `ranch run` invocations can consume it
+without re-querying.
+
+Phase H5 of the Ranch hand epic (#70).
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from .config import RANCH_HOME
+from .triage import (
+    FIGMA_URL_RE,
+    JiraClient,
+    JiraConfig,
+    JiraConfigError,
+    JiraTicket,
+)
+
+SCOPES_DIR = RANCH_HOME / "scopes"
+CONFLUENCE_URL_RE = re.compile(r"https?://[\w.-]+\.atlassian\.net/wiki/[^\s)>\]]+", re.IGNORECASE)
+TICKET_KEY_RE = re.compile(r"\b([A-Z]+-\d+)\b")
+
+
+# ─── Domain types ─────────────────────────────────────────────────
+
+
+@dataclass
+class PrSummary:
+    """A normalized view of an open PR — agnostic to bb/gh shape."""
+
+    id: str
+    title: str
+    branch: str
+    url: str
+    author: str | None = None
+    referenced_ticket_keys: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Scope:
+    """The full pre-flight context bundle for a ticket."""
+
+    ticket: JiraTicket
+    epic: JiraTicket | None = None
+    sisters: list[JiraTicket] = field(default_factory=list)
+    related_prs: list[PrSummary] = field(default_factory=list)
+    design_links: list[str] = field(default_factory=list)
+    confluence_refs: list[str] = field(default_factory=list)
+
+    @property
+    def primary_key(self) -> str:
+        return self.ticket.key
+
+    def to_dict(self) -> dict:
+        """JSON-safe representation for --json mode and ranch hand consumption."""
+        return {
+            "ticket": _ticket_to_dict(self.ticket),
+            "epic": _ticket_to_dict(self.epic) if self.epic else None,
+            "sisters": [_ticket_to_dict(s) for s in self.sisters],
+            "related_prs": [
+                {
+                    "id": p.id, "title": p.title, "branch": p.branch, "url": p.url,
+                    "author": p.author, "referenced_ticket_keys": p.referenced_ticket_keys,
+                }
+                for p in self.related_prs
+            ],
+            "design_links": self.design_links,
+            "confluence_refs": self.confluence_refs,
+        }
+
+
+def _ticket_to_dict(t: JiraTicket) -> dict:
+    return {
+        "key": t.key,
+        "summary": t.summary,
+        "status": t.status,
+        "priority": t.priority,
+        "assignee_email": t.assignee_email,
+        "labels": t.labels,
+        "has_figma_link": t.has_figma_link,
+        "created": t.created.isoformat(),
+        "updated": t.updated.isoformat(),
+        # description omitted from compact dict to keep JSON payloads bounded —
+        # it's rendered in the markdown bundle instead
+    }
+
+
+# ─── PR discovery via bb / gh ──────────────────────────────────────
+
+
+def _bb_pr_list_open(cwd: Path) -> list[dict]:
+    """Return all open PRs as parsed JSON. Empty list if `bb` errors out
+    (e.g. not a Bitbucket repo, auth issue) — PR discovery is best-effort."""
+    try:
+        result = subprocess.run(
+            ["bb", "--json", "pr", "list", "--state", "OPEN", "--all"],
+            cwd=str(cwd), capture_output=True, text=True, timeout=30,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return []
+    if result.returncode != 0:
+        return []
+    try:
+        return json.loads(result.stdout) or []
+    except json.JSONDecodeError:
+        return []
+
+
+def _extract_referenced_tickets(text: str) -> list[str]:
+    """Pull ticket keys (e.g. ECD-1234) out of arbitrary text."""
+    seen: list[str] = []
+    for m in TICKET_KEY_RE.findall(text or ""):
+        if m not in seen:
+            seen.append(m)
+    return seen
+
+
+def find_open_prs(cwd: Path, ticket_keys: Iterable[str]) -> list[PrSummary]:
+    """Find open PRs whose branch name or title references any of the given keys.
+
+    `cwd` should be inside a Bitbucket repo (the agent's worktree). Best-effort —
+    if `bb` is missing or the repo isn't on Bitbucket, returns []. Future:
+    layer in a GH backend the same way pr_backend.py does.
+    """
+    keys_lower = {k.lower() for k in ticket_keys}
+    if not keys_lower:
+        return []
+    prs: list[PrSummary] = []
+    for raw in _bb_pr_list_open(cwd):
+        title = raw.get("title") or ""
+        branch = (raw.get("source") or {}).get("branch", {}).get("name") or ""
+        haystack = f"{branch} {title}".lower()
+        referenced = _extract_referenced_tickets(branch + " " + title)
+        if not any(k in haystack for k in keys_lower):
+            continue
+        url = (raw.get("links") or {}).get("html", {}).get("href") or ""
+        author = (raw.get("author") or {}).get("display_name")
+        prs.append(PrSummary(
+            id=str(raw.get("id")),
+            title=title,
+            branch=branch,
+            url=url,
+            author=author,
+            referenced_ticket_keys=referenced,
+        ))
+    return prs
+
+
+# ─── Link extraction ───────────────────────────────────────────────
+
+
+def _collect_text(ticket: JiraTicket) -> str:
+    """Concatenate description + all comments for regex scanning."""
+    return ticket.description + "\n" + "\n".join(ticket.comments)
+
+
+def _extract_unique_urls(pattern: re.Pattern[str], *tickets: JiraTicket) -> list[str]:
+    seen: list[str] = []
+    for t in tickets:
+        for m in pattern.findall(_collect_text(t)):
+            if m not in seen:
+                seen.append(m)
+    return seen
+
+
+# ─── Scope assembly ────────────────────────────────────────────────
+
+
+def build_scope(ticket_key: str, *, jira: JiraClient, cwd: Path | None = None) -> Scope:
+    """Assemble a Scope by querying Jira + (optionally) bb for PRs.
+
+    `jira` is injected so tests can pass a stub; production callers use
+    `JiraClient(JiraConfig.load())`.
+    """
+    ticket, epic_key = jira.get_ticket(ticket_key)
+
+    epic: JiraTicket | None = None
+    sisters: list[JiraTicket] = []
+    if epic_key:
+        epic, _ = jira.get_ticket(epic_key)
+        sisters = [t for t in jira.list_sisters(epic_key) if t.key != ticket_key]
+
+    # Design + Confluence links: drawn from the ticket itself and the epic.
+    text_sources: list[JiraTicket] = [ticket]
+    if epic:
+        text_sources.append(epic)
+    design_links = _extract_unique_urls(FIGMA_URL_RE, *text_sources)
+    confluence_refs = _extract_unique_urls(CONFLUENCE_URL_RE, *text_sources)
+
+    # PRs that mention this ticket or any sister.
+    related_prs: list[PrSummary] = []
+    if cwd is not None:
+        all_keys = [ticket_key] + [s.key for s in sisters]
+        if epic_key:
+            all_keys.append(epic_key)
+        related_prs = find_open_prs(cwd, all_keys)
+
+    return Scope(
+        ticket=ticket,
+        epic=epic,
+        sisters=sisters,
+        related_prs=related_prs,
+        design_links=design_links,
+        confluence_refs=confluence_refs,
+    )
+
+
+# ─── Rendering ─────────────────────────────────────────────────────
+
+
+def render_scope_markdown(scope: Scope) -> str:
+    """Produce a human + agent-readable markdown bundle for the scope."""
+    t = scope.ticket
+    lines: list[str] = []
+    lines.append(f"# {t.key} — {t.summary}")
+    lines.append("")
+    lines.append(f"- **Status**: {t.status or '?'}")
+    if t.priority:
+        lines.append(f"- **Priority**: {t.priority}")
+    if t.assignee_email:
+        lines.append(f"- **Assignee**: {t.assignee_email}")
+    if t.labels:
+        lines.append(f"- **Labels**: {', '.join(t.labels)}")
+    lines.append(f"- **Updated**: {t.updated.isoformat()}")
+
+    if scope.epic:
+        e = scope.epic
+        lines.append("")
+        lines.append(f"## Epic — {e.key}: {e.summary}")
+        lines.append(f"_Status: {e.status}_")
+        if e.description.strip():
+            lines.append("")
+            lines.append(e.description.strip())
+
+    if scope.sisters:
+        lines.append("")
+        lines.append(f"## Sister tickets ({len(scope.sisters)})")
+        for s in scope.sisters:
+            pri = f" ({s.priority})" if s.priority else ""
+            lines.append(f"- `{s.key}` [{s.status}]{pri} — {s.summary}")
+
+    if scope.related_prs:
+        lines.append("")
+        lines.append(f"## Open PRs in this epic ({len(scope.related_prs)})")
+        for p in scope.related_prs:
+            refs = f" — refs {', '.join(p.referenced_ticket_keys)}" if p.referenced_ticket_keys else ""
+            lines.append(f"- #{p.id} `{p.branch}` — {p.title}{refs}")
+            if p.url:
+                lines.append(f"    {p.url}")
+
+    if scope.design_links:
+        lines.append("")
+        lines.append("## Design references")
+        for url in scope.design_links:
+            lines.append(f"- {url}")
+
+    if scope.confluence_refs:
+        lines.append("")
+        lines.append("## Confluence references")
+        for url in scope.confluence_refs:
+            lines.append(f"- {url}")
+
+    if t.description.strip():
+        lines.append("")
+        lines.append("## Ticket description")
+        lines.append("")
+        lines.append(t.description.strip())
+
+    return "\n".join(lines) + "\n"
+
+
+# ─── Persistence ───────────────────────────────────────────────────
+
+
+def scope_path(ticket_key: str) -> Path:
+    """Where the saved scope for a ticket lives on disk."""
+    return SCOPES_DIR / f"{ticket_key}.md"
+
+
+def save_scope(scope: Scope) -> Path:
+    """Write the markdown bundle to ~/.ranch/scopes/<key>.md, return the path."""
+    SCOPES_DIR.mkdir(parents=True, exist_ok=True)
+    path = scope_path(scope.primary_key)
+    path.write_text(render_scope_markdown(scope))
+    return path
+
+
+def load_scope_markdown(ticket_key: str) -> str | None:
+    """Return the saved markdown bundle for a ticket, or None if not saved.
+
+    Used by `ranch propose` / `ranch run` to inject prior scope into the brief.
+    """
+    path = scope_path(ticket_key)
+    if not path.exists():
+        return None
+    return path.read_text()

--- a/ranch/triage.py
+++ b/ranch/triage.py
@@ -308,25 +308,47 @@ class JiraClient:
     def __exit__(self, *args) -> None:
         self.close()
 
+    # Jira Cloud's /rest/api/3/search returns issues with a configurable
+    # field projection. We use one canonical projection across all queries so
+    # _normalize_ticket has consistent input shape.
+    _FIELDS = "summary,status,priority,created,updated,description,comment,labels,assignee,parent"
+
     def list_assigned_to_me(self, *, project: str | None = None) -> list[JiraTicket]:
         """Return all open tickets currently assigned to the authenticated user."""
         jql_parts = ["assignee = currentUser()", "statusCategory != Done"]
         if project:
             jql_parts.append(f"project = {project}")
         jql = " AND ".join(jql_parts) + " ORDER BY priority DESC, updated DESC"
+        return self._search(jql)
 
-        # Jira Cloud's /rest/api/3/search/jql is the documented endpoint.
-        # We pull a generous set of fields so scoring is fully informed without
-        # follow-up calls.
-        params = {
-            "jql": jql,
-            "fields": "summary,status,priority,created,updated,description,comment,labels,assignee",
-            "maxResults": 100,
-        }
+    def get_ticket(self, key: str) -> tuple[JiraTicket, str | None]:
+        """Fetch one ticket. Returns (ticket, parent_epic_key) — parent_epic_key
+        is None if this ticket isn't under an epic.
+
+        Used by `ranch scope <ticket>` to build the context bundle (H5).
+        """
+        resp = self._client.get(f"/rest/api/3/issue/{key}", params={"fields": self._FIELDS})
+        resp.raise_for_status()
+        issue = resp.json()
+        ticket = _normalize_ticket(issue)
+        parent = (issue.get("fields") or {}).get("parent")
+        parent_key = parent.get("key") if parent else None
+        return ticket, parent_key
+
+    def list_sisters(self, epic_key: str) -> list[JiraTicket]:
+        """All tickets under the given epic, including any in Done state.
+
+        Used by `ranch scope` so the agent can see what else has shipped or
+        is in flight for this epic.
+        """
+        jql = f'parent = {epic_key} ORDER BY status ASC, updated DESC'
+        return self._search(jql)
+
+    def _search(self, jql: str) -> list[JiraTicket]:
+        params = {"jql": jql, "fields": self._FIELDS, "maxResults": 100}
         resp = self._client.get("/rest/api/3/search", params=params)
         resp.raise_for_status()
-        data = resp.json()
-        return [_normalize_ticket(issue) for issue in data.get("issues", [])]
+        return [_normalize_ticket(issue) for issue in (resp.json() or {}).get("issues", [])]
 
 
 # ─── In-flight detection (from ranch's own DB) ─────────────────────

--- a/tests/test_scope.py
+++ b/tests/test_scope.py
@@ -1,0 +1,342 @@
+"""Tests for the scope bundle assembly + rendering + persistence (Phase H5).
+
+The Jira side is tested via a stub `JiraClient`-shaped object so we don't
+hit the network. The bb side is tested by patching the module's
+`_bb_pr_list_open` helper.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ranch.scope import (
+    PrSummary,
+    Scope,
+    _extract_referenced_tickets,
+    build_scope,
+    find_open_prs,
+    load_scope_markdown,
+    render_scope_markdown,
+    save_scope,
+    scope_path,
+)
+from ranch.triage import JiraTicket
+
+
+def _ticket(**overrides) -> JiraTicket:
+    base = dict(
+        key="ECD-100",
+        summary="Add /healthz endpoint",
+        status="In Progress",
+        status_category="indeterminate",
+        priority="Medium",
+        created=datetime(2026, 4, 1, tzinfo=timezone.utc),
+        updated=datetime(2026, 4, 10, tzinfo=timezone.utc),
+        description="Plain description.",
+        comments=[],
+        labels=[],
+        has_figma_link=False,
+    )
+    base.update(overrides)
+    return JiraTicket(**base)
+
+
+class _StubJiraClient:
+    """Mimics the methods build_scope uses, fed by a static catalog."""
+
+    def __init__(self, tickets: dict[str, JiraTicket], parents: dict[str, str | None], sisters: dict[str, list[JiraTicket]]):
+        self.tickets = tickets
+        self.parents = parents
+        self.sisters = sisters
+
+    def get_ticket(self, key: str):
+        return self.tickets[key], self.parents.get(key)
+
+    def list_sisters(self, epic_key: str):
+        return self.sisters.get(epic_key, [])
+
+
+# ─── _extract_referenced_tickets ───────────────────────────────────
+
+
+def test_extract_referenced_tickets_dedupes():
+    assert _extract_referenced_tickets("ECD-1 fix and ECD-1 again with ECD-2") == ["ECD-1", "ECD-2"]
+
+
+def test_extract_referenced_tickets_ignores_lowercase():
+    assert _extract_referenced_tickets("ecd-1 ecd-2") == []
+
+
+def test_extract_referenced_tickets_empty():
+    assert _extract_referenced_tickets("") == []
+    assert _extract_referenced_tickets(None) == []  # type: ignore[arg-type]
+
+
+# ─── find_open_prs ─────────────────────────────────────────────────
+
+
+def _bb_pr_payload(prs):
+    """Build the shape `bb --json pr list` returns."""
+    return prs
+
+
+def test_find_open_prs_matches_branch_containing_key():
+    fake_prs = [
+        {"id": 42, "title": "Fix the thing",
+         "source": {"branch": {"name": "feature/ECD-100-healthz"}},
+         "links": {"html": {"href": "https://bitbucket.org/x/y/pull-requests/42"}},
+         "author": {"display_name": "Ethan"}},
+        {"id": 43, "title": "Unrelated",
+         "source": {"branch": {"name": "chore/bump-deps"}},
+         "links": {}, "author": {"display_name": "Other"}},
+    ]
+    with patch("ranch.scope._bb_pr_list_open", return_value=fake_prs):
+        prs = find_open_prs(Path("/tmp"), ["ECD-100"])
+    assert len(prs) == 1
+    assert prs[0].id == "42"
+    assert prs[0].branch == "feature/ECD-100-healthz"
+    assert prs[0].author == "Ethan"
+    assert "ECD-100" in prs[0].referenced_ticket_keys
+
+
+def test_find_open_prs_matches_title_when_branch_lacks_key():
+    fake_prs = [
+        {"id": 50, "title": "ECD-200: refactor service",
+         "source": {"branch": {"name": "feature/refactor-service"}},
+         "links": {}, "author": {}},
+    ]
+    with patch("ranch.scope._bb_pr_list_open", return_value=fake_prs):
+        prs = find_open_prs(Path("/tmp"), ["ECD-200"])
+    assert len(prs) == 1
+    assert prs[0].id == "50"
+    assert "ECD-200" in prs[0].referenced_ticket_keys
+
+
+def test_find_open_prs_empty_keys_returns_empty():
+    with patch("ranch.scope._bb_pr_list_open", return_value=[{"id": 1, "title": "x"}]):
+        assert find_open_prs(Path("/tmp"), []) == []
+
+
+def test_find_open_prs_handles_bb_failure_gracefully():
+    """If `bb` errors out, scope discovery shouldn't crash — just no PRs."""
+    with patch("ranch.scope._bb_pr_list_open", return_value=[]):
+        assert find_open_prs(Path("/tmp"), ["ECD-100"]) == []
+
+
+# ─── build_scope ───────────────────────────────────────────────────
+
+
+def test_build_scope_no_epic():
+    """A ticket without a parent — no epic, no sisters."""
+    t = _ticket(key="ECD-100", description="Just a single ticket.")
+    stub = _StubJiraClient({"ECD-100": t}, parents={"ECD-100": None}, sisters={})
+
+    with patch("ranch.scope._bb_pr_list_open", return_value=[]):
+        scope = build_scope("ECD-100", jira=stub, cwd=Path("/tmp"))
+
+    assert scope.ticket.key == "ECD-100"
+    assert scope.epic is None
+    assert scope.sisters == []
+    assert scope.related_prs == []
+    assert scope.design_links == []
+
+
+def test_build_scope_with_epic_and_sisters():
+    t = _ticket(key="ECD-100", summary="The work")
+    epic = _ticket(key="ECD-001", summary="Big epic",
+                   description="Epic spans https://figma.com/file/ABC")
+    sister_a = _ticket(key="ECD-101", summary="Sibling A")
+    sister_b = _ticket(key="ECD-102", summary="Sibling B", status="Done")
+
+    stub = _StubJiraClient(
+        {"ECD-100": t, "ECD-001": epic},
+        parents={"ECD-100": "ECD-001", "ECD-001": None},
+        sisters={"ECD-001": [t, sister_a, sister_b]},  # source ticket included; should be filtered
+    )
+
+    with patch("ranch.scope._bb_pr_list_open", return_value=[]):
+        scope = build_scope("ECD-100", jira=stub, cwd=Path("/tmp"))
+
+    assert scope.epic is not None
+    assert scope.epic.key == "ECD-001"
+    sister_keys = [s.key for s in scope.sisters]
+    assert "ECD-100" not in sister_keys  # filtered out
+    assert sister_keys == ["ECD-101", "ECD-102"]
+    # Design link surfaced from epic description
+    assert any("figma.com/file/ABC" in d for d in scope.design_links)
+
+
+def test_build_scope_dedupes_design_links_across_ticket_and_epic():
+    t = _ticket(key="ECD-100", description="Design: https://figma.com/file/X")
+    epic = _ticket(key="ECD-001", description="Also https://figma.com/file/X and https://figma.com/file/Y")
+    stub = _StubJiraClient(
+        {"ECD-100": t, "ECD-001": epic},
+        parents={"ECD-100": "ECD-001", "ECD-001": None},
+        sisters={"ECD-001": []},
+    )
+    with patch("ranch.scope._bb_pr_list_open", return_value=[]):
+        scope = build_scope("ECD-100", jira=stub, cwd=Path("/tmp"))
+    # X appears in both ticket and epic — should be listed once
+    figma_x_count = sum(1 for url in scope.design_links if "figma.com/file/X" in url)
+    assert figma_x_count == 1
+    assert any("figma.com/file/Y" in url for url in scope.design_links)
+
+
+def test_build_scope_extracts_confluence_links():
+    t = _ticket(key="ECD-100", description="See https://citemed.atlassian.net/wiki/spaces/ENG/pages/123")
+    stub = _StubJiraClient({"ECD-100": t}, parents={"ECD-100": None}, sisters={})
+    with patch("ranch.scope._bb_pr_list_open", return_value=[]):
+        scope = build_scope("ECD-100", jira=stub, cwd=Path("/tmp"))
+    assert len(scope.confluence_refs) == 1
+    assert "wiki/spaces/ENG/pages/123" in scope.confluence_refs[0]
+
+
+def test_build_scope_includes_prs_referencing_epic_or_sisters():
+    t = _ticket(key="ECD-100")
+    sister = _ticket(key="ECD-101")
+    epic = _ticket(key="ECD-001")
+    stub = _StubJiraClient(
+        {"ECD-100": t, "ECD-001": epic},
+        parents={"ECD-100": "ECD-001", "ECD-001": None},
+        sisters={"ECD-001": [sister]},
+    )
+    fake_prs = [
+        {"id": 1, "title": "WIP: ECD-101 sister work",
+         "source": {"branch": {"name": "feature/ECD-101-foo"}},
+         "links": {"html": {"href": "https://example/pull/1"}}, "author": {}},
+    ]
+    with patch("ranch.scope._bb_pr_list_open", return_value=fake_prs):
+        scope = build_scope("ECD-100", jira=stub, cwd=Path("/tmp"))
+    assert len(scope.related_prs) == 1
+    assert scope.related_prs[0].id == "1"
+
+
+def test_build_scope_skips_pr_discovery_when_no_cwd():
+    """If caller passes cwd=None, bb is never invoked."""
+    t = _ticket(key="ECD-100")
+    stub = _StubJiraClient({"ECD-100": t}, parents={"ECD-100": None}, sisters={})
+
+    def _should_not_be_called(_cwd):
+        raise AssertionError("PR discovery should be skipped without cwd")
+
+    with patch("ranch.scope._bb_pr_list_open", side_effect=_should_not_be_called):
+        scope = build_scope("ECD-100", jira=stub, cwd=None)
+    assert scope.related_prs == []
+
+
+# ─── render_scope_markdown ─────────────────────────────────────────
+
+
+def test_render_includes_ticket_header():
+    t = _ticket(key="ECD-100", summary="Add /healthz", priority="High",
+                labels=["backend"], assignee_email="max@example.com")
+    md = render_scope_markdown(Scope(ticket=t))
+    assert "# ECD-100 — Add /healthz" in md
+    assert "**Status**: In Progress" in md
+    assert "**Priority**: High" in md
+    assert "**Assignee**: max@example.com" in md
+    assert "**Labels**: backend" in md
+
+
+def test_render_includes_epic_section_when_present():
+    t = _ticket(key="ECD-100")
+    epic = _ticket(key="ECD-001", summary="Epic", description="Epic-level context here.")
+    md = render_scope_markdown(Scope(ticket=t, epic=epic))
+    assert "## Epic — ECD-001: Epic" in md
+    assert "Epic-level context here." in md
+
+
+def test_render_includes_sisters_with_status_and_priority():
+    t = _ticket(key="ECD-100")
+    sisters = [
+        _ticket(key="ECD-101", status="To Do", priority="High"),
+        _ticket(key="ECD-102", status="Done", priority=None),
+    ]
+    md = render_scope_markdown(Scope(ticket=t, sisters=sisters))
+    assert "## Sister tickets (2)" in md
+    assert "`ECD-101` [To Do] (High)" in md
+    assert "`ECD-102` [Done]" in md
+
+
+def test_render_includes_prs_with_refs():
+    t = _ticket(key="ECD-100")
+    prs = [PrSummary(id="42", title="Fix it", branch="feature/ECD-100-fix",
+                     url="https://bb/pr/42", referenced_ticket_keys=["ECD-100"])]
+    md = render_scope_markdown(Scope(ticket=t, related_prs=prs))
+    assert "## Open PRs in this epic (1)" in md
+    assert "#42 `feature/ECD-100-fix`" in md
+    assert "refs ECD-100" in md
+    assert "https://bb/pr/42" in md
+
+
+def test_render_omits_empty_sections():
+    t = _ticket(key="ECD-100")
+    md = render_scope_markdown(Scope(ticket=t))
+    assert "## Sister tickets" not in md
+    assert "## Open PRs" not in md
+    assert "## Design references" not in md
+    assert "## Confluence references" not in md
+
+
+def test_render_includes_description_block():
+    t = _ticket(key="ECD-100", description="Detailed problem statement here.")
+    md = render_scope_markdown(Scope(ticket=t))
+    assert "## Ticket description" in md
+    assert "Detailed problem statement here." in md
+
+
+# ─── Persistence ───────────────────────────────────────────────────
+
+
+def test_save_and_load_scope_roundtrip(tmp_path, monkeypatch):
+    """save_scope writes the markdown; load_scope_markdown reads it back."""
+    monkeypatch.setattr("ranch.scope.SCOPES_DIR", tmp_path)
+    monkeypatch.setattr("ranch.scope.scope_path",
+                        lambda key: tmp_path / f"{key}.md")
+
+    t = _ticket(key="ECD-100", summary="Roundtrip test")
+    scope = Scope(ticket=t)
+
+    path = save_scope(scope)
+    assert path.exists()
+    loaded = load_scope_markdown("ECD-100")
+    assert loaded is not None
+    assert "# ECD-100 — Roundtrip test" in loaded
+
+
+def test_load_scope_markdown_returns_none_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr("ranch.scope.scope_path", lambda key: tmp_path / f"{key}.md")
+    assert load_scope_markdown("DOES-NOT-EXIST") is None
+
+
+# ─── Scope.to_dict ─────────────────────────────────────────────────
+
+
+def test_scope_to_dict_omits_none_epic():
+    t = _ticket(key="ECD-100")
+    d = Scope(ticket=t).to_dict()
+    assert d["epic"] is None
+    assert d["sisters"] == []
+    assert d["related_prs"] == []
+
+
+def test_scope_to_dict_serializes_full_bundle():
+    t = _ticket(key="ECD-100")
+    epic = _ticket(key="ECD-001", summary="Epic")
+    sister = _ticket(key="ECD-101")
+    pr = PrSummary(id="42", title="X", branch="b", url="u", referenced_ticket_keys=["ECD-100"])
+    scope = Scope(
+        ticket=t, epic=epic, sisters=[sister], related_prs=[pr],
+        design_links=["https://figma.com/file/X"],
+        confluence_refs=["https://citemed.atlassian.net/wiki/x"],
+    )
+    d = scope.to_dict()
+    assert d["ticket"]["key"] == "ECD-100"
+    assert d["epic"]["key"] == "ECD-001"
+    assert d["sisters"][0]["key"] == "ECD-101"
+    assert d["related_prs"][0]["id"] == "42"
+    assert d["design_links"] == ["https://figma.com/file/X"]
+    assert d["confluence_refs"] == ["https://citemed.atlassian.net/wiki/x"]


### PR DESCRIPTION
## Summary

Second triage stage of the ranch hand loop (#81). Given a ticket key, fetch epic + sisters + open PRs + design/Confluence links, render as a markdown bundle, save to disk for downstream consumption. Stacked on #86.

## What you can do after this lands

```bash
ranch scope ECD-1234                 # print bundle to stdout
ranch scope ECD-1234 --save          # also persist to ~/.ranch/scopes/ECD-1234.md
ranch scope ECD-1234 --json          # JSON for the scheduler
ranch scope ECD-1234 --cwd /Users/ethand320/code/citemed/max/citemed_web   # bb PR discovery uses this worktree
```

`ranch propose` and `ranch run` (later) read the saved bundle so the agent starts with the full picture instead of discovering it tool-call by tool-call.

## Architecture

- **`ranch/scope.py`** — `Scope` dataclass + `build_scope(ticket_key, *, jira, cwd)` orchestrator. Pure logic; Jira client injected so tests stub it without touching the network. PR discovery via `bb --json pr list` shells out best-effort — missing `bb` returns an empty PR list, doesn't abort the bundle. Future: layered gh fallback the same way `pr_backend.py` does.
- **`ranch/triage.py`** — extended `JiraClient` with `get_ticket(key) → (ticket, parent_epic_key)` and `list_sisters(epic_key)`. Pulled the field projection into a class-level `_FIELDS` constant + a private `_search(jql)` helper so all queries normalize through one path. The `parent` field is what Jira Cloud's Next-gen projects use for epic linkage — for classic projects with a custom "Epic Link" field we'd need to extend the projection; flagging if your workflow uses it.
- **Markdown bundle** — ticket header, epic section (only if present), sister list with status/priority, PR list with `referenced_ticket_keys` extracted from branch + title, design + Confluence link sections, full ticket description at the bottom. Empty sections are omitted, not rendered as blank.

## Test plan

- [x] 23 new tests covering: ticket key extraction + dedup, PR matching by branch name vs title, build_scope with/without epic, sister filtering (source ticket excluded from sisters), design+confluence link dedup across ticket + epic, render of every section + omit-when-empty behavior, save/load roundtrip, JSON serialization
- [x] Full suite: 199 passed
- [ ] Live run against a real Jira ticket — once `RANCH_JIRA_API_TOKEN` is in env, try `ranch scope <real-key> --cwd <citemed_web worktree>` and check the bundle reflects the actual epic + PRs

## Notes for review

- `Scope.to_dict()` deliberately omits the description from the compact JSON (the markdown bundle has the full thing). Keeps the JSON small enough to pass around in scheduler messages.
- Confluence URL regex is conservative — `*.atlassian.net/wiki/...`. If you have docs on a non-Atlassian wiki we can broaden.
- The "parent" mechanism is Next-gen Jira; if the citemed workflow uses the classic "Epic Link" custom field, we'll need a small extension to the `_FIELDS` projection + a fallback in `get_ticket`.

Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)