### PR TITLE
H1c: add details field to dossier — long-form expand content

### DIFF
--- a/ranch/cli.py
+++ b/ranch/cli.py
@@ -549,6 +549,20 @@ def _render_dossier_panel(run: dict, payload: dict | None):
         listing = ", ".join(files[:8]) + ("..." if len(files) > 8 else "")
         body.append(f"\nFiles touched ({len(files)}): {listing}\n", style="dim")
 
+    details = payload.get("details")
+    if details:
+        # Compact preview — the UI's expand view will show the full thing.
+        # Show first ~3 lines or 240 chars, whichever is smaller, so the CLI
+        # panel stays usable when scanning many runs at once.
+        lines = details.strip().splitlines()
+        preview = "\n".join(lines[:3])
+        if len(preview) > 240:
+            preview = preview[:237] + "..."
+        elif len(lines) > 3:
+            preview += "\n..."
+        body.append("\nDetails:\n", style="bold")
+        body.append(f"{preview}\n", style="dim")
+
     return Panel(body, title=title, border_style=state_color)
 
 

--- a/ranch/runner/messages.py
+++ b/ranch/runner/messages.py
@@ -67,6 +67,11 @@ class RecordStateInput(BaseModel):
     The dossier is the agent's structured self-report of where it is right now.
     The console renders it as the primary view of the run (replacing the need
     to scroll the transcript). See ROADMAP Phase H1.
+
+    `just_did` is the always-required one-liner shown in the collapsed view.
+    `details` is the optional long-form expand-on-click narrative for the UI's
+    Confluence-style stage entries (see #72) — what was attempted, results,
+    decisions, issues, conclusions. Recommended when the step is non-trivial.
     """
 
     plan: list[PlanStep]
@@ -76,6 +81,7 @@ class RecordStateInput(BaseModel):
     options: Optional[list[DossierOption]] = None
     files_touched: list[str] = []
     ticket: Optional[str] = None
+    details: Optional[str] = None
 
     @field_validator("just_did")
     @classmethod

--- a/ranch/runner/prompts.py
+++ b/ranch/runner/prompts.py
@@ -60,7 +60,15 @@ Call `record_state` at these moments, at minimum:
 You may also call it whenever your understanding shifts materially (new
 blocker discovered, scope change).
 
-`just_did` is one or two sentences in plain English, not raw tool calls.
+`just_did` is one or two sentences in plain English, not raw tool calls —
+this is what shows in the collapsed view.
+
+For non-trivial steps, ALSO populate `details` with a multi-paragraph
+narrative — what you attempted, the results you saw, decisions you made
+and why, any issues encountered, your conclusion. This is what the
+operator reads when they expand this stage in the UI. Skip `details`
+for routine transitions; use it whenever you had to think.
+
 Don't update on every tool use — once per meaningful phase transition is
 the right cadence. Aim for at least one `record_state` call for every 5-10
 other tool calls.
@@ -121,8 +129,15 @@ Call `record_state` at these moments, at minimum:
 5. **Before stopping**, even if successful — final `record_state` with all
    plan steps `done` and a closing `just_did` summary
 
-`just_did` is one or two sentences in plain English. Aim for at least one
-`record_state` call for every 5-10 other tool calls.
+`just_did` is one or two sentences in plain English — this is what shows
+in the collapsed view.
+
+For non-trivial steps, ALSO populate `details` with a multi-paragraph
+narrative — what you attempted, results, decisions made, issues
+encountered, conclusion. This is what the operator reads when they
+expand this stage in the UI. Skip `details` for routine transitions.
+
+Aim for at least one `record_state` call for every 5-10 other tool calls.
 
 ## Other rules
 

--- a/ranch/runner/tools.py
+++ b/ranch/runner/tools.py
@@ -89,6 +89,15 @@ STATE_INPUT_SCHEMA = {
             "type": "string",
             "description": "Ticket identifier (e.g. ECD-1234), if known.",
         },
+        "details": {
+            "type": "string",
+            "description": (
+                "Optional long-form narrative for this step — what you attempted, "
+                "results, decisions, issues, conclusions. This is what the operator "
+                "reads when they expand this stage in the UI. Use when the step is "
+                "non-trivial; omit for routine transitions."
+            ),
+        },
     },
     "required": ["plan", "just_did", "state"],
 }

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -170,6 +170,48 @@ def test_render_dossier_panel_handles_missing_payload():
     assert panel is not None
 
 
+def test_render_dossier_panel_shows_details_preview():
+    """When `details` is populated, the panel shows a short preview."""
+    from ranch.cli import _render_dossier_panel
+    payload = {
+        "state": "coding",
+        "just_did": "Wrote the failing test.",
+        "details": (
+            "Started by reading existing tests in tests/test_foo.py.\n"
+            "Identified the pattern: each test uses CliRunner + isolated DB.\n"
+            "Wrote a matching test for the new endpoint. Ran it — fails as expected."
+        ),
+        "plan": [{"step": "Test it", "status": "in_progress"}],
+    }
+    panel = _render_dossier_panel(
+        {"id": 1, "agent": "max", "ticket": "ECD-1", "state": "in_development"},
+        payload,
+    )
+    from io import StringIO
+    from rich.console import Console as RichConsole
+    buf = StringIO()
+    RichConsole(file=buf, force_terminal=False, width=120).print(panel)
+    output = buf.getvalue()
+    assert "Details:" in output
+    assert "Started by reading existing tests" in output
+
+
+def test_render_dossier_panel_skips_details_section_when_absent():
+    """Routine emissions without `details` shouldn't render the section."""
+    from ranch.cli import _render_dossier_panel
+    payload = {"state": "coding", "just_did": "Bumped a version.",
+               "plan": [{"step": "Bump", "status": "done"}]}
+    panel = _render_dossier_panel(
+        {"id": 1, "agent": "max", "ticket": "ECD-1", "state": "in_development"},
+        payload,
+    )
+    from io import StringIO
+    from rich.console import Console as RichConsole
+    buf = StringIO()
+    RichConsole(file=buf, force_terminal=False, width=120).print(panel)
+    assert "Details:" not in buf.getvalue()
+
+
 def test_render_dossier_panel_includes_all_sections():
     from ranch.cli import _render_dossier_panel
     payload = {

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -222,3 +222,21 @@ def test_dossier_option_requires_both_fields():
     DossierOption(label="approve", description="Go ahead.")
     with pytest.raises(ValidationError):
         DossierOption(label="approve")  # missing description
+
+
+def test_record_state_details_optional():
+    """`details` is the long-form expand content — omitted for routine steps."""
+    payload = RecordStateInput.model_validate(_minimal_state())
+    assert payload.details is None
+
+
+def test_record_state_details_accepts_multiline():
+    """Non-trivial steps should populate `details` with the full narrative."""
+    long_details = (
+        "Tried approach A first — checked existing patterns in foo.py.\n"
+        "Hit an edge case where the cache wasn't being invalidated.\n"
+        "Decided to switch to approach B which sidesteps the cache entirely.\n"
+        "Result: cleaner diff, no perf regression."
+    )
+    payload = RecordStateInput.model_validate(_minimal_state(details=long_details))
+    assert payload.details == long_details


### PR DESCRIPTION
## Summary

Small additive schema iteration enabling the Confluence-expand timeline UI vision (#72). Adds an optional `details` field to the dossier so non-trivial steps can carry a multi-paragraph narrative for the expand-on-click view, alongside the existing `just_did` one-liner.

Stacked on #87.

## What changed

- **`RecordStateInput.details: Optional[str]`** — the long-form narrative
- **`STATE_INPUT_SCHEMA`** — exposes the field with usage guidance ("what you attempted, results, decisions, issues, conclusion")
- **System prompts** — both structured and free modes now explain the split: `just_did` is the always-required one-liner, `details` is optional and populated "whenever you had to think"
- **`_render_dossier_panel`** — shows a 3-line / 240-char preview when details is present. CLI stays scannable; the future React render will show the full expand
- **4 new tests** — validation + render with/without details. 203 tests passing total.

## UI vision this enables

```
ECD-111  ·  Claims Management
▾ Coding
  ⚠  Implementation - hit state mgmt edge case   [expand →]
                                                       ↓ click
  ┌──────────────────────────────────────────────────────┐
  │ Tried approach A — checked existing patterns…      │
  │ Hit an edge case where the cache wasn't being…     │
  │ Decided to switch to approach B which sidesteps…   │
  │ Result: cleaner diff, no perf regression.          │
  └──────────────────────────────────────────────────────┘
```

The details content is the agent's own narrative — not auto-derived from the transcript. The prompt instructs it to populate `details` only for steps that warranted thought, keeping the timeline dense with substance instead of noise.

## Notes

- Purely additive — existing dossiers and existing `record_state` calls keep working unchanged.
- Auto-derivation from transcript slices remains the fallback for when `details` is empty (per #72 spec) — that's a renderer-side concern, not a schema concern, so it doesn't gate this PR.

Related: #71 (H1, where the schema was introduced), #72 (H2 — where this gets rendered as expands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)