### PR TITLE
H11 MVP: ranch hand daemon — composes triage → scope → propose (#81)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -455,7 +455,8 @@ When the console proves out, these become real concerns. Not before.
         ├─ A3 (project registry) + A7 (dispatch UI)  ← when 2nd project arrives
         ├─ B1..B4 (project config externalization)  ← when 5th agent / 2nd project arrives
         ├─ C1..C4 (docker orchestration)  ← when make-context-switching becomes annoying
-        ├─ D1..D4 (autonomous mode)  ← after MVP ergonomics dial in
+        ├─ H11 (ranch hand MVP)  ← landed: triage → scope → propose → park
+    ├─ D1..D4 (autonomous mode)  ← after MVP ergonomics dial in
         ├─ E1..E4 (inbox + timeline)  ← needs A2 (event bus)
         └─ F1..F3 (memory panel)  ← opportunistic
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -97,6 +97,32 @@ ranch runs --agent max      # filter by agent
 ranch resume 3              # resume run #3 by SDK session ID
 ```
 
+## Ranch hand daemon (Phase H11 — MVP)
+
+The persistent virtual engineer that runs the pilot loop on autopilot.
+Picks the next viable Jira ticket, gathers context, drafts a plan, parks
+for your review.
+
+```bash
+ranch hand start max --poll 30 --project ECD    # foreground daemon for agent 'max'
+ranch hand status                               # see what every hand is doing
+ranch hand stop max                             # graceful stop after the current step
+```
+
+MVP scope: one ticket at a time per hand. The hand triages → scopes →
+proposes → parks. While a recently-parked proposal is awaiting your
+review (24h window), the hand idles instead of piling on new work.
+
+After you review a parked proposal:
+- If you want to proceed, run `ranch run max --ticket <key> --brief "<plan>"`
+  using the plan from the dossier — execution wiring lands when the next
+  H-tickets layer in (H8 self-judge, H9 labs handoff, H10 PR draft).
+- If you want to reject, just delete or supersede the parked run; the
+  hand will triage past it once it falls outside the 24h window.
+
+Stop semantics: `ranch hand stop` writes a sentinel file the daemon polls
+for between cycles — clean exit, never kills mid-tool-use.
+
 ## Propose a plan (Phase H6)
 
 Run a bounded, file-system-read-only SDK session that produces a plan +

--- a/ranch/cli.py
+++ b/ranch/cli.py
@@ -613,6 +613,90 @@ def dossier_cmd(run_id, as_json, watch, interval):
             pass
 
 
+@cli.group("hand")
+def hand_group():
+    """Ranch hand — virtual engineer daemon (Phase H11)."""
+
+
+@hand_group.command("start")
+@click.argument("name")
+@click.option("--poll", default=30.0, type=float, help="Poll interval in seconds (default 30).")
+@click.option("--project", default=None, help="Restrict triage to a single Jira project key.")
+def hand_start_cmd(name, poll, project):
+    """Start the ranch hand daemon for an agent. Runs in the foreground."""
+    import asyncio as _asyncio
+    from .config import AGENTS, reload_agents
+    from .hand import RanchHand, _read_pid, _pid_alive
+
+    reload_agents()
+    if name not in AGENTS:
+        console.print(f"[red]Unknown agent '{name}'. Configure it in ~/.ranch/config.toml.[/red]")
+        raise click.Abort()
+
+    existing_pid = _read_pid(name)
+    if existing_pid and _pid_alive(existing_pid):
+        console.print(f"[red]Ranch hand '{name}' is already running (pid {existing_pid}).[/red]")
+        raise click.Abort()
+
+    hand = RanchHand(
+        name=name,
+        cwd=AGENTS[name].worktree,
+        poll_seconds=poll,
+        jira_project=project,
+    )
+    try:
+        _asyncio.run(hand.run())
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Interrupted.[/yellow]")
+
+
+@hand_group.command("stop")
+@click.argument("name")
+def hand_stop_cmd(name):
+    """Request a graceful stop of the ranch hand daemon."""
+    from .hand import request_stop
+    if request_stop(name):
+        console.print(f"[green]Stop signal sent to ranch hand '{name}'.[/green]")
+    else:
+        console.print(f"[yellow]Ranch hand '{name}' is not running.[/yellow]")
+
+
+@hand_group.command("status")
+@click.option("--name", default=None, help="Show status for one hand only.")
+def hand_status_cmd(name):
+    """Show what each ranch hand is doing."""
+    from .hand import get_hand_status, list_all_hand_statuses
+    if name:
+        statuses = [get_hand_status(name)]
+    else:
+        statuses = list_all_hand_statuses()
+
+    if not statuses:
+        console.print("[yellow]No hands configured.[/yellow]")
+        return
+
+    table = Table(title="Ranch hands", show_header=True)
+    table.add_column("Hand")
+    table.add_column("State")
+    table.add_column("PID", width=8)
+    table.add_column("Run", width=8)
+    table.add_column("Ticket")
+    table.add_column("Dossier")
+    table.add_column("Detail")
+    state_styles = {"running": "green", "stopped": "dim", "missing": "red", "idle": "yellow"}
+    for s in statuses:
+        table.add_row(
+            s.name,
+            f"[{state_styles.get(s.state, 'white')}]{s.state}[/{state_styles.get(s.state, 'white')}]",
+            str(s.pid) if s.pid else "—",
+            f"#{s.current_run_id}" if s.current_run_id else "—",
+            s.current_ticket or "—",
+            s.current_dossier_state or "—",
+            s.detail,
+        )
+    console.print(table)
+
+
 @cli.command("propose")
 @click.argument("ticket", type=str)
 @click.option("--agent", default=None, help="Agent whose worktree to run in. Required if --cwd isn't given.")

--- a/ranch/hand.py
+++ b/ranch/hand.py
@@ -1,0 +1,420 @@
+"""H11 — Ranch hand: the daemon that composes the pilot loop primitives.
+
+MVP scope (this file):
+
+  loop forever:
+    if I have an in-flight run → leave it alone, sleep
+    else if my last run is parked-and-awaiting-approval → leave it alone, sleep
+    else → triage → scope → propose → park (next cycle sees the parked dossier)
+
+The hand picks one ticket at a time in this MVP. Multi-ticket juggling
+(the "real" ranch hand model where it parks one and works another) is a
+follow-up — adding it requires a richer state machine that's worth
+landing on top of a working single-ticket loop first.
+
+Stop semantics: write a sentinel file `~/.ranch/hands/<name>.stop` to
+request a graceful stop after the current step. The hand polls for it
+between cycles.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+
+from rich.console import Console
+
+from .config import AGENTS, RANCH_HOME, reload_agents
+from .db import db_session
+from .models import Dossier, Run
+
+console = Console()
+
+HANDS_DIR = RANCH_HOME / "hands"
+HANDS_DIR.mkdir(parents=True, exist_ok=True)
+
+# How long after a propose finishes do we still consider it "awaiting approval"
+# rather than stale enough to triage past? Keeps the hand from churning a
+# new triage on a recently-parked ticket the operator hasn't seen yet.
+AWAITING_APPROVAL_WINDOW = timedelta(hours=24)
+
+
+@dataclass
+class HandStatus:
+    """Snapshot of what a hand is doing right now — surfaced by `ranch hand status`."""
+
+    name: str
+    pid: int | None
+    state: str  # "running" | "idle" | "stopped" | "missing"
+    current_run_id: int | None
+    current_ticket: str | None
+    current_dossier_state: str | None
+    detail: str = ""
+
+
+# ─── Sentinel files for daemon lifecycle ───────────────────────────
+
+
+def _pid_file(name: str) -> Path:
+    return HANDS_DIR / f"{name}.pid"
+
+
+def _stop_file(name: str) -> Path:
+    return HANDS_DIR / f"{name}.stop"
+
+
+def _write_pid(name: str, pid: int) -> None:
+    _pid_file(name).write_text(str(pid))
+
+
+def _clear_pid(name: str) -> None:
+    p = _pid_file(name)
+    if p.exists():
+        p.unlink()
+
+
+def request_stop(name: str) -> bool:
+    """Touch the stop sentinel. Returns False if no pid file (hand isn't running)."""
+    if not _pid_file(name).exists():
+        return False
+    _stop_file(name).touch()
+    return True
+
+
+def _read_pid(name: str) -> int | None:
+    p = _pid_file(name)
+    if not p.exists():
+        return None
+    try:
+        return int(p.read_text().strip())
+    except (ValueError, OSError):
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    """Check if a pid is still running. signal(0) is the POSIX 'is alive' probe."""
+    import os
+    import signal as _signal
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except OSError:
+        return False
+
+
+# ─── Run lookups ───────────────────────────────────────────────────
+
+
+TERMINAL_RUN_STATES = {"completed", "stopped", "error"}
+
+
+def _active_run_for(agent: str) -> Optional["Run"]:
+    """Return the most-recent non-terminal Run for this agent, or None."""
+    with db_session() as db:
+        run = (
+            db.query(Run)
+            .filter(Run.agent == agent)
+            .filter(~Run.state.in_(TERMINAL_RUN_STATES))
+            .order_by(Run.started_at.desc())
+            .first()
+        )
+        if not run:
+            return None
+        return _snapshot_run(run)
+
+
+def _last_parked_run_for(agent: str) -> Optional["Run"]:
+    """Return the most-recent terminal Run whose latest dossier is parked AND
+    that finished within AWAITING_APPROVAL_WINDOW. None otherwise.
+
+    Used to detect 'a propose finished recently, the operator still needs to
+    look at it — don't start a new triage cycle on top of it.'
+    """
+    with db_session() as db:
+        cutoff = datetime.now(timezone.utc) - AWAITING_APPROVAL_WINDOW
+        # Most recent terminal run for this agent
+        run = (
+            db.query(Run)
+            .filter(Run.agent == agent)
+            .filter(Run.state.in_(TERMINAL_RUN_STATES))
+            .filter(Run.ended_at >= cutoff)
+            .order_by(Run.ended_at.desc())
+            .first()
+        )
+        if not run:
+            return None
+        # Is the latest dossier parked?
+        latest = (
+            db.query(Dossier)
+            .filter_by(run_id=run.id)
+            .order_by(Dossier.created_at.desc())
+            .first()
+        )
+        if not latest or latest.state != "parked":
+            return None
+        return _snapshot_run(run)
+
+
+@dataclass
+class _RunSnapshot:
+    id: int
+    agent: str
+    ticket: str | None
+    state: str
+
+
+def _snapshot_run(run: "Run") -> _RunSnapshot:
+    return _RunSnapshot(id=run.id, agent=run.agent, ticket=run.ticket, state=run.state)
+
+
+# ─── The hand itself ───────────────────────────────────────────────
+
+
+class RanchHand:
+    """One virtual engineer. Polls for work and drives the pilot loop."""
+
+    def __init__(
+        self,
+        name: str,
+        cwd: Path,
+        *,
+        poll_seconds: float = 30.0,
+        idle_log_freq_minutes: float = 30.0,
+        jira_project: str | None = None,
+        triage_fn: Optional[Callable[[str | None], list[str]]] = None,
+        scope_fn: Optional[Callable[[str], None]] = None,
+        propose_fn: Optional[Callable[[str], Awaitable[None]]] = None,
+    ):
+        self.name = name
+        self.cwd = cwd
+        self.poll_seconds = poll_seconds
+        self.idle_log_freq_minutes = idle_log_freq_minutes
+        self.jira_project = jira_project
+
+        # Injection seams for tests + offline mode. Default impls hit Jira /
+        # invoke H5+H6; the validation harness injects synthetic versions.
+        self.triage_fn = triage_fn or self._default_triage
+        self.scope_fn = scope_fn or self._default_scope
+        self.propose_fn = propose_fn or self._default_propose
+
+        self.stop_requested = False
+        self._last_idle_log = datetime.now(timezone.utc) - timedelta(days=1)
+
+    # ─── Default backends ────────────────────────────────────────
+
+    def _default_triage(self, project: str | None) -> list[str]:
+        """Live triage via Jira. Returns ticket keys in ranked order."""
+        from .triage import (
+            JiraClient,
+            JiraConfig,
+            JiraConfigError,
+            in_flight_ticket_keys_for_agent,
+            triage,
+        )
+        try:
+            cfg = JiraConfig.load()
+        except JiraConfigError as e:
+            console.print(f"[yellow]{self.name}: Jira not configured — {e}[/yellow]")
+            return []
+        in_flight = in_flight_ticket_keys_for_agent(self.name)
+        with JiraClient(cfg) as client:
+            tickets = client.list_assigned_to_me(project=project)
+        ranked = triage(tickets, in_flight)
+        return [t.key for t, _ in ranked]
+
+    def _default_scope(self, ticket_key: str) -> None:
+        """Build + save the scope bundle via H5."""
+        from .scope import build_scope, save_scope
+        from .triage import JiraClient, JiraConfig
+        with JiraClient(JiraConfig.load()) as client:
+            scope = build_scope(ticket_key, jira=client, cwd=self.cwd)
+        save_scope(scope)
+
+    async def _default_propose(self, ticket_key: str) -> None:
+        """Run a propose session via H6 against this hand's worktree."""
+        from .propose import (
+            DEFAULT_PROPOSE_BUDGET_SECONDS,
+            PROPOSE_ALLOWED_TOOLS,
+            PROPOSE_SYSTEM_PROMPT,
+            build_propose_brief,
+            resolve_scope_markdown,
+        )
+        from .runner.orchestrator import Orchestrator
+
+        scope_md = resolve_scope_markdown(ticket_key)
+        brief = build_propose_brief(ticket_key, scope_md)
+        orch = Orchestrator(
+            agent=self.name,
+            cwd=self.cwd,
+            ticket=ticket_key,
+            brief=brief,
+            free=True,
+            auto_approve=True,  # propose finishes cleanly; the parked dossier IS the gate
+            allowed_tools_override=PROPOSE_ALLOWED_TOOLS,
+            budget_seconds=DEFAULT_PROPOSE_BUDGET_SECONDS,
+            append_system_prompt_override=PROPOSE_SYSTEM_PROMPT,
+        )
+        await orch.run()
+
+    # ─── Loop ────────────────────────────────────────────────────
+
+    def _check_stop_signal(self) -> bool:
+        """True if the operator dropped a stop sentinel for us."""
+        return _stop_file(self.name).exists()
+
+    def _consume_stop_signal(self) -> None:
+        sp = _stop_file(self.name)
+        if sp.exists():
+            sp.unlink()
+
+    def _maybe_log_idle(self, msg: str) -> None:
+        """Throttle the 'idle' log so we don't spam every poll cycle."""
+        now = datetime.now(timezone.utc)
+        if now - self._last_idle_log >= timedelta(minutes=self.idle_log_freq_minutes):
+            console.print(f"[dim]{self.name}: {msg}[/dim]")
+            self._last_idle_log = now
+
+    async def run(self) -> None:
+        """Main daemon loop. Returns when stop is requested."""
+        import os
+        _write_pid(self.name, os.getpid())
+        console.print(
+            f"[bold cyan]ranch hand '{self.name}' started[/bold cyan]  "
+            f"[dim](cwd={self.cwd}, poll={self.poll_seconds}s)[/dim]"
+        )
+        try:
+            while not self.stop_requested:
+                if self._check_stop_signal():
+                    console.print(f"[yellow]{self.name}: stop signal received — exiting cleanly.[/yellow]")
+                    self._consume_stop_signal()
+                    break
+
+                # 1. Anything already in flight? Don't double-pick.
+                active = _active_run_for(self.name)
+                if active:
+                    self._maybe_log_idle(
+                        f"run #{active.id} ({active.ticket}) in flight — leaving alone"
+                    )
+                    await asyncio.sleep(self.poll_seconds)
+                    continue
+
+                # 2. Recently parked & still within the operator-review window?
+                parked = _last_parked_run_for(self.name)
+                if parked:
+                    self._maybe_log_idle(
+                        f"run #{parked.id} ({parked.ticket}) parked — awaiting human review"
+                    )
+                    await asyncio.sleep(self.poll_seconds)
+                    continue
+
+                # 3. Nothing in flight, nothing parked → triage for new work.
+                console.print(f"[cyan]{self.name}: no active work — triaging...[/cyan]")
+                try:
+                    candidates = self.triage_fn(self.jira_project)
+                except Exception as e:
+                    console.print(f"[red]{self.name}: triage failed — {e}[/red]")
+                    await asyncio.sleep(self.poll_seconds)
+                    continue
+
+                if not candidates:
+                    self._maybe_log_idle("no viable tickets — staying idle")
+                    await asyncio.sleep(self.poll_seconds)
+                    continue
+
+                ticket = candidates[0]
+                console.print(f"[bold green]{self.name}: picked {ticket}[/bold green]")
+
+                # 4. Scope it
+                try:
+                    self.scope_fn(ticket)
+                except Exception as e:
+                    console.print(f"[red]{self.name}: scope failed for {ticket} — {e}[/red]")
+                    await asyncio.sleep(self.poll_seconds)
+                    continue
+
+                # 5. Propose
+                console.print(f"[cyan]{self.name}: proposing plan for {ticket}...[/cyan]")
+                try:
+                    await self.propose_fn(ticket)
+                except Exception as e:
+                    console.print(f"[red]{self.name}: propose failed for {ticket} — {e}[/red]")
+                    await asyncio.sleep(self.poll_seconds)
+                    continue
+
+                console.print(f"[green]{self.name}: {ticket} parked at propose — next cycle will wait for review[/green]")
+                # Loop continues: next iteration sees the parked run + waits
+
+        finally:
+            _clear_pid(self.name)
+            console.print(f"[dim]{self.name}: stopped.[/dim]")
+
+
+# ─── Status surface ────────────────────────────────────────────────
+
+
+def get_hand_status(name: str) -> HandStatus:
+    """One-shot status snapshot for `ranch hand status`."""
+    pid = _read_pid(name)
+    if pid is None:
+        return HandStatus(name=name, pid=None, state="stopped",
+                           current_run_id=None, current_ticket=None,
+                           current_dossier_state=None,
+                           detail="not running")
+    if not _pid_alive(pid):
+        # Stale pid file — daemon crashed without cleaning up
+        return HandStatus(name=name, pid=pid, state="missing",
+                           current_run_id=None, current_ticket=None,
+                           current_dossier_state=None,
+                           detail=f"pid {pid} not alive (stale pidfile?)")
+
+    active = _active_run_for(name)
+    if active:
+        with db_session() as db:
+            latest = (
+                db.query(Dossier)
+                .filter_by(run_id=active.id)
+                .order_by(Dossier.created_at.desc())
+                .first()
+            )
+            dstate = latest.state if latest else None
+        return HandStatus(
+            name=name, pid=pid, state="running",
+            current_run_id=active.id, current_ticket=active.ticket,
+            current_dossier_state=dstate,
+            detail=f"working on {active.ticket}",
+        )
+
+    parked = _last_parked_run_for(name)
+    if parked:
+        return HandStatus(
+            name=name, pid=pid, state="running",
+            current_run_id=parked.id, current_ticket=parked.ticket,
+            current_dossier_state="parked",
+            detail=f"parked on {parked.ticket} — awaiting review",
+        )
+
+    return HandStatus(name=name, pid=pid, state="running",
+                       current_run_id=None, current_ticket=None,
+                       current_dossier_state=None,
+                       detail="idle (no work)")
+
+
+def list_all_hand_statuses() -> list[HandStatus]:
+    """Aggregate status for every agent known to the config + every active pid file."""
+    reload_agents()
+    seen: set[str] = set()
+    out: list[HandStatus] = []
+    for name in AGENTS:
+        out.append(get_hand_status(name))
+        seen.add(name)
+    # Also pick up pid files for hands not in config (ad-hoc test hands etc.)
+    for pid_path in HANDS_DIR.glob("*.pid"):
+        nm = pid_path.stem
+        if nm not in seen:
+            out.append(get_hand_status(nm))
+    return out

--- a/tests/test_hand.py
+++ b/tests/test_hand.py
@@ -1,0 +1,312 @@
+"""Tests for the ranch hand scheduler (Phase H11).
+
+The Jira side, the scope side, and the propose side are all injected as
+fakes — these tests exercise the decision logic. End-to-end real-agent
+behavior lives in the tier-2 validation script.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ranch.db import db_session, init_db
+from ranch.hand import (
+    AWAITING_APPROVAL_WINDOW,
+    HANDS_DIR,
+    RanchHand,
+    _active_run_for,
+    _last_parked_run_for,
+    _pid_file,
+    _read_pid,
+    _stop_file,
+    get_hand_status,
+    list_all_hand_statuses,
+    request_stop,
+)
+from ranch.models import Dossier, Run
+
+
+# ─── Fixture: isolate the hands dir per test ──────────────────────
+
+
+@pytest.fixture(autouse=True)
+def isolated_hands_dir(tmp_path, monkeypatch):
+    h = tmp_path / "hands"
+    h.mkdir()
+    monkeypatch.setattr("ranch.hand.HANDS_DIR", h)
+    monkeypatch.setattr("ranch.hand._pid_file", lambda name: h / f"{name}.pid")
+    monkeypatch.setattr("ranch.hand._stop_file", lambda name: h / f"{name}.stop")
+    yield h
+
+
+# ─── Helpers ──────────────────────────────────────────────────────
+
+
+def _make_run(agent: str, ticket: str, state: str = "planning",
+              ended_at: datetime | None = None) -> int:
+    init_db()
+    with db_session() as db:
+        run = Run(agent=agent, ticket=ticket, cwd="/tmp", initial_prompt="x",
+                  state=state, ended_at=ended_at)
+        db.add(run)
+        db.flush()
+        return run.id
+
+
+def _add_dossier(run_id: int, state: str, **extra):
+    init_db()
+    with db_session() as db:
+        payload = {"plan": [{"step": "x", "status": "done"}],
+                   "just_did": "did the thing", "state": state, **extra}
+        db.add(Dossier(run_id=run_id, state=state,
+                        payload_json=json.dumps(payload)))
+
+
+# ─── Run lookups ──────────────────────────────────────────────────
+
+
+def test_active_run_returns_none_when_nothing_active():
+    init_db()
+    assert _active_run_for("max") is None
+
+
+def test_active_run_finds_non_terminal_run():
+    rid = _make_run("max", "ECD-1", state="in_development")
+    snap = _active_run_for("max")
+    assert snap is not None
+    assert snap.id == rid
+
+
+def test_active_run_excludes_terminal_states():
+    _make_run("max", "ECD-1", state="completed")
+    _make_run("max", "ECD-2", state="error")
+    assert _active_run_for("max") is None
+
+
+def test_active_run_is_agent_scoped():
+    _make_run("jeffy", "ECD-J", state="planning")
+    assert _active_run_for("max") is None
+
+
+def test_last_parked_run_recognizes_parked_dossier_on_terminal_run():
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "planning")
+    _add_dossier(rid, "parked", blocker="Awaiting approval")
+    parked = _last_parked_run_for("max")
+    assert parked is not None
+    assert parked.id == rid
+
+
+def test_last_parked_run_ignores_non_parked_terminal_runs():
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "coding")  # ended without parking
+    assert _last_parked_run_for("max") is None
+
+
+def test_last_parked_run_respects_window():
+    """A propose from 30 hours ago is stale — operator already saw it or won't."""
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc) - timedelta(hours=30))
+    _add_dossier(rid, "parked", blocker="x")
+    assert _last_parked_run_for("max") is None
+
+
+# ─── Stop signal handling ────────────────────────────────────────
+
+
+def test_request_stop_returns_false_when_no_pid_file():
+    assert request_stop("max") is False
+
+
+def test_request_stop_writes_sentinel_when_pid_exists(isolated_hands_dir):
+    pid_path = isolated_hands_dir / "max.pid"
+    pid_path.write_text("12345")
+    assert request_stop("max") is True
+    assert (isolated_hands_dir / "max.stop").exists()
+
+
+# ─── Scheduler decision loop ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hand_picks_top_triage_and_runs_scope_then_propose(tmp_path):
+    """The happy path: no active work → triage returns a key → scope + propose fire."""
+    called: dict[str, list[str]] = {"triage": [], "scope": [], "propose": []}
+    cycles = {"n": 0}
+
+    def triage_fn(_project):
+        called["triage"].append("called")
+        return ["ECD-100", "ECD-200"]
+
+    def scope_fn(key):
+        called["scope"].append(key)
+
+    async def propose_fn(key):
+        called["propose"].append(key)
+        # Simulate the side effect: a run + parked dossier exist after propose
+        rid = _make_run("testhand", key, state="completed",
+                        ended_at=datetime.now(timezone.utc))
+        _add_dossier(rid, "parked", blocker="Awaiting approval")
+
+    hand = RanchHand("testhand", tmp_path, poll_seconds=0.01,
+                      triage_fn=triage_fn, scope_fn=scope_fn, propose_fn=propose_fn)
+
+    # Stop after one iteration to avoid an infinite loop in tests.
+    async def stop_after_first_cycle():
+        await asyncio.sleep(0.02)
+        hand.stop_requested = True
+
+    init_db()
+    await asyncio.gather(hand.run(), stop_after_first_cycle())
+
+    assert called["triage"] == ["called"]
+    assert called["scope"] == ["ECD-100"]  # top of the ranking
+    assert called["propose"] == ["ECD-100"]
+
+
+@pytest.mark.asyncio
+async def test_hand_skips_triage_when_active_run_exists(tmp_path):
+    """If there's already an active run, leave it alone."""
+    _make_run("testhand", "ECD-7", state="in_development")
+    called: dict[str, int] = {"triage": 0, "scope": 0, "propose": 0}
+
+    def triage_fn(_p): called["triage"] += 1; return ["ECD-1"]
+    def scope_fn(_k): called["scope"] += 1
+    async def propose_fn(_k): called["propose"] += 1
+
+    hand = RanchHand("testhand", tmp_path, poll_seconds=0.01,
+                      triage_fn=triage_fn, scope_fn=scope_fn, propose_fn=propose_fn)
+
+    async def stop():
+        await asyncio.sleep(0.05)
+        hand.stop_requested = True
+
+    await asyncio.gather(hand.run(), stop())
+    assert called["triage"] == 0
+    assert called["scope"] == 0
+    assert called["propose"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hand_skips_triage_when_recent_parked_run_exists(tmp_path):
+    """If the previous propose just parked, wait for human review — don't pile on."""
+    rid = _make_run("testhand", "ECD-7", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "parked", blocker="x")
+
+    called = {"triage": 0}
+    def triage_fn(_p): called["triage"] += 1; return ["ECD-1"]
+
+    hand = RanchHand("testhand", tmp_path, poll_seconds=0.01, triage_fn=triage_fn)
+
+    async def stop():
+        await asyncio.sleep(0.05)
+        hand.stop_requested = True
+
+    await asyncio.gather(hand.run(), stop())
+    assert called["triage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hand_handles_empty_triage_gracefully(tmp_path):
+    """Empty triage shouldn't crash — just sleep + retry next cycle."""
+    cycles = {"triage": 0}
+    def triage_fn(_p): cycles["triage"] += 1; return []
+
+    hand = RanchHand("testhand", tmp_path, poll_seconds=0.01, triage_fn=triage_fn)
+    async def stop():
+        await asyncio.sleep(0.05)
+        hand.stop_requested = True
+
+    init_db()
+    await asyncio.gather(hand.run(), stop())
+    assert cycles["triage"] >= 1  # tried at least once, didn't crash
+
+
+@pytest.mark.asyncio
+async def test_hand_handles_triage_exception_gracefully(tmp_path):
+    """If triage raises, log + continue."""
+    def triage_fn(_p): raise RuntimeError("jira down")
+
+    hand = RanchHand("testhand", tmp_path, poll_seconds=0.01, triage_fn=triage_fn)
+    async def stop():
+        await asyncio.sleep(0.05)
+        hand.stop_requested = True
+
+    init_db()
+    await asyncio.gather(hand.run(), stop())  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_stop_signal_file_terminates_loop(tmp_path, isolated_hands_dir):
+    """Touching the .stop sentinel exits cleanly between cycles."""
+    triggered = {"n": 0}
+    def triage_fn(_p):
+        triggered["n"] += 1
+        # Drop the stop sentinel as a side effect of the first triage call
+        (isolated_hands_dir / "testhand.stop").touch()
+        return []
+
+    hand = RanchHand("testhand", tmp_path, poll_seconds=0.01, triage_fn=triage_fn)
+    init_db()
+    await hand.run()
+    assert triggered["n"] >= 1
+    # Sentinel is consumed by the loop
+    assert not (isolated_hands_dir / "testhand.stop").exists()
+
+
+# ─── Status snapshots ────────────────────────────────────────────
+
+
+def test_status_when_no_pid_returns_stopped(isolated_hands_dir):
+    s = get_hand_status("max")
+    assert s.state == "stopped"
+    assert s.pid is None
+
+
+def test_status_when_pid_alive_and_active_run(isolated_hands_dir):
+    import os
+    (isolated_hands_dir / "max.pid").write_text(str(os.getpid()))
+    rid = _make_run("max", "ECD-1", state="in_development")
+    _add_dossier(rid, "coding")
+
+    s = get_hand_status("max")
+    assert s.state == "running"
+    assert s.current_run_id == rid
+    assert s.current_ticket == "ECD-1"
+    assert s.current_dossier_state == "coding"
+
+
+def test_status_when_pid_alive_and_parked(isolated_hands_dir):
+    import os
+    (isolated_hands_dir / "max.pid").write_text(str(os.getpid()))
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "parked", blocker="x")
+
+    s = get_hand_status("max")
+    assert s.current_dossier_state == "parked"
+    assert "awaiting review" in s.detail
+
+
+def test_status_when_pid_alive_no_work(isolated_hands_dir):
+    import os
+    (isolated_hands_dir / "max.pid").write_text(str(os.getpid()))
+    init_db()
+    s = get_hand_status("max")
+    assert s.state == "running"
+    assert "idle" in s.detail
+
+
+def test_status_when_pid_stale_returns_missing(isolated_hands_dir):
+    # A pid that's almost certainly not alive
+    (isolated_hands_dir / "max.pid").write_text("999999")
+    s = get_hand_status("max")
+    assert s.state == "missing"


### PR DESCRIPTION
## Summary

First runnable cut of the **ranch hand** — the persistent virtual engineer that runs the pilot loop on autopilot. Picks the next viable Jira ticket, gathers context (H5), drafts a plan (H6), parks at `parked` with options for human review. The hand idles until you act; no piling-on.

Stacked on #90 (H6).

## What you can do after this lands

```bash
ranch hand start max --poll 30 --project ECD    # foreground daemon
ranch hand status                               # see what every hand is doing
ranch hand stop max                             # graceful stop
```

## Tier-2 validation — real propose, end-to-end ✓

Ran the actual hand against a fake ticket with synthetic triage + the existing test worktree:

| Check | Result |
|---|---|
| Triage called once | ✓ (1 call total — didn't re-triage on the 2nd cycle) |
| Scope called once with top of triage | ✓ |
| Real propose session ran | ✓ (84s, real SDK call) |
| 2 dossier rows emitted (researching → parked) | ✓ |
| Final dossier `state=parked` + blocker + options | ✓ |
| Worktree modifications during propose | **0 files** ✓ |
| Hand skipped 2nd triage when recent parked run existed | ✓ |
| Stop sentinel exited cleanly between cycles | ✓ |

**Bonus signal:** during the validation, the fake ticket's premise was wrong (it referenced commands not in the test worktree's snapshot). The agent **noticed and surfaced "needs-info" as a third option** instead of fabricating. Exactly the "don't go off the rails" behavior we wanted — the H6 system prompt's "if ambiguous, surface rather than guess" instruction is landing in production behavior.

## MVP scope

This PR delivers **single ticket per hand**:
- Loop: if active run → leave alone; else if recent parked run (within 24h) → leave alone for human review; else triage → scope → propose → park
- Hand idles politely between cycles with throttled logs (default once per 30 min)
- Stop = `~/.ranch/hands/<name>.stop` sentinel; daemon polls between cycles
- Status = pid file + dossier introspection, rendered as a Rich table

**What's intentionally deferred to the next iteration:**
- Multi-ticket juggling (park ticket A, work ticket B, resume A when unblocked)
- Auto-resume on `!approve` (today the operator manually kicks off the execution run after reviewing the proposal)
- Unblock detection on PR comments / CI / labs deploys (the integration points are wired by H8/H9/H10)

Splitting it this way means the loop ships and gets feedback before we land the bigger state-machine extensions.

## Files

- **`ranch/hand.py`** — `RanchHand` class. Injection seams (`triage_fn`, `scope_fn`, `propose_fn`) so tests + offline modes don't need live Jira. PID + stop-sentinel lifecycle in `~/.ranch/hands/`. Status surface (`get_hand_status`, `list_all_hand_statuses`).
- **`ranch/cli.py`** — `ranch hand start|stop|status` subcommand group.
- **`tests/test_hand.py`** — 20 tests: active/parked run lookups (agent-scoped, window-aware, terminal-state filtering), stop signal handling, scheduler decisions, status snapshots (alive + active, parked, idle, stale pid).
- **Full suite:** 238 passed.

## Notes for review

- The 24h "awaiting review" window is a heuristic — `AWAITING_APPROVAL_WINDOW = timedelta(hours=24)`. Anything older than that and the hand assumes you've already seen + decided, so it triages past. Tunable later per-hand once we have signal on the right cadence.
- Hand-as-daemon: foreground for now. `--daemon`-style detachment is a follow-up; for the MVP, run it under `tmux`, `caffeinate`, or your supervisor of choice.
- The `_pid_file` / `_stop_file` helpers are monkeypatched in tests to redirect to `tmp_path`; production uses `~/.ranch/hands/`. Standard isolation pattern.

Closes #81 (or at least its MVP scope — open follow-ups: multi-ticket, auto-resume, unblock detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)