### PR TITLE
H8 v1: self-judge via run_acceptance MCP tool (#78)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -388,7 +388,7 @@ The "polling now, webhooks later" call: each agent's pilot daemon polls every ~3
 - H5 (#75) — `ranch scope <ticket>` — context bundle [in flight]
 - H6 (#76) — `ranch propose <ticket>` — bounded plan + acceptance criteria [in flight]
 - H7 (#77) — `ranch design <ticket>` — figma frame discovery
-- H8 (#78) — Self-judge integration loop
+- H8 (#78) — Self-judge integration loop [v1 in flight: unit_test/script/http]
 - H9 (#79) — Ethan-labs deploy handoff
 - H10 (#80) — PR draft with testing instructions + labs link + Qase MCP
 - H11 (#81) — Agent scheduler — proactive multi-ticket loop

--- a/USAGE.md
+++ b/USAGE.md
@@ -97,6 +97,27 @@ ranch runs --agent max      # filter by agent
 ranch resume 3              # resume run #3 by SDK session ID
 ```
 
+## Self-judge integration loop (Phase H8)
+
+During an execute run, the agent verifies its own work via `run_acceptance` —
+an in-process MCP tool that runs the acceptance checks set by `ranch propose`.
+
+Three check kinds in v1: `unit_test`, `script`, `http`. Browser + figma-diff
+are v2 (need playwright + visual-diff infra).
+
+Acceptance flow:
+1. `ranch propose` writes a structured `acceptance` array into the parked
+   dossier (alongside `details`, `plan`, etc.)
+2. Execute run launches with the same dossier in scope
+3. Agent calls `run_acceptance` (no args) — hook reads the dossier's acceptance,
+   runs every check, returns structured pass/fail to the agent
+4. If anything failed, agent reads the output, fixes the issue, re-calls
+5. Budget guard: 8 calls per session by default; refuses past that with a
+   "park as stuck" instruction
+
+No new CLI command needed for v1 — the tool is invoked by the agent during
+its run, not by the operator directly.
+
 ## Ranch hand daemon (Phase H11 — MVP)
 
 The persistent virtual engineer that runs the pilot loop on autopilot.

--- a/ranch/judge.py
+++ b/ranch/judge.py
@@ -1,0 +1,194 @@
+"""H8 — self-judge: run the acceptance checks emitted by `ranch propose`.
+
+The judge is invoked by the agent via the `run_acceptance` MCP tool during
+execute runs. Each check is independently runnable; results come back as a
+structured list the agent can read, react to, and iterate on.
+
+v1 supports three check kinds:
+  - unit_test: shell command + pass_pattern (substring or regex in stdout)
+  - script:    same shape as unit_test; semantic naming for the operator
+  - http:      httpx GET + status code / body-substring assertions
+
+Browser + figma_diff are reserved for v2 (need playwright + screenshot-diff
+infra) — they're already in the AcceptanceCheck enum's `kind`, but the
+runner rejects them with a clear error so misuse is loud, not silent.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+import httpx
+
+from .runner.messages import AcceptanceCheck
+
+
+@dataclass
+class AcceptanceResult:
+    """One acceptance check's outcome — what the agent reads to decide next step."""
+
+    name: str
+    kind: str
+    passed: bool
+    duration_ms: int
+    output: str = ""  # for unit_test/script: stdout+stderr tail; for http: status+body sample
+    error: str = ""  # populated when the check couldn't run (config error, timeout, etc.)
+
+    def summary_line(self) -> str:
+        mark = "✓" if self.passed else "✗"
+        return f"  {mark} [{self.kind}] {self.name}  ({self.duration_ms}ms)"
+
+
+@dataclass
+class JudgeRun:
+    """Aggregate result for one `run_acceptance` invocation."""
+
+    results: list[AcceptanceResult] = field(default_factory=list)
+
+    @property
+    def all_passed(self) -> bool:
+        return bool(self.results) and all(r.passed for r in self.results)
+
+    @property
+    def num_failed(self) -> int:
+        return sum(1 for r in self.results if not r.passed)
+
+    def to_dict(self) -> dict:
+        return {
+            "all_passed": self.all_passed,
+            "num_failed": self.num_failed,
+            "results": [
+                {
+                    "name": r.name, "kind": r.kind, "passed": r.passed,
+                    "duration_ms": r.duration_ms,
+                    "output": r.output[:2000] if r.output else "",
+                    "error": r.error,
+                }
+                for r in self.results
+            ],
+        }
+
+
+# ─── Per-kind runners ──────────────────────────────────────────────
+
+
+def _trim_for_report(text: str, limit: int = 3000) -> str:
+    """Keep the tail when output is huge — failures usually surface there."""
+    if len(text) <= limit:
+        return text
+    return f"...[truncated {len(text) - limit} chars]...\n{text[-limit:]}"
+
+
+def _matches(pattern: str, text: str) -> bool:
+    r"""Match either as a regex if it compiles, else as a substring.
+
+    Agents naturally write things like 'passed' (substring) and '\d+ passed'
+    (regex). Tolerate both without forcing them to escape.
+    """
+    if not pattern:
+        return True
+    try:
+        return re.search(pattern, text, re.MULTILINE) is not None
+    except re.error:
+        return pattern in text
+
+
+def _run_subprocess_check(check: AcceptanceCheck, cwd: Path) -> AcceptanceResult:
+    if not check.cmd:
+        return AcceptanceResult(
+            name=check.name, kind=check.kind, passed=False, duration_ms=0,
+            error=f"{check.kind} check missing `cmd`",
+        )
+    if not check.pass_pattern:
+        return AcceptanceResult(
+            name=check.name, kind=check.kind, passed=False, duration_ms=0,
+            error=f"{check.kind} check missing `pass_pattern`",
+        )
+
+    start = time.time()
+    try:
+        proc = subprocess.run(
+            check.cmd, cwd=str(cwd), shell=True,
+            capture_output=True, text=True, timeout=check.timeout_seconds,
+        )
+        elapsed_ms = int((time.time() - start) * 1000)
+        combined = (proc.stdout or "") + ("\n" + proc.stderr if proc.stderr else "")
+        passed = (proc.returncode == 0) and _matches(check.pass_pattern, combined)
+        return AcceptanceResult(
+            name=check.name, kind=check.kind, passed=passed,
+            duration_ms=elapsed_ms, output=_trim_for_report(combined),
+        )
+    except subprocess.TimeoutExpired as e:
+        elapsed_ms = int((time.time() - start) * 1000)
+        return AcceptanceResult(
+            name=check.name, kind=check.kind, passed=False,
+            duration_ms=elapsed_ms,
+            error=f"timed out after {check.timeout_seconds}s",
+            output=_trim_for_report((e.stdout or "") + (e.stderr or "")),
+        )
+    except (OSError, ValueError) as e:
+        return AcceptanceResult(
+            name=check.name, kind=check.kind, passed=False, duration_ms=0,
+            error=f"subprocess failed: {e}",
+        )
+
+
+def _run_http_check(check: AcceptanceCheck) -> AcceptanceResult:
+    if not check.url:
+        return AcceptanceResult(
+            name=check.name, kind="http", passed=False, duration_ms=0,
+            error="http check missing `url`",
+        )
+    expected_status = check.expected_status if check.expected_status is not None else 200
+
+    start = time.time()
+    try:
+        with httpx.Client(timeout=check.timeout_seconds) as client:
+            resp = client.get(check.url)
+        elapsed_ms = int((time.time() - start) * 1000)
+        body = resp.text
+        status_ok = (resp.status_code == expected_status)
+        body_ok = (
+            check.expected_body_contains is None
+            or check.expected_body_contains in body
+        )
+        passed = status_ok and body_ok
+        report = f"HTTP {resp.status_code}\nbody[:500]: {body[:500]}"
+        if not status_ok:
+            report += f"\n!! expected status {expected_status}"
+        if not body_ok:
+            report += f"\n!! body did not contain {check.expected_body_contains!r}"
+        return AcceptanceResult(
+            name=check.name, kind="http", passed=passed,
+            duration_ms=elapsed_ms, output=report,
+        )
+    except httpx.RequestError as e:
+        elapsed_ms = int((time.time() - start) * 1000)
+        return AcceptanceResult(
+            name=check.name, kind="http", passed=False,
+            duration_ms=elapsed_ms, error=f"request failed: {e}",
+        )
+
+
+# ─── Public entry point ────────────────────────────────────────────
+
+
+def run_acceptance(checks: Iterable[AcceptanceCheck], cwd: Path) -> JudgeRun:
+    """Run every check in order. Always returns a complete JudgeRun, even if
+    individual checks crash — the agent reads `error` per result to triage."""
+    run = JudgeRun()
+    for c in checks:
+        if c.kind in ("unit_test", "script"):
+            run.results.append(_run_subprocess_check(c, cwd))
+        elif c.kind == "http":
+            run.results.append(_run_http_check(c))
+        else:  # pragma: no cover — Pydantic guards the enum, but be loud if it slips
+            run.results.append(AcceptanceResult(
+                name=c.name, kind=c.kind, passed=False, duration_ms=0,
+                error=f"check kind {c.kind!r} not yet supported (browser/figma_diff are v2)",
+            ))
+    return run

--- a/ranch/propose.py
+++ b/ranch/propose.py
@@ -60,13 +60,20 @@ landing on the final proposal. Your FINAL record_state call MUST have:
 - details = a multi-paragraph narrative containing:
     1. **Summary** — what you're going to build, in 2-3 sentences
     2. **Plan** — repeat the ordered steps with rationale per step
-    3. **Acceptance criteria** — structured checks, including:
-       - unit_tests: commands and expected pass patterns
-       - scripts: integration checks (curl/health endpoints/etc.)
-       - browser: if relevant, URLs + visual assertions
-       - figma_diff: if a design link is in the scope, the target frame
+    3. **Acceptance criteria** — human-readable description of what will prove it works
     4. **Complexity** — S/M/L with one-sentence rationale
     5. **Risks / open questions** — anything the operator should know
+- acceptance = STRUCTURED machine-runnable checks (an array). This is the
+  contract used by the `run_acceptance` tool during execute (H8). Each item:
+    - kind = "unit_test" | "script" | "http"
+    - name = short label
+    - For unit_test / script: cmd (shell command) + pass_pattern (substring or
+      regex in stdout that proves pass)
+    - For http: url + expected_status (default 200) + optional expected_body_contains
+  Aim for 2-5 checks. They must be RUNNABLE from the worktree root. Do NOT
+  invent commands; only use what genuinely exists (e.g. pytest if there's a
+  tests/ dir, curl for endpoints the ticket adds, etc.). If a kind isn't
+  applicable, simply omit it — don't pad.
 
 Plain markdown is fine — the operator reads `details` in the Confluence-expand
 view of the dossier.

--- a/ranch/runner/judge_hook.py
+++ b/ranch/runner/judge_hook.py
@@ -1,0 +1,136 @@
+"""H8 — PostToolUse hook that runs the acceptance checks for `run_acceptance`.
+
+The MCP tool body (tools.py) just ticks the budget and returns a placeholder.
+This hook is what actually executes the checks in the worktree, then injects
+the structured results back to the agent as `additionalContext` on the same
+tool result — so the agent's next turn sees the pass/fail breakdown attached
+to its own tool call (same trick as the checkpoint hook).
+"""
+from __future__ import annotations
+
+import json
+from typing import Iterable
+
+from claude_code_sdk import HookMatcher
+from claude_code_sdk.types import HookContext
+from pydantic import ValidationError
+
+from ranch.db import db_session
+from ranch.judge import run_acceptance as _run_acceptance
+from ranch.models import Dossier
+from ranch.runner.messages import AcceptanceCheck
+
+RUN_ACCEPTANCE_TOOL = "mcp__ranch__run_acceptance"
+
+
+def _latest_acceptance_from_dossier(run_id: int | None) -> list[AcceptanceCheck]:
+    """Pull the most-recent acceptance list off this run's dossier history."""
+    if run_id is None:
+        return []
+    with db_session() as db:
+        rows = (
+            db.query(Dossier)
+            .filter_by(run_id=run_id)
+            .order_by(Dossier.created_at.desc())
+            .all()
+        )
+        for row in rows:
+            try:
+                payload = json.loads(row.payload_json)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            acceptance = payload.get("acceptance")
+            if acceptance:
+                try:
+                    return [AcceptanceCheck.model_validate(c) for c in acceptance]
+                except ValidationError:
+                    continue
+    return []
+
+
+def _format_results_for_agent(judge_run, source: str) -> str:
+    """Render the JudgeRun as plain text the agent can read + react to."""
+    if not judge_run.results:
+        return (
+            "ACCEPTANCE RUN — no checks executed.\n"
+            "No `acceptance` list was found in this run's dossier and none were "
+            "passed inline. If you intended to run inline checks, pass them as "
+            "the `checks` argument. If propose was supposed to set acceptance, "
+            "the dossier missed it — record_state with the acceptance field now."
+        )
+
+    header = (
+        f"ACCEPTANCE RUN — source: {source}\n"
+        f"{'PASS' if judge_run.all_passed else 'FAIL'} "
+        f"({len(judge_run.results) - judge_run.num_failed}/{len(judge_run.results)} passed)\n"
+    )
+    lines = [header]
+    for r in judge_run.results:
+        lines.append(r.summary_line())
+        if not r.passed:
+            if r.error:
+                lines.append(f"      error: {r.error}")
+            if r.output:
+                # Indent the output so it's visually clear it belongs to this check
+                indented = "\n".join("      " + ln for ln in r.output.splitlines()[:30])
+                lines.append(indented)
+
+    if judge_run.all_passed:
+        lines.append("\nAll checks passed. You may proceed to pre_push or park.")
+    else:
+        lines.append(
+            "\nOne or more checks failed. Read the output above, fix the underlying "
+            "issue (edit code, restart a server, etc.), and call run_acceptance again "
+            "to re-verify. Don't park until checks pass or your judge budget is exhausted."
+        )
+    return "\n".join(lines)
+
+
+def make_judge_hook(orchestrator) -> HookMatcher:
+    """Return a PostToolUse HookMatcher for run_acceptance."""
+
+    async def on_post_tool_use(
+        input_data: dict,
+        tool_use_id: str | None,
+        context: HookContext,
+    ) -> dict:
+        tool_name = input_data.get("tool_name", "")
+        if tool_name != RUN_ACCEPTANCE_TOOL:
+            return {}
+
+        tool_input = input_data.get("tool_input") or {}
+        inline_checks_raw: Iterable[dict] = tool_input.get("checks") or []
+        cwd_override = tool_input.get("cwd")
+        cwd = orchestrator.cwd if not cwd_override else type(orchestrator.cwd)(cwd_override)
+
+        # Resolve which checks to run
+        checks: list[AcceptanceCheck] = []
+        source: str
+        if inline_checks_raw:
+            try:
+                checks = [AcceptanceCheck.model_validate(c) for c in inline_checks_raw]
+                source = f"inline ({len(checks)} check{'s' if len(checks) != 1 else ''})"
+            except ValidationError as exc:
+                return {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PostToolUse",
+                        "additionalContext": (
+                            f"run_acceptance: inline `checks` failed validation:\n{exc}"
+                        ),
+                    }
+                }
+        else:
+            checks = _latest_acceptance_from_dossier(orchestrator.run_id)
+            source = "dossier (from propose)" if checks else "none-found"
+
+        judge_run = _run_acceptance(checks, cwd)
+        report = _format_results_for_agent(judge_run, source)
+
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": report,
+            }
+        }
+
+    return HookMatcher(matcher=RUN_ACCEPTANCE_TOOL, hooks=[on_post_tool_use])

--- a/ranch/runner/messages.py
+++ b/ranch/runner/messages.py
@@ -61,6 +61,36 @@ class DossierOption(BaseModel):
     description: str
 
 
+AcceptanceKind = Literal["unit_test", "script", "http"]
+
+
+class AcceptanceCheck(BaseModel):
+    """One machine-verifiable acceptance criterion for a ticket.
+
+    Produced by `ranch propose` and consumed by `run_acceptance` (H8). Each
+    check is independently runnable. Browser + figma_diff are deliberately
+    left out of v1 (need playwright + screenshot-diff infra); they layer on
+    later without schema break.
+    """
+
+    kind: AcceptanceKind
+    name: str  # human-readable label, e.g. "smoke test the /healthz endpoint"
+    # Per-kind payload — kept loose; the judge module enforces shape per kind.
+    cmd: Optional[str] = None  # unit_test + script
+    pass_pattern: Optional[str] = None  # unit_test + script: substring or regex that proves pass
+    url: Optional[str] = None  # http
+    expected_status: Optional[int] = None  # http
+    expected_body_contains: Optional[str] = None  # http
+    timeout_seconds: float = 60.0
+
+    @field_validator("name")
+    @classmethod
+    def name_not_empty(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("name must not be empty")
+        return v
+
+
 class RecordStateInput(BaseModel):
     """Payload the agent sends when calling mcp__ranch__record_state.
 
@@ -82,6 +112,7 @@ class RecordStateInput(BaseModel):
     files_touched: list[str] = []
     ticket: Optional[str] = None
     details: Optional[str] = None
+    acceptance: Optional[list[AcceptanceCheck]] = None  # H8 — produced by propose, consumed by run_acceptance
 
     @field_validator("just_did")
     @classmethod

--- a/ranch/runner/orchestrator.py
+++ b/ranch/runner/orchestrator.py
@@ -15,10 +15,11 @@ from ranch.db import db_session
 from ranch.models import Run, Checkpoint, Dossier, Interjection
 from ranch.runner.checkpoints import make_checkpoint_hook, APPROVAL_REQUIRED
 from ranch.runner.dossier import make_dossier_hook
+from ranch.runner.judge_hook import make_judge_hook
 from ranch.runner.messages import HumanDecision, HumanNote, RecordStateInput
 from ranch.runner.prompts import SYSTEM_PROMPT, SYSTEM_PROMPT_FREE, initial_user_prompt
 from ranch.runner.state import transition
-from ranch.runner.tools import ranch_mcp
+from ranch.runner.tools import ranch_mcp, reset_judge_budget
 
 console = Console()
 
@@ -43,7 +44,7 @@ def _detect_branch(cwd: Path) -> str | None:
 DEFAULT_ALLOWED_TOOLS = [
     "Read", "Write", "Edit", "Bash", "Grep", "Glob",
     "mcp__ranch__record_checkpoint", "mcp__ranch__log_decision",
-    "mcp__ranch__record_state",
+    "mcp__ranch__record_state", "mcp__ranch__run_acceptance",
 ]
 
 
@@ -152,6 +153,9 @@ class Orchestrator:
                 run = db.query(Run).filter_by(id=self.run_id).one()
                 run.state = "planning"
 
+        # H8: every new run starts with a fresh judge budget
+        reset_judge_budget()
+
         console.print(f"[bold cyan]Ranch run #{self.run_id} — {self.agent} / {self.ticket or 'ad-hoc'}[/bold cyan]")
         console.print("[dim]Commands: !note <text>  !approve  !reject <reason>  !stop[/dim]")
         console.print()
@@ -172,7 +176,7 @@ class Orchestrator:
             append_system_prompt=effective_append,
             mcp_servers={"ranch": ranch_mcp},
             allowed_tools=effective_tools,
-            hooks={"PostToolUse": [make_checkpoint_hook(self), make_dossier_hook(self)]},
+            hooks={"PostToolUse": [make_checkpoint_hook(self), make_dossier_hook(self), make_judge_hook(self)]},
             permission_mode="acceptEdits",
         )
 
@@ -462,7 +466,7 @@ async def resume_run(run_id: int) -> None:
             "Read", "Write", "Edit", "Bash", "Grep", "Glob",
             "mcp__ranch__record_checkpoint", "mcp__ranch__log_decision",
         ],
-        hooks={"PostToolUse": [make_checkpoint_hook(orch), make_dossier_hook(orch)]},
+        hooks={"PostToolUse": [make_checkpoint_hook(orch), make_dossier_hook(orch), make_judge_hook(orch)]},
         permission_mode="acceptEdits",
         resume=sdk_session_id,
     )

--- a/ranch/runner/prompts.py
+++ b/ranch/runner/prompts.py
@@ -73,6 +73,30 @@ Don't update on every tool use — once per meaningful phase transition is
 the right cadence. Aim for at least one `record_state` call for every 5-10
 other tool calls.
 
+## Verifying your work with `run_acceptance`
+
+When the ticket has `acceptance` checks in its dossier (set during `ranch
+propose`), use the `run_acceptance` tool to verify your changes objectively
+before parking at pre_push. The tool runs every check and reports pass/fail
+per check, with stdout/stderr on failures.
+
+Flow:
+1. After you've made your changes and unit tests are green, call `run_acceptance`
+   (no arguments — it reads the dossier's acceptance list automatically).
+2. Read the results. Every `✓` is a real pass; every `✗` shows you what failed.
+3. If anything failed: fix the underlying issue (edit code, restart a server,
+   adjust config), then call `run_acceptance` again. Iterate until all pass.
+4. Do NOT call `record_checkpoint(kind="pre_push")` until acceptance is green —
+   the human relies on your acceptance results to trust the push.
+
+Budget: limited calls per session (default 8). Don't burn calls speculatively.
+If you exhaust the budget without passing, park at state=`parked` with
+blocker=`stuck_judge_budget_exhausted` so the operator can intervene.
+
+You may also pass inline `checks` to `run_acceptance` to verify ad-hoc things
+during development — but the canonical run after code-complete should be
+argument-free so it uses the propose-defined contract.
+
 ## Rules
 
 - Never push, open a PR, or create a branch without a `pre_push` approval.
@@ -138,6 +162,14 @@ encountered, conclusion. This is what the operator reads when they
 expand this stage in the UI. Skip `details` for routine transitions.
 
 Aim for at least one `record_state` call for every 5-10 other tool calls.
+
+## Verifying your work with `run_acceptance`
+
+If the run's dossier carries `acceptance` checks (from `ranch propose`), call
+`run_acceptance` after making changes to verify them objectively. The tool
+runs every check and reports pass/fail with stdout/stderr on failures. On
+failure, fix and re-call; iterate until green. Budget: limited calls per
+session — don't burn them speculatively.
 
 ## Other rules
 

--- a/ranch/runner/tools.py
+++ b/ranch/runner/tools.py
@@ -1,4 +1,6 @@
 """In-process MCP tools exposed to the agent during a run."""
+from pathlib import Path
+
 from claude_code_sdk import tool, create_sdk_mcp_server
 
 CHECKPOINT_INPUT_SCHEMA = {
@@ -98,6 +100,41 @@ STATE_INPUT_SCHEMA = {
                 "non-trivial; omit for routine transitions."
             ),
         },
+        "acceptance": {
+            "type": "array",
+            "description": (
+                "Machine-verifiable acceptance criteria for the ticket. Set during "
+                "`ranch propose` (H6); consumed by the `run_acceptance` tool during "
+                "execute (H8). Each check is independently runnable. Browser + "
+                "figma diff are NOT yet supported — use unit_test / script / http."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "enum": ["unit_test", "script", "http"],
+                    },
+                    "name": {"type": "string"},
+                    "cmd": {
+                        "type": "string",
+                        "description": "Shell command for unit_test / script kinds.",
+                    },
+                    "pass_pattern": {
+                        "type": "string",
+                        "description": "Substring or regex in stdout that proves pass. Required for unit_test / script.",
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "HTTP endpoint to probe (http kind).",
+                    },
+                    "expected_status": {"type": "integer"},
+                    "expected_body_contains": {"type": "string"},
+                    "timeout_seconds": {"type": "number", "default": 60},
+                },
+                "required": ["kind", "name"],
+            },
+        },
     },
     "required": ["plan", "just_did", "state"],
 }
@@ -126,8 +163,104 @@ async def record_state(args: dict) -> dict:
     return {"content": [{"type": "text", "text": "Dossier updated."}]}
 
 
+# ─── H8: run_acceptance ────────────────────────────────────────────
+
+
+# Per-process budget guard — refuses past this many calls within a single
+# orchestrator session. Prevents the "agent stuck in an iterate-until-pass
+# loop" failure mode. Reset by `reset_judge_budget()` at session start.
+DEFAULT_JUDGE_BUDGET = 8
+_judge_call_count = 0
+
+
+def reset_judge_budget() -> None:
+    """Called by the orchestrator at the start of each run."""
+    global _judge_call_count
+    _judge_call_count = 0
+
+
+def _judge_budget_remaining() -> int:
+    return DEFAULT_JUDGE_BUDGET - _judge_call_count
+
+
+RUN_ACCEPTANCE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "checks": {
+            "type": "array",
+            "description": (
+                "Inline acceptance checks to run. If omitted, the tool reads "
+                "the latest record_state's `acceptance` field (set during "
+                "ranch propose). Provide inline only when you want to verify "
+                "an ad-hoc check during development."
+            ),
+            "items": {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string", "enum": ["unit_test", "script", "http"]},
+                    "name": {"type": "string"},
+                    "cmd": {"type": "string"},
+                    "pass_pattern": {"type": "string"},
+                    "url": {"type": "string"},
+                    "expected_status": {"type": "integer"},
+                    "expected_body_contains": {"type": "string"},
+                    "timeout_seconds": {"type": "number"},
+                },
+                "required": ["kind", "name"],
+            },
+        },
+        "cwd": {
+            "type": "string",
+            "description": "Override the working directory. Defaults to the run's worktree.",
+        },
+    },
+}
+
+
+@tool(
+    "run_acceptance",
+    (
+        "Run the ticket's acceptance checks (unit tests, scripts, HTTP probes) "
+        "and report pass/fail per check. Use this after you've made changes to "
+        "verify your work objectively before parking at pre_push. If a check "
+        "fails, the result includes its stdout/stderr — read it, fix the issue, "
+        "and call run_acceptance again. Budget: limited calls per session, so "
+        "don't burn calls on speculative runs."
+    ),
+    RUN_ACCEPTANCE_SCHEMA,
+)
+async def run_acceptance(args: dict) -> dict:
+    """Run the acceptance checks. The orchestrator's PostToolUse hook
+    actually executes them (it has access to the run's cwd + dossier);
+    the body here just records the budget tick and returns a placeholder
+    that the hook replaces via additionalContext."""
+    global _judge_call_count
+    _judge_call_count += 1
+    remaining = _judge_budget_remaining()
+    if remaining < 0:
+        return {
+            "content": [{
+                "type": "text",
+                "text": (
+                    "JUDGE BUDGET EXHAUSTED. You've called run_acceptance too "
+                    "many times this session. Park at state=parked with "
+                    "blocker='stuck_judge_budget_exhausted' and let the operator "
+                    "review."
+                ),
+            }],
+        }
+    # The hook injects the real results as additionalContext; this echo is
+    # a sentinel the agent will see if the hook didn't fire (e.g., misconfig).
+    return {
+        "content": [{
+            "type": "text",
+            "text": f"(run_acceptance pending hook execution — call {_judge_call_count}/{DEFAULT_JUDGE_BUDGET})",
+        }],
+    }
+
+
 ranch_mcp = create_sdk_mcp_server(
     name="ranch",
     version="0.1.0",
-    tools=[record_checkpoint, log_decision, record_state],
+    tools=[record_checkpoint, log_decision, record_state, run_acceptance],
 )

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,0 +1,242 @@
+"""Tests for the H8 self-judge runner.
+
+Subprocess checks are exercised with real `bash -c` invocations — they're
+hermetic enough and prove the actual subprocess path. HTTP checks use
+httpx.MockTransport so we don't hit the network.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from ranch.judge import (
+    AcceptanceResult,
+    JudgeRun,
+    _matches,
+    _trim_for_report,
+    run_acceptance,
+)
+from ranch.runner.messages import AcceptanceCheck
+
+
+# ─── _matches ─────────────────────────────────────────────────────
+
+
+def test_matches_substring():
+    assert _matches("passed", "1 test passed") is True
+    assert _matches("failed", "1 test passed") is False
+
+
+def test_matches_regex():
+    assert _matches(r"\d+ passed", "5 passed") is True
+    assert _matches(r"\d+ passed", "all good") is False
+
+
+def test_matches_invalid_regex_falls_back_to_substring():
+    """A bare '*' isn't a valid regex — should be treated as substring."""
+    assert _matches("*", "before * after") is True
+
+
+def test_matches_empty_pattern_is_pass():
+    """No pattern = no constraint."""
+    assert _matches("", "anything") is True
+
+
+# ─── _trim_for_report ─────────────────────────────────────────────
+
+
+def test_trim_keeps_tail():
+    body = "a" * 5000
+    trimmed = _trim_for_report(body, limit=100)
+    assert "[truncated 4900 chars]" in trimmed
+    assert trimmed.endswith("a" * 100)
+
+
+def test_trim_passes_short_unchanged():
+    assert _trim_for_report("short") == "short"
+
+
+# ─── subprocess checks ────────────────────────────────────────────
+
+
+def test_unit_test_passes_when_cmd_zero_and_pattern_matches(tmp_path):
+    check = AcceptanceCheck(
+        kind="unit_test", name="echo-pass",
+        cmd="echo '3 passed'", pass_pattern=r"\d+ passed",
+    )
+    run = run_acceptance([check], tmp_path)
+    assert run.all_passed
+    assert run.num_failed == 0
+    assert run.results[0].duration_ms >= 0
+
+
+def test_unit_test_fails_when_pattern_missing(tmp_path):
+    check = AcceptanceCheck(
+        kind="unit_test", name="echo-fail",
+        cmd="echo 'nothing here'", pass_pattern="passed",
+    )
+    run = run_acceptance([check], tmp_path)
+    assert not run.all_passed
+    assert run.num_failed == 1
+    assert "nothing here" in run.results[0].output
+
+
+def test_unit_test_fails_on_nonzero_exit(tmp_path):
+    """Pattern present but exit code nonzero → still a fail."""
+    check = AcceptanceCheck(
+        kind="unit_test", name="false-with-pattern",
+        cmd="echo passed && exit 1", pass_pattern="passed",
+    )
+    run = run_acceptance([check], tmp_path)
+    assert run.results[0].passed is False
+
+
+def test_unit_test_missing_cmd_reports_error(tmp_path):
+    check = AcceptanceCheck(kind="unit_test", name="bad", pass_pattern="x")
+    run = run_acceptance([check], tmp_path)
+    assert run.results[0].passed is False
+    assert "missing `cmd`" in run.results[0].error
+
+
+def test_unit_test_missing_pattern_reports_error(tmp_path):
+    check = AcceptanceCheck(kind="unit_test", name="bad", cmd="echo x")
+    run = run_acceptance([check], tmp_path)
+    assert run.results[0].passed is False
+    assert "missing `pass_pattern`" in run.results[0].error
+
+
+def test_unit_test_timeout_reports_clean_failure(tmp_path):
+    check = AcceptanceCheck(
+        kind="unit_test", name="hang",
+        cmd="sleep 5", pass_pattern="never",
+        timeout_seconds=0.2,
+    )
+    run = run_acceptance([check], tmp_path)
+    assert run.results[0].passed is False
+    assert "timed out" in run.results[0].error
+
+
+def test_script_kind_uses_same_runner_as_unit_test(tmp_path):
+    """Semantic alias for the operator — agent picks `script` for integration
+    checks vs `unit_test` for actual test invocations."""
+    check = AcceptanceCheck(
+        kind="script", name="smoke",
+        cmd="echo READY", pass_pattern="READY",
+    )
+    run = run_acceptance([check], tmp_path)
+    assert run.all_passed
+
+
+def test_runs_in_cwd(tmp_path):
+    (tmp_path / "marker.txt").write_text("present")
+    check = AcceptanceCheck(
+        kind="script", name="cwd-check",
+        cmd="ls marker.txt", pass_pattern="marker.txt",
+    )
+    run = run_acceptance([check], tmp_path)
+    assert run.all_passed
+
+
+# ─── http checks (mock transport) ─────────────────────────────────
+
+
+def _client_with_responder(responder, monkeypatch):
+    """Patch httpx.Client to use a MockTransport that calls `responder`."""
+    real_client = httpx.Client
+
+    def factory(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(responder)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr("ranch.judge.httpx.Client", factory)
+
+
+def test_http_pass_on_status_and_body(tmp_path, monkeypatch):
+    def responder(request):
+        assert request.url.path == "/healthz"
+        return httpx.Response(200, text='{"status":"ok"}')
+    _client_with_responder(responder, monkeypatch)
+
+    check = AcceptanceCheck(
+        kind="http", name="healthz",
+        url="http://example/healthz",
+        expected_status=200, expected_body_contains='"status":"ok"',
+    )
+    run = run_acceptance([check], tmp_path)
+    assert run.all_passed
+
+
+def test_http_fails_on_unexpected_status(tmp_path, monkeypatch):
+    def responder(_req):
+        return httpx.Response(500, text="boom")
+    _client_with_responder(responder, monkeypatch)
+
+    check = AcceptanceCheck(
+        kind="http", name="healthz",
+        url="http://example/healthz", expected_status=200,
+    )
+    run = run_acceptance([check], tmp_path)
+    assert run.results[0].passed is False
+    assert "expected status 200" in run.results[0].output
+
+
+def test_http_fails_on_body_not_containing_substring(tmp_path, monkeypatch):
+    def responder(_req):
+        return httpx.Response(200, text="hello world")
+    _client_with_responder(responder, monkeypatch)
+
+    check = AcceptanceCheck(
+        kind="http", name="x",
+        url="http://example/x", expected_body_contains="goodbye",
+    )
+    run = run_acceptance([check], tmp_path)
+    assert run.results[0].passed is False
+    assert "goodbye" in run.results[0].output
+
+
+def test_http_default_expected_status_is_200(tmp_path, monkeypatch):
+    """If expected_status is omitted, 200 is the assumed contract."""
+    def responder(_req):
+        return httpx.Response(200, text="ok")
+    _client_with_responder(responder, monkeypatch)
+
+    check = AcceptanceCheck(kind="http", name="x", url="http://example/x")
+    run = run_acceptance([check], tmp_path)
+    assert run.all_passed
+
+
+def test_http_missing_url_reports_error(tmp_path):
+    check = AcceptanceCheck(kind="http", name="no-url")
+    run = run_acceptance([check], tmp_path)
+    assert run.results[0].passed is False
+    assert "missing `url`" in run.results[0].error
+
+
+# ─── JudgeRun aggregation ─────────────────────────────────────────
+
+
+def test_judge_run_all_passed_requires_at_least_one_check():
+    """An empty run shouldn't report all_passed — caller should treat empty
+    as a misconfiguration, not as success."""
+    assert JudgeRun().all_passed is False
+
+
+def test_judge_run_to_dict_truncates_long_output():
+    r = AcceptanceResult(name="x", kind="script", passed=True,
+                          duration_ms=1, output="z" * 5000)
+    d = JudgeRun(results=[r]).to_dict()
+    assert len(d["results"][0]["output"]) <= 2000
+
+
+def test_judge_run_mixed_results_reports_num_failed(tmp_path):
+    checks = [
+        AcceptanceCheck(kind="script", name="a", cmd="echo ok", pass_pattern="ok"),
+        AcceptanceCheck(kind="script", name="b", cmd="echo nope", pass_pattern="missing"),
+        AcceptanceCheck(kind="script", name="c", cmd="echo also-ok", pass_pattern="also"),
+    ]
+    run = run_acceptance(checks, tmp_path)
+    assert run.all_passed is False
+    assert run.num_failed == 1
+    assert [r.passed for r in run.results] == [True, False, True]

--- a/tests/test_judge_hook.py
+++ b/tests/test_judge_hook.py
@@ -1,0 +1,254 @@
+"""Tests for the H8 PostToolUse hook + budget tracker.
+
+The hook intercepts mcp__ranch__run_acceptance, resolves the checks (inline
+or from the dossier), runs them, and returns formatted results as
+additionalContext. We mock _run_acceptance so these tests don't exec real
+subprocesses (the runner itself is tested in test_judge.py).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ranch.db import db_session, init_db
+from ranch.judge import AcceptanceResult, JudgeRun
+from ranch.models import Dossier, Run
+from ranch.runner.judge_hook import (
+    RUN_ACCEPTANCE_TOOL,
+    _format_results_for_agent,
+    _latest_acceptance_from_dossier,
+    make_judge_hook,
+)
+from ranch.runner.tools import (
+    DEFAULT_JUDGE_BUDGET,
+    _judge_budget_remaining,
+    reset_judge_budget,
+)
+
+
+# ─── Budget tracking ─────────────────────────────────────────────
+
+
+def test_reset_judge_budget_starts_fresh():
+    reset_judge_budget()
+    assert _judge_budget_remaining() == DEFAULT_JUDGE_BUDGET
+
+
+def test_reset_judge_budget_clears_counter_after_calls():
+    """Budget state is module-level. Increment via the same path the tool does."""
+    import ranch.runner.tools as _tools
+    reset_judge_budget()
+    _tools._judge_call_count = 3
+    assert _judge_budget_remaining() == DEFAULT_JUDGE_BUDGET - 3
+    reset_judge_budget()
+    assert _judge_budget_remaining() == DEFAULT_JUDGE_BUDGET
+
+
+def test_budget_remaining_goes_negative_after_overrun():
+    """The tool body uses `remaining < 0` as the exhausted signal."""
+    import ranch.runner.tools as _tools
+    reset_judge_budget()
+    _tools._judge_call_count = DEFAULT_JUDGE_BUDGET + 1
+    assert _judge_budget_remaining() < 0
+    reset_judge_budget()
+
+
+# ─── _latest_acceptance_from_dossier ────────────────────────────
+
+
+def _seed_dossier(run_id, payload):
+    with db_session() as db:
+        db.add(Dossier(run_id=run_id, state=payload.get("state", "planning"),
+                        payload_json=json.dumps(payload)))
+
+
+def test_latest_acceptance_returns_empty_when_no_run_id():
+    assert _latest_acceptance_from_dossier(None) == []
+
+
+def test_latest_acceptance_returns_empty_when_no_dossier():
+    init_db()
+    with db_session() as db:
+        run = Run(agent="x", ticket="T-1", cwd="/tmp", initial_prompt="x", state="planning")
+        db.add(run); db.flush()
+        rid = run.id
+    assert _latest_acceptance_from_dossier(rid) == []
+
+
+def test_latest_acceptance_skips_dossiers_without_acceptance():
+    init_db()
+    with db_session() as db:
+        run = Run(agent="x", ticket="T-1", cwd="/tmp", initial_prompt="x", state="planning")
+        db.add(run); db.flush()
+        rid = run.id
+    _seed_dossier(rid, {"plan": [], "just_did": "x", "state": "coding"})
+    assert _latest_acceptance_from_dossier(rid) == []
+
+
+def test_latest_acceptance_returns_validated_checks():
+    init_db()
+    with db_session() as db:
+        run = Run(agent="x", ticket="T-1", cwd="/tmp", initial_prompt="x", state="planning")
+        db.add(run); db.flush()
+        rid = run.id
+    _seed_dossier(rid, {
+        "plan": [], "just_did": "x", "state": "parked",
+        "acceptance": [
+            {"kind": "unit_test", "name": "pytest", "cmd": "pytest", "pass_pattern": "passed"},
+        ],
+    })
+    checks = _latest_acceptance_from_dossier(rid)
+    assert len(checks) == 1
+    assert checks[0].kind == "unit_test"
+    assert checks[0].cmd == "pytest"
+
+
+def test_latest_acceptance_prefers_most_recent():
+    """Walks dossier rows newest first; returns the first non-empty list."""
+    import time
+    init_db()
+    with db_session() as db:
+        run = Run(agent="x", ticket="T-1", cwd="/tmp", initial_prompt="x", state="planning")
+        db.add(run); db.flush()
+        rid = run.id
+    # Older row with one check
+    _seed_dossier(rid, {
+        "plan": [], "just_did": "old", "state": "planning",
+        "acceptance": [{"kind": "script", "name": "old", "cmd": "true", "pass_pattern": "."}],
+    })
+    time.sleep(0.01)
+    # Newer row with two checks — this is what should be returned
+    _seed_dossier(rid, {
+        "plan": [], "just_did": "new", "state": "parked",
+        "acceptance": [
+            {"kind": "unit_test", "name": "a", "cmd": "echo a", "pass_pattern": "a"},
+            {"kind": "unit_test", "name": "b", "cmd": "echo b", "pass_pattern": "b"},
+        ],
+    })
+    checks = _latest_acceptance_from_dossier(rid)
+    assert [c.name for c in checks] == ["a", "b"]
+
+
+# ─── _format_results_for_agent ──────────────────────────────────
+
+
+def test_format_empty_run_explains_misconfig():
+    text = _format_results_for_agent(JudgeRun(), source="dossier (from propose)")
+    assert "no checks executed" in text.lower()
+
+
+def test_format_all_pass_says_proceed():
+    run = JudgeRun(results=[
+        AcceptanceResult(name="a", kind="unit_test", passed=True, duration_ms=10),
+        AcceptanceResult(name="b", kind="http", passed=True, duration_ms=20),
+    ])
+    text = _format_results_for_agent(run, source="dossier (from propose)")
+    assert "PASS" in text
+    assert "2/2 passed" in text
+    assert "proceed" in text.lower() or "pre_push" in text
+
+
+def test_format_failure_includes_output_and_next_steps():
+    run = JudgeRun(results=[
+        AcceptanceResult(name="pytest", kind="unit_test", passed=False,
+                         duration_ms=100, output="FAILED: assertion error"),
+    ])
+    text = _format_results_for_agent(run, source="dossier (from propose)")
+    assert "FAIL" in text
+    assert "FAILED: assertion error" in text
+    assert "fix" in text.lower()
+    assert "run_acceptance again" in text
+
+
+# ─── Hook integration ───────────────────────────────────────────
+
+
+def _make_orch(run_id):
+    orch = MagicMock()
+    orch.cwd = Path("/tmp")
+    orch.run_id = run_id
+    return orch
+
+
+@pytest.mark.asyncio
+async def test_hook_ignores_other_tools():
+    hook_fn = make_judge_hook(_make_orch(None)).hooks[0]
+    res = await hook_fn({"tool_name": "Bash", "tool_input": {}}, "tid", MagicMock())
+    assert res == {}
+
+
+@pytest.mark.asyncio
+async def test_hook_runs_inline_checks_and_returns_report():
+    """Inline checks bypass dossier lookup; results land in additionalContext."""
+    init_db()
+    orch = _make_orch(None)
+
+    fake_run = JudgeRun(results=[
+        AcceptanceResult(name="echo", kind="script", passed=True, duration_ms=5),
+    ])
+    with patch("ranch.runner.judge_hook._run_acceptance", return_value=fake_run):
+        hook_fn = make_judge_hook(orch).hooks[0]
+        res = await hook_fn(
+            {
+                "tool_name": RUN_ACCEPTANCE_TOOL,
+                "tool_input": {"checks": [
+                    {"kind": "script", "name": "echo", "cmd": "echo x", "pass_pattern": "x"},
+                ]},
+            },
+            "tid", MagicMock(),
+        )
+    ctx = res["hookSpecificOutput"]["additionalContext"]
+    assert "inline (1 check)" in ctx
+    assert "PASS" in ctx
+
+
+@pytest.mark.asyncio
+async def test_hook_falls_back_to_dossier_when_no_inline_checks():
+    init_db()
+    with db_session() as db:
+        run = Run(agent="x", ticket="T-1", cwd="/tmp", initial_prompt="x", state="planning")
+        db.add(run); db.flush()
+        rid = run.id
+    _seed_dossier(rid, {
+        "plan": [], "just_did": "x", "state": "parked",
+        "acceptance": [
+            {"kind": "unit_test", "name": "p", "cmd": "echo passed", "pass_pattern": "passed"},
+        ],
+    })
+
+    orch = _make_orch(rid)
+    fake_run = JudgeRun(results=[
+        AcceptanceResult(name="p", kind="unit_test", passed=True, duration_ms=5),
+    ])
+    captured = {}
+    def fake_runner(checks, cwd):
+        captured["count"] = len(list(checks))
+        captured["cwd"] = cwd
+        return fake_run
+    with patch("ranch.runner.judge_hook._run_acceptance", side_effect=fake_runner):
+        hook_fn = make_judge_hook(orch).hooks[0]
+        res = await hook_fn(
+            {"tool_name": RUN_ACCEPTANCE_TOOL, "tool_input": {}},
+            "tid", MagicMock(),
+        )
+
+    assert captured["count"] == 1
+    assert "dossier" in res["hookSpecificOutput"]["additionalContext"]
+
+
+@pytest.mark.asyncio
+async def test_hook_validates_inline_checks_and_surfaces_errors():
+    orch = _make_orch(None)
+    hook_fn = make_judge_hook(orch).hooks[0]
+    res = await hook_fn(
+        {
+            "tool_name": RUN_ACCEPTANCE_TOOL,
+            "tool_input": {"checks": [{"kind": "nonsense", "name": "x"}]},
+        },
+        "tid", MagicMock(),
+    )
+    ctx = res["hookSpecificOutput"]["additionalContext"]
+    assert "validation" in ctx.lower()

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -3,6 +3,7 @@ import pytest
 from pydantic import ValidationError
 
 from ranch.runner.messages import (
+    AcceptanceCheck,
     CheckpointInput,
     DecisionLogInput,
     DossierOption,
@@ -228,6 +229,46 @@ def test_record_state_details_optional():
     """`details` is the long-form expand content — omitted for routine steps."""
     payload = RecordStateInput.model_validate(_minimal_state())
     assert payload.details is None
+
+
+def test_acceptance_check_unit_test_minimal():
+    c = AcceptanceCheck(kind="unit_test", name="pytest", cmd="pytest tests/", pass_pattern="passed")
+    assert c.kind == "unit_test"
+    assert c.timeout_seconds == 60.0  # default applied
+
+
+def test_acceptance_check_http_minimal():
+    c = AcceptanceCheck(kind="http", name="healthz", url="http://localhost:8000/healthz", expected_status=200)
+    assert c.url == "http://localhost:8000/healthz"
+
+
+def test_acceptance_check_rejects_bad_kind():
+    with pytest.raises(ValidationError):
+        AcceptanceCheck(kind="nonsense", name="x")  # type: ignore[arg-type]
+
+
+def test_acceptance_check_rejects_empty_name():
+    with pytest.raises(ValidationError, match="name must not be empty"):
+        AcceptanceCheck(kind="script", name="   ", cmd="echo hi", pass_pattern="hi")
+
+
+def test_record_state_accepts_acceptance_list():
+    payload = RecordStateInput.model_validate({
+        **_minimal_state(state="parked"),
+        "blocker": "Awaiting plan approval",
+        "acceptance": [
+            {"kind": "unit_test", "name": "pytest", "cmd": "pytest", "pass_pattern": "passed"},
+            {"kind": "http", "name": "healthz", "url": "http://localhost:8000/healthz", "expected_status": 200},
+        ],
+    })
+    assert len(payload.acceptance) == 2
+    assert payload.acceptance[0].kind == "unit_test"
+    assert payload.acceptance[1].url.endswith("/healthz")
+
+
+def test_record_state_acceptance_optional():
+    payload = RecordStateInput.model_validate(_minimal_state())
+    assert payload.acceptance is None
 
 
 def test_record_state_details_accepts_multiline():

--- a/tests/test_propose.py
+++ b/tests/test_propose.py
@@ -96,10 +96,17 @@ def test_propose_system_prompt_requires_parked_final_state():
 
 
 def test_propose_system_prompt_specifies_acceptance_schema():
+    """The propose prompt must teach the agent the v1 acceptance check kinds.
+
+    Browser + figma_diff are v2 (H8 ships unit_test/script/http only); the
+    prompt deliberately doesn't mention them so the agent doesn't emit
+    checks the judge can't run.
+    """
     p = PROPOSE_SYSTEM_PROMPT
-    # Must mention each acceptance check kind
-    for kind in ("unit_tests", "scripts", "browser", "figma_diff"):
+    for kind in ("unit_test", "script", "http"):
         assert kind in p, f"acceptance kind '{kind}' missing from system prompt"
+    # Must mention the contract is consumed by run_acceptance
+    assert "run_acceptance" in p
 
 
 def test_propose_system_prompt_requires_details_field():


### PR DESCRIPTION
## Summary

Closes the autonomy gap between code-complete and pre_push: the agent verifies its own work by calling `run_acceptance`, reads structured pass/fail per check, and iterates until green (or until its budget is exhausted). The keystone for letting a ranch hand drive execution unattended.

Stacked on #91 (H11 MVP).

## Architecture decision — agent-driven, not state machine

Mirrors how a real engineer thinks ("let me run the tests"). The MCP tool body increments a per-session budget counter. A PostToolUse hook intercepts the call, resolves checks (inline OR from the latest dossier's `acceptance` field), runs them, and returns formatted pass/fail as `additionalContext` on the same tool result — same trick as the checkpoint hook. The agent's next turn sees the results attached to its own call and reacts.

**Why this over an orchestrator-side state machine:**
- Reusable mid-development, not only at end-of-task
- Simpler — no new run states, no synchronous gate
- Agent-native ergonomics: it decides when to verify, like a real engineer

## Schema iteration

Dossier gains an `acceptance: list[AcceptanceCheck]` field (purely additive). `ranch propose` now emits machine-runnable checks alongside the human-readable AC section in `details`. **The propose → execute handoff is now a structured contract**, not freeform markdown — unlocks responsible automation of the execute step.

v1 check kinds: `unit_test`, `script`, `http`. Browser + figma_diff are reserved; the prompt deliberately omits them so the agent doesn't emit checks the judge can't run.

## Tier-2 validation ✓

Real agent, fake ticket engineered to force iterate-until-pass:

| Check | Result |
|---|---|
| Agent called `run_acceptance` to read the contract pre-flight | ✓ |
| Agent called `run_acceptance` post-Write to verify | ✓ |
| All 3 acceptance checks went green | ✓ (file exists; line 1 = "hello"; line 2 = "world") |
| Independent re-run of same checks | ✓ PASS |
| Dossiers emitted | 3 (planning → coding → parked) |
| Budget consumed | 2 of 8 |
| End-to-end duration | 25s |

Bonus observation: the agent figured out the contract by reading the tool's pass/fail output, not by me explaining the contract in the brief. Propose → execute really is a self-contained structured handoff now.

## What you can build with this

After this lands, the ranch hand can responsibly run unattended past the propose step: hand fires `ranch run` → agent codes → agent calls `run_acceptance` → on green → parks at pre_push for human approval. The hand → execute wiring lands when H10 (PR draft) closes the loop the rest of the way; this PR is the precondition that makes that wiring safe.

## Test plan

- [x] 22 new tests in `test_judge.py` — `_matches` regex/substring, trim, per-kind runners (pass/fail/timeout/missing-fields/cwd), http with mocked transport, JudgeRun aggregation
- [x] 15 new tests in `test_judge_hook.py` — budget tracking, dossier lookup precedence (latest-wins), formatting (empty/pass/fail variants), full hook flow (ignore-non-target, inline checks, dossier fallback, validation errors)
- [x] 5 new tests in `test_messages.py` — `AcceptanceCheck` validation + `acceptance` on `RecordStateInput`
- [x] `test_propose.py` updated for v1 kinds + `run_acceptance` reference
- [x] **Full suite: 281 passed**
- [x] **Tier-2 real-agent validation** (see above)

## Notes for review

- `_matches` accepts both regex and substring — agents naturally write `"passed"` (substring) and `r"\d+ passed"` (regex). Tolerate both without forcing escaping.
- `_run_subprocess_check` uses `shell=True` so agents can pipe (`pytest | tee log.txt`); cwd is the run's worktree (overridable via `cwd` tool arg).
- Output is trimmed to 3000 chars in the hook reply (keeps the tail — failures live there) and 2000 chars in `JudgeRun.to_dict()` (for downstream JSON serialization).
- Budget is per-process module-level state; reset by orchestrator at run start. Multi-orchestrator-per-process is not yet supported (would need per-run budget tracking). Acceptable for v1 since the hand runs orchestrators sequentially.

Closes #78 (v1 scope; browser + figma_diff are a v2 enhancement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)