### PR TITLE
H10: ranch pr draft / open — structured PR from accumulated run data (#80)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -390,7 +390,7 @@ The "polling now, webhooks later" call: each agent's pilot daemon polls every ~3
 - H7 (#77) — `ranch design <ticket>` — figma frame discovery
 - H8 (#78) — Self-judge integration loop [v1 in flight: unit_test/script/http]
 - H9 (#79) — Ethan-labs deploy handoff
-- H10 (#80) — PR draft with testing instructions + labs link + Qase MCP
+- H10 (#80) — PR draft with testing instructions + labs link + Qase MCP [in flight: draft + open, no Qase yet]
 - H11 (#81) — Agent scheduler — proactive multi-ticket loop
 
 ### Open design questions

--- a/USAGE.md
+++ b/USAGE.md
@@ -97,6 +97,37 @@ ranch runs --agent max      # filter by agent
 ranch resume 3              # resume run #3 by SDK session ID
 ```
 
+## PR draft + open (Phase H10)
+
+After a run finishes (whether human-driven or hand-driven), turn the
+accumulated dossier + diff + acceptance into a real PR with a structured
+body. No remote calls needed for the preview path.
+
+```bash
+ranch pr draft <run_id>                  # render the PR title + body to stdout
+ranch pr draft <run_id> --out /tmp/x.md  # write to a file instead
+ranch pr draft <run_id> --figma https://figma.com/file/X --jira-base https://citemed.atlassian.net
+                                         # decorate with Jira + design links
+
+ranch pr open <run_id>                   # actually fire `bb pr create --draft` (or gh)
+ranch pr open <run_id> --ready           # not a draft — ready for review immediately
+ranch pr open <run_id> --base-branch develop
+ranch pr open <run_id> --yes             # skip the confirmation prompt
+```
+
+The body is assembled from:
+- Dossier `details` — Summary, Manual verification (from "Acceptance
+  criteria" prose), Risks / open questions
+- Dossier `plan` — checklist of steps with done/in_progress/pending marks
+- Dossier `acceptance` — machine-runnable check list (the H8 contract)
+- `git diff --stat origin/develop...HEAD` (falls back to develop / main)
+  — authoritative Changes section
+- `Run.branch_name` + `Run.agent` — footer attribution
+- Optional Jira + Figma URLs you pass at draft time
+
+Platform backend (`bb` vs `gh`) is auto-detected from the worktree;
+override with `--platform`.
+
 ## Self-judge integration loop (Phase H8)
 
 During an execute run, the agent verifies its own work via `run_acceptance` —

--- a/ranch/cli.py
+++ b/ranch/cli.py
@@ -613,6 +613,99 @@ def dossier_cmd(run_id, as_json, watch, interval):
             pass
 
 
+@cli.group("pr")
+def pr_group():
+    """PR draft + open (Phase H10)."""
+
+
+@pr_group.command("draft")
+@click.argument("run_id", type=int)
+@click.option("--figma", default=None, help="Optional figma URL to link.")
+@click.option("--jira-base", default=None, help="Jira base URL for linking the ticket (e.g. https://yourorg.atlassian.net).")
+@click.option("--out", default=None, type=click.Path(), help="Write the body to a file instead of stdout.")
+def pr_draft_cmd(run_id, figma, jira_base, out):
+    """Render a PR title + body for a completed run, no remote calls."""
+    from .pr_draft import render_draft
+
+    try:
+        draft, _ = render_draft(run_id, figma_url=figma, jira_base_url=jira_base)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise click.Abort()
+
+    if out:
+        from pathlib import Path as _Path
+        _Path(out).write_text(f"# {draft.title}\n\n{draft.body}")
+        console.print(f"[dim]Wrote draft → {out}[/dim]")
+        return
+
+    console.print(f"[bold cyan]Title:[/bold cyan] {draft.title}\n")
+    # Body is markdown — emit with click.echo so Rich doesn't mangle [x] / [kind] tags
+    click.echo(draft.body)
+
+
+@pr_group.command("open")
+@click.argument("run_id", type=int)
+@click.option("--figma", default=None, help="Optional figma URL to link.")
+@click.option("--jira-base", default=None, help="Jira base URL for linking the ticket.")
+@click.option("--ready", is_flag=True, help="Open as ready-for-review instead of draft.")
+@click.option("--base-branch", default=None, help="Override the PR base branch.")
+@click.option("--platform", default=None, type=click.Choice(["bb", "gh"]), help="Force a backend. Default: auto-detect via .git/config.")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
+def pr_open_cmd(run_id, figma, jira_base, ready, base_branch, platform, yes):
+    """Actually fire `bb pr create` (or gh) using the rendered draft."""
+    from pathlib import Path as _Path
+    from .pr_draft import render_draft
+    from .runner.pr_backend import (
+        PRBackendError, detect_platform, get_backend,
+    )
+
+    try:
+        draft, artifacts = render_draft(run_id, figma_url=figma, jira_base_url=jira_base)
+    except ValueError as e:
+        console.print(f"[red]{e}[/red]")
+        raise click.Abort()
+
+    cwd = _Path(artifacts.cwd)
+    pf = platform or detect_platform(cwd)
+    if not pf:
+        console.print("[red]Could not detect a PR platform (bb or gh) for this worktree.[/red]")
+        raise click.Abort()
+
+    console.print(f"[bold cyan]Title:[/bold cyan] {draft.title}\n")
+    # Body is markdown — emit raw to avoid Rich markup parsing
+    click.echo(draft.body)
+    console.print()
+    console.print(f"[dim]Backend: {pf}  ·  draft: {not ready}  ·  cwd: {cwd}[/dim]")
+
+    if not yes:
+        if not click.confirm("Open this PR?", default=False):
+            console.print("[yellow]Cancelled.[/yellow]")
+            return
+
+    backend = get_backend(pf)
+    try:
+        pr_id, url = backend.create_pr(
+            title=draft.title, body=draft.body, cwd=cwd,
+            draft=not ready, base_branch=base_branch,
+        )
+    except PRBackendError as e:
+        console.print(f"[red]{pf} pr create failed:[/red] {e}")
+        raise click.Abort()
+
+    # Persist the PR linkage to the Run row so the existing poll-pr / respond-pr
+    # commands can find this PR without re-discovering by branch.
+    from .models import Run
+    with db_session() as db:
+        run = db.query(Run).filter_by(id=run_id).one_or_none()
+        if run:
+            run.pr_id = pr_id
+            run.pr_platform = pf
+            run.pr_url = url
+
+    console.print(f"[green]Opened PR #{pr_id}[/green]  {url}")
+
+
 @cli.group("hand")
 def hand_group():
     """Ranch hand — virtual engineer daemon (Phase H11)."""

--- a/ranch/pr_draft.py
+++ b/ranch/pr_draft.py
@@ -1,0 +1,282 @@
+"""H10 — `ranch pr draft <run_id>` / `ranch pr open <run_id>`.
+
+Gathers structured artifacts produced during a run (dossier, plan,
+acceptance results, files touched, branch, ticket) and renders them
+into a PR title + body. Operator can preview with `draft` or actually
+fire `bb pr create --draft` (or `gh pr create --draft`) with `open`.
+
+Per the H10 spec, the body sections are derived from data we already
+collected through H1+H5+H6+H8, not from rerun analysis. That keeps PR
+creation cheap and deterministic.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from .db import db_session
+from .models import Dossier, Run
+from .scope import load_scope_markdown
+
+# Same ticket-key shape used elsewhere
+TICKET_KEY_RE = re.compile(r"\b([A-Z]+-\d+)\b")
+
+
+# ─── Domain ────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunArtifacts:
+    """Everything we collected during a run that's PR-body-worthy."""
+
+    ticket: str | None
+    agent: str
+    branch_name: str | None
+    cwd: str
+    # Dossier-derived
+    final_state: str | None = None
+    final_just_did: str = ""
+    final_details: str = ""
+    plan_steps: list[dict] = field(default_factory=list)
+    files_touched: list[str] = field(default_factory=list)
+    acceptance: list[dict] = field(default_factory=list)
+    # Git-derived
+    diff_stat: str = ""
+    # Optional decorations the operator provides at draft time
+    figma_url: str | None = None
+    jira_base_url: str | None = None
+
+
+@dataclass
+class PRDraft:
+    """Title + body for the PR."""
+
+    title: str
+    body: str
+
+
+# ─── Gather ────────────────────────────────────────────────────────
+
+
+def _git(args: list[str], cwd: Path | str, timeout: float = 15.0) -> str:
+    """Run a git command, return stdout (empty string on failure)."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def gather_run_artifacts(run_id: int) -> RunArtifacts:
+    """Pull every PR-body-relevant artifact from the DB + worktree git state."""
+    with db_session() as db:
+        run = db.query(Run).filter_by(id=run_id).one_or_none()
+        if not run:
+            raise ValueError(f"Run #{run_id} not found")
+        # Snapshot before exiting the session — Run is detached after.
+        artifacts = RunArtifacts(
+            ticket=run.ticket, agent=run.agent,
+            branch_name=run.branch_name, cwd=run.cwd,
+        )
+        latest = (
+            db.query(Dossier)
+            .filter_by(run_id=run_id)
+            .order_by(Dossier.created_at.desc())
+            .first()
+        )
+        if latest:
+            try:
+                payload = json.loads(latest.payload_json)
+            except (json.JSONDecodeError, TypeError):
+                payload = {}
+            artifacts.final_state = payload.get("state")
+            artifacts.final_just_did = payload.get("just_did", "")
+            artifacts.final_details = payload.get("details", "") or ""
+            artifacts.plan_steps = payload.get("plan", []) or []
+            artifacts.files_touched = payload.get("files_touched", []) or []
+            artifacts.acceptance = payload.get("acceptance", []) or []
+
+    # Diff stat against develop (preferred) or main
+    cwd = Path(artifacts.cwd) if artifacts.cwd else Path.cwd()
+    for base in ("origin/develop", "develop", "origin/main", "main"):
+        stat = _git(["diff", "--stat", f"{base}...HEAD"], cwd)
+        if stat:
+            artifacts.diff_stat = stat
+            break
+    if not artifacts.diff_stat:
+        # Fall back to "since last common ancestor with HEAD~10" — best-effort
+        artifacts.diff_stat = _git(["diff", "--stat", "HEAD~10...HEAD"], cwd)
+
+    return artifacts
+
+
+# ─── Render ────────────────────────────────────────────────────────
+
+
+def _strip_section(text: str, header_pattern: str) -> str:
+    """Extract a single section from the agent's `details` markdown.
+
+    Looks for `## <header>` (or `### <header>`) and returns the content
+    up to the next same-or-higher-level header. Empty string if not found.
+
+    The propose system prompt instructs the agent to use Summary / Plan /
+    Acceptance criteria / Complexity / Risks headers — we mine those.
+    """
+    # Wrap header_pattern in a non-capturing group AND name the body group
+    # so internal capture groups in `header_pattern` (e.g. `( / open questions)?`)
+    # don't shift positional group indices.
+    pat = re.compile(
+        rf"^#{{1,4}}\s*\**(?:{header_pattern})\**\s*$(?P<body>.*?)(?=^#{{1,4}}\s|\Z)",
+        re.MULTILINE | re.IGNORECASE | re.DOTALL,
+    )
+    m = pat.search(text)
+    if not m:
+        return ""
+    return m.group("body").strip()
+
+
+def _format_plan_progress(plan_steps: list[dict]) -> str:
+    if not plan_steps:
+        return ""
+    lines = ["### Plan progress"]
+    for step in plan_steps:
+        status = step.get("status", "pending")
+        mark = {"done": "[x]", "in_progress": "[~]", "pending": "[ ]"}.get(status, "[ ]")
+        text = step.get("step", "")
+        lines.append(f"- {mark} {text}")
+        if step.get("notes"):
+            lines.append(f"      _{step['notes']}_")
+    return "\n".join(lines)
+
+
+def _format_acceptance(acceptance: list[dict]) -> str:
+    if not acceptance:
+        return ""
+    lines = ["### Acceptance checks"]
+    for c in acceptance:
+        kind = c.get("kind", "?")
+        name = c.get("name", "(unnamed)")
+        detail = ""
+        if kind in ("unit_test", "script") and c.get("cmd"):
+            detail = f" — `{c['cmd']}`"
+        elif kind == "http" and c.get("url"):
+            detail = f" — `GET {c['url']}`"
+        lines.append(f"- **[{kind}]** {name}{detail}")
+    return "\n".join(lines)
+
+
+def _format_files_touched(files: list[str], diff_stat: str) -> str:
+    """Prefer git diff --stat (authoritative) over the agent's reported list."""
+    if diff_stat:
+        return "```\n" + diff_stat.strip() + "\n```"
+    if files:
+        return "\n".join(f"- `{f}`" for f in files)
+    return "_(no diff captured)_"
+
+
+def derive_title(artifacts: RunArtifacts) -> str:
+    """Title format: `<TICKET>: <summary line>`.
+
+    Pulled from the dossier's just_did first sentence, with a sensible
+    fallback. Ticket prefix is added if not already present.
+    """
+    summary_source = ""
+    # Prefer the Summary section of `details` if present
+    if artifacts.final_details:
+        summary_section = _strip_section(artifacts.final_details, "summary")
+        if summary_section:
+            summary_source = summary_section.splitlines()[0]
+    if not summary_source:
+        summary_source = artifacts.final_just_did
+
+    # First sentence, capped
+    summary_source = summary_source.strip()
+    # Strip leading "**bold**" or trailing period
+    summary_source = re.sub(r"\*+", "", summary_source).strip().rstrip(".")
+    first_sentence = re.split(r"(?<=[.!?])\s", summary_source, maxsplit=1)[0]
+    if len(first_sentence) > 72:
+        first_sentence = first_sentence[:69].rstrip() + "..."
+
+    if artifacts.ticket and not artifacts.ticket.lower() in first_sentence.lower():
+        return f"{artifacts.ticket}: {first_sentence}"
+    return first_sentence or (artifacts.ticket or "PR")
+
+
+def render_pr_body(artifacts: RunArtifacts) -> str:
+    """Build the PR body from accumulated structured data."""
+    sections: list[str] = []
+
+    # Summary — agent's narration
+    summary = _strip_section(artifacts.final_details, "summary")
+    if summary:
+        sections.append(f"## Summary\n\n{summary}")
+    elif artifacts.final_just_did:
+        sections.append(f"## Summary\n\n{artifacts.final_just_did}")
+
+    # Plan progress
+    plan_block = _format_plan_progress(artifacts.plan_steps)
+    if plan_block:
+        sections.append(plan_block)
+
+    # Changes — prefer authoritative git diff stat
+    changes = _format_files_touched(artifacts.files_touched, artifacts.diff_stat)
+    sections.append(f"## Changes\n\n{changes}")
+
+    # Testing — agent's `acceptance` is the machine-verifiable contract;
+    # the prose AC from `details` is the human-readable version.
+    testing_lines = ["## Testing"]
+    accept_block = _format_acceptance(artifacts.acceptance)
+    if accept_block:
+        testing_lines.append("")
+        testing_lines.append(accept_block)
+    ac_prose = _strip_section(artifacts.final_details, "acceptance criteria")
+    if ac_prose:
+        testing_lines.append("")
+        testing_lines.append("### Manual verification")
+        testing_lines.append("")
+        testing_lines.append(ac_prose)
+    if len(testing_lines) > 1:
+        sections.append("\n".join(testing_lines))
+
+    # Risks / open questions
+    risks = _strip_section(artifacts.final_details, r"risks( / open questions)?")
+    if risks:
+        sections.append(f"## Open questions / risks\n\n{risks}")
+
+    # Linked
+    linked_lines = []
+    if artifacts.ticket and artifacts.jira_base_url:
+        linked_lines.append(f"- Jira: {artifacts.jira_base_url.rstrip('/')}/browse/{artifacts.ticket}")
+    elif artifacts.ticket:
+        linked_lines.append(f"- Jira: `{artifacts.ticket}`")
+    if artifacts.figma_url:
+        linked_lines.append(f"- Design: {artifacts.figma_url}")
+    if linked_lines:
+        sections.append("## Linked\n\n" + "\n".join(linked_lines))
+
+    # Footer attribution
+    sections.append(
+        "---\n_PR drafted from ranch run "
+        f"on branch `{artifacts.branch_name or '?'}` by agent `{artifacts.agent}`._"
+    )
+
+    return "\n\n".join(sections).strip() + "\n"
+
+
+def render_draft(run_id: int, *, figma_url: str | None = None,
+                  jira_base_url: str | None = None) -> tuple[PRDraft, RunArtifacts]:
+    """Convenience: gather + render in one shot."""
+    artifacts = gather_run_artifacts(run_id)
+    artifacts.figma_url = figma_url
+    artifacts.jira_base_url = jira_base_url
+    return PRDraft(title=derive_title(artifacts),
+                    body=render_pr_body(artifacts)), artifacts

--- a/ranch/runner/pr_backend.py
+++ b/ranch/runner/pr_backend.py
@@ -118,6 +118,29 @@ class BBBackend:
             argv += ["--reply-to", str(reply_to)]
         _run(argv, cwd)
 
+    def create_pr(self, title: str, body: str, cwd: Path, draft: bool = True,
+                  base_branch: str | None = None) -> tuple[str, str]:
+        """Open a new PR. Returns (pr_id, url). Defaults to draft.
+
+        H10: used by `ranch pr open <run_id>` to finalize a finished run.
+        """
+        argv = ["bb", "--json", "pr", "create", "-t", title, "-b", body]
+        if draft:
+            argv.append("--draft")
+        if base_branch:
+            argv += ["-d", base_branch]
+        raw = _run(argv, cwd, timeout=60.0)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise PRBackendError(f"bb pr create returned non-JSON: {e}\nstdout: {raw[:500]}") from e
+        pr_id = str(data.get("id"))
+        url = (
+            data.get("links", {}).get("html", {}).get("href")
+            or data.get("url", "")
+        )
+        return pr_id, url
+
 
 # ─── GitHub (gh) ──────────────────────────────────────────────────
 
@@ -193,6 +216,30 @@ class GHBackend:
         if reply_to:
             body = f"(reply to comment {reply_to})\n\n{body}"
         _run(["gh", "pr", "comment", pr_id, "--body", body], cwd)
+
+    def create_pr(self, title: str, body: str, cwd: Path, draft: bool = True,
+                  base_branch: str | None = None) -> tuple[str, str]:
+        """Open a new PR. Returns (pr_id, url). Defaults to draft.
+
+        gh prints the PR URL to stdout on success. We re-query via
+        `gh pr view --json` to recover the numeric ID since `gh pr create`
+        doesn't emit JSON.
+        """
+        argv = ["gh", "pr", "create", "--title", title, "--body", body]
+        if draft:
+            argv.append("--draft")
+        if base_branch:
+            argv += ["--base", base_branch]
+        url = _run(argv, cwd, timeout=60.0).strip().splitlines()[-1].strip()
+        # Recover the numeric ID
+        try:
+            raw = _run(["gh", "pr", "view", url, "--json", "number,url"], cwd)
+            data = json.loads(raw)
+            pr_id = str(data.get("number"))
+            url = data.get("url", url)
+        except PRBackendError:
+            pr_id = url.rsplit("/", 1)[-1]  # fallback — last path segment
+        return pr_id, url
 
 
 # ─── Dispatch ─────────────────────────────────────────────────────

--- a/tests/test_pr_draft.py
+++ b/tests/test_pr_draft.py
@@ -1,0 +1,360 @@
+"""Tests for H10 — PR draft assembly + backend create_pr methods.
+
+Backend tests use subprocess mocks; the renderer tests are pure-Python
+against synthetic Run + Dossier rows.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from ranch.db import db_session, init_db
+from ranch.models import Dossier, Run
+from ranch.pr_draft import (
+    PRDraft,
+    RunArtifacts,
+    _format_acceptance,
+    _format_files_touched,
+    _format_plan_progress,
+    _strip_section,
+    derive_title,
+    gather_run_artifacts,
+    render_draft,
+    render_pr_body,
+)
+
+
+# ─── Helpers ───────────────────────────────────────────────────────
+
+
+def _seed_run(ticket: str = "ECD-1234", branch: str = "feature/ECD-1234-foo",
+              agent: str = "max", cwd: str = "/tmp", state: str = "completed") -> int:
+    init_db()
+    with db_session() as db:
+        run = Run(
+            agent=agent, ticket=ticket, cwd=cwd, initial_prompt="brief",
+            state=state, branch_name=branch,
+        )
+        db.add(run); db.flush()
+        return run.id
+
+
+def _seed_dossier(run_id: int, payload: dict, state: str = "parked"):
+    with db_session() as db:
+        db.add(Dossier(run_id=run_id, state=state, payload_json=json.dumps(payload)))
+
+
+# ─── _strip_section ───────────────────────────────────────────────
+
+
+def test_strip_section_extracts_h2():
+    text = "## Summary\n\nBuild a /healthz endpoint.\n\n## Plan\n\n1. a\n"
+    assert "Build a /healthz endpoint." in _strip_section(text, "summary")
+    assert "Plan" not in _strip_section(text, "summary")
+
+
+def test_strip_section_handles_bold_wrap():
+    """Agents sometimes wrap headers in bold: `## **Summary**`."""
+    text = "## **Summary**\n\nbody\n\n## Plan\n\nx"
+    assert "body" in _strip_section(text, "summary")
+
+
+def test_strip_section_case_insensitive():
+    text = "## SUMMARY\n\nbody\n\n## next\n\nz"
+    assert "body" in _strip_section(text, "summary")
+
+
+def test_strip_section_returns_empty_when_not_found():
+    assert _strip_section("no headers", "summary") == ""
+
+
+def test_strip_section_handles_regex_header_alternation():
+    text = "## Risks / open questions\n\nbe careful\n\n"
+    assert "be careful" in _strip_section(text, r"risks( / open questions)?")
+
+
+# ─── _format_plan_progress ────────────────────────────────────────
+
+
+def test_format_plan_renders_checklist():
+    steps = [
+        {"step": "Read code", "status": "done"},
+        {"step": "Write tests", "status": "in_progress"},
+        {"step": "Implement", "status": "pending"},
+    ]
+    out = _format_plan_progress(steps)
+    assert "[x] Read code" in out
+    assert "[~] Write tests" in out
+    assert "[ ] Implement" in out
+
+
+def test_format_plan_includes_notes():
+    steps = [{"step": "x", "status": "done", "notes": "tricky"}]
+    assert "_tricky_" in _format_plan_progress(steps)
+
+
+def test_format_plan_empty():
+    assert _format_plan_progress([]) == ""
+
+
+# ─── _format_acceptance ──────────────────────────────────────────
+
+
+def test_format_acceptance_includes_cmd_for_subprocess_kinds():
+    out = _format_acceptance([
+        {"kind": "unit_test", "name": "pytest", "cmd": "pytest tests/"},
+        {"kind": "script", "name": "smoke", "cmd": "curl localhost"},
+        {"kind": "http", "name": "healthz", "url": "http://localhost/h"},
+    ])
+    assert "pytest tests/" in out
+    assert "curl localhost" in out
+    assert "GET http://localhost/h" in out
+
+
+def test_format_acceptance_empty():
+    assert _format_acceptance([]) == ""
+
+
+# ─── _format_files_touched ───────────────────────────────────────
+
+
+def test_format_files_prefers_diff_stat():
+    """When git diff stat is available, use it — it's authoritative."""
+    out = _format_files_touched(
+        files=["agent_said_this.py"],
+        diff_stat=" foo.py | 1 +\n bar.py | 2 +-\n",
+    )
+    assert "foo.py" in out
+    assert "agent_said_this.py" not in out
+
+
+def test_format_files_falls_back_to_agent_list():
+    out = _format_files_touched(files=["a.py", "b.py"], diff_stat="")
+    assert "`a.py`" in out
+    assert "`b.py`" in out
+
+
+def test_format_files_handles_nothing():
+    out = _format_files_touched(files=[], diff_stat="")
+    assert "no diff captured" in out
+
+
+# ─── derive_title ────────────────────────────────────────────────
+
+
+def test_title_uses_summary_first_line():
+    art = RunArtifacts(
+        ticket="ECD-100", agent="max", branch_name="b", cwd="/tmp",
+        final_details="## Summary\n\nAdd /healthz endpoint.\nMore detail.",
+    )
+    assert derive_title(art) == "ECD-100: Add /healthz endpoint"
+
+
+def test_title_falls_back_to_just_did_when_no_summary():
+    art = RunArtifacts(
+        ticket="ECD-100", agent="max", branch_name="b", cwd="/tmp",
+        final_just_did="Shipped the toast component.",
+    )
+    assert derive_title(art) == "ECD-100: Shipped the toast component"
+
+
+def test_title_truncates_long_lines():
+    art = RunArtifacts(
+        ticket="ECD-100", agent="max", branch_name="b", cwd="/tmp",
+        final_just_did="a" * 200,
+    )
+    title = derive_title(art)
+    assert title.endswith("...")
+    assert len(title) <= 90
+
+
+def test_title_omits_ticket_prefix_when_already_present_in_summary():
+    art = RunArtifacts(
+        ticket="ECD-100", agent="max", branch_name="b", cwd="/tmp",
+        final_just_did="ECD-100 — initial draft",
+    )
+    title = derive_title(art)
+    # We don't double-prefix
+    assert title.lower().count("ecd-100") == 1
+
+
+def test_title_strips_bold_markers():
+    art = RunArtifacts(
+        ticket="ECD-100", agent="max", branch_name="b", cwd="/tmp",
+        final_details="## Summary\n\n**Add the endpoint.**",
+    )
+    assert "**" not in derive_title(art)
+
+
+# ─── render_pr_body ──────────────────────────────────────────────
+
+
+def test_render_body_has_all_sections_when_inputs_present():
+    art = RunArtifacts(
+        ticket="ECD-100", agent="max", branch_name="feature/ECD-100", cwd="/tmp",
+        final_just_did="Tests green, ready for review.",
+        final_details=(
+            "## Summary\n\nAdd /healthz.\n\n"
+            "## Plan\n\n1. test\n2. impl\n\n"
+            "## Acceptance criteria\n\nVerify the endpoint returns 200.\n\n"
+            "## Complexity\n\nS\n\n"
+            "## Risks / open questions\n\nNone.\n"
+        ),
+        plan_steps=[{"step": "Test", "status": "done"}],
+        files_touched=["a.py"],
+        acceptance=[{"kind": "unit_test", "name": "pytest", "cmd": "pytest"}],
+        diff_stat=" a.py | 5 +\n",
+        figma_url="https://figma.com/file/X",
+        jira_base_url="https://example.atlassian.net",
+    )
+    body = render_pr_body(art)
+    assert "## Summary" in body
+    assert "Add /healthz." in body
+    assert "### Plan progress" in body
+    assert "## Changes" in body
+    assert "a.py | 5 +" in body
+    assert "## Testing" in body
+    assert "[unit_test]" in body
+    assert "### Manual verification" in body
+    assert "Verify the endpoint returns 200." in body
+    assert "## Open questions / risks" in body
+    assert "## Linked" in body
+    assert "https://example.atlassian.net/browse/ECD-100" in body
+    assert "https://figma.com/file/X" in body
+    assert "drafted from ranch run" in body
+
+
+def test_render_body_omits_sections_with_no_input():
+    art = RunArtifacts(
+        ticket=None, agent="max", branch_name=None, cwd="/tmp",
+        final_just_did="Did something.",
+    )
+    body = render_pr_body(art)
+    assert "## Plan progress" not in body
+    assert "## Open questions" not in body
+    assert "## Testing" not in body  # nothing to put there
+    assert "## Linked" not in body
+    # But Summary + Changes are always present (changes shows "no diff captured")
+    assert "## Summary" in body
+    assert "## Changes" in body
+
+
+def test_render_body_falls_back_to_ticket_code_when_no_jira_base():
+    art = RunArtifacts(
+        ticket="ECD-100", agent="max", branch_name="b", cwd="/tmp",
+        final_just_did="x",
+    )
+    body = render_pr_body(art)
+    assert "`ECD-100`" in body
+
+
+# ─── gather + render_draft ───────────────────────────────────────
+
+
+def test_gather_returns_dossier_state_and_run_metadata(tmp_path):
+    rid = _seed_run(ticket="ECD-9", branch="feature/ECD-9", cwd=str(tmp_path))
+    _seed_dossier(rid, {
+        "plan": [{"step": "x", "status": "done"}],
+        "just_did": "Tests green.",
+        "state": "parked",
+        "details": "## Summary\n\nA tiny thing.",
+        "files_touched": ["foo.py"],
+        "acceptance": [{"kind": "unit_test", "name": "pytest", "cmd": "pytest"}],
+    })
+    art = gather_run_artifacts(rid)
+    assert art.ticket == "ECD-9"
+    assert art.branch_name == "feature/ECD-9"
+    assert art.final_state == "parked"
+    assert art.files_touched == ["foo.py"]
+    assert len(art.acceptance) == 1
+
+
+def test_gather_raises_when_run_missing():
+    init_db()
+    with pytest.raises(ValueError, match="Run #999"):
+        gather_run_artifacts(999)
+
+
+def test_render_draft_end_to_end(tmp_path):
+    rid = _seed_run(ticket="ECD-1", cwd=str(tmp_path))
+    _seed_dossier(rid, {
+        "plan": [], "just_did": "Ready.", "state": "parked",
+        "details": "## Summary\n\nShipping it.",
+    })
+    draft, art = render_draft(rid, figma_url="https://figma.com/f")
+    assert isinstance(draft, PRDraft)
+    assert "ECD-1" in draft.title
+    assert "Shipping it." in draft.body
+    assert "figma.com/f" in draft.body
+    assert art.figma_url == "https://figma.com/f"
+
+
+# ─── Backend.create_pr — subprocess mocked ───────────────────────
+
+
+def test_bb_backend_create_pr_passes_draft_flag(monkeypatch):
+    from ranch.runner.pr_backend import BBBackend
+
+    captured = {}
+
+    def fake_run(argv, cwd, timeout=30.0):
+        captured["argv"] = argv
+        return json.dumps({"id": 42, "links": {"html": {"href": "https://bb/pr/42"}}})
+
+    monkeypatch.setattr("ranch.runner.pr_backend._run", fake_run)
+    pr_id, url = BBBackend().create_pr("title", "body", Path("/tmp"), draft=True)
+    assert pr_id == "42"
+    assert url == "https://bb/pr/42"
+    assert "--draft" in captured["argv"]
+    assert "-t" in captured["argv"] and "title" in captured["argv"]
+    assert "-b" in captured["argv"] and "body" in captured["argv"]
+
+
+def test_bb_backend_create_pr_skips_draft_when_false(monkeypatch):
+    from ranch.runner.pr_backend import BBBackend
+
+    captured = {}
+    def fake_run(argv, cwd, timeout=30.0):
+        captured["argv"] = argv
+        return json.dumps({"id": 1, "links": {"html": {"href": "u"}}})
+
+    monkeypatch.setattr("ranch.runner.pr_backend._run", fake_run)
+    BBBackend().create_pr("t", "b", Path("/tmp"), draft=False)
+    assert "--draft" not in captured["argv"]
+
+
+def test_gh_backend_create_pr_parses_url_and_recovers_id(monkeypatch):
+    from ranch.runner.pr_backend import GHBackend
+
+    calls = []
+    def fake_run(argv, cwd, timeout=30.0):
+        calls.append(argv)
+        if "create" in argv:
+            return "https://github.com/o/r/pull/77\n"
+        if "view" in argv:
+            return json.dumps({"number": 77, "url": "https://github.com/o/r/pull/77"})
+        return ""
+
+    monkeypatch.setattr("ranch.runner.pr_backend._run", fake_run)
+    pr_id, url = GHBackend().create_pr("title", "body", Path("/tmp"), draft=True)
+    assert pr_id == "77"
+    assert url.endswith("/pull/77")
+    create_argv = calls[0]
+    assert "--draft" in create_argv
+
+
+def test_gh_backend_create_pr_falls_back_to_url_parse_on_view_failure(monkeypatch):
+    """If `gh pr view` fails, derive the ID from the URL's tail."""
+    from ranch.runner.pr_backend import GHBackend, PRBackendError
+
+    def fake_run(argv, cwd, timeout=30.0):
+        if "create" in argv:
+            return "https://github.com/o/r/pull/55\n"
+        raise PRBackendError("view failed")
+
+    monkeypatch.setattr("ranch.runner.pr_backend._run", fake_run)
+    pr_id, url = GHBackend().create_pr("t", "b", Path("/tmp"))
+    assert pr_id == "55"


### PR DESCRIPTION
## Summary

Closes the ticket-to-PR loop. After a run finishes, gather everything the agent collected (dossier details, plan, acceptance, files_touched) + git diff stat, render into a structured PR title + body, optionally fire \`bb pr create --draft\` (or gh).

Stacked on #93 (H8).

## What you can do after this lands

```bash
ranch pr draft <run_id>                       # preview the rendered PR locally
ranch pr draft <run_id> --out /tmp/pr.md      # write to file instead of stdout
ranch pr draft <run_id> --figma <url> --jira-base https://citemed.atlassian.net

ranch pr open <run_id>                        # actually open the PR (draft)
ranch pr open <run_id> --ready                # ready-for-review instead of draft
ranch pr open <run_id> --base-branch develop
ranch pr open <run_id> --yes                  # skip confirmation prompt
```

## Architecture

**Operator-facing CLI, not an agent MCP tool.** The agent's job stops at \`pre_push\` parked; the hand (or operator) handles the PR creation step. Keeps the agent's tool set lean and the boundary between "code the change" and "ship the change" clean.

### Body composition

| Section | Source |
|---|---|
| \`## Summary\` | Dossier \`details\` → "Summary" section |
| \`### Plan progress\` | Dossier \`plan\` checklist with \`[x] [~] [ ]\` marks |
| \`## Changes\` | \`git diff --stat\` (origin/develop preferred, fallback chain) OR dossier \`files_touched\` |
| \`### Acceptance checks\` | Dossier \`acceptance\` array (the H8 contract) |
| \`### Manual verification\` | Dossier \`details\` → "Acceptance criteria" prose |
| \`## Open questions / risks\` | Dossier \`details\` → "Risks" section |
| \`## Linked\` | Jira + Figma URLs you supply at draft time |
| Footer | Branch + agent attribution |

### Backend extensions

- **\`BBBackend.create_pr\`** — \`bb --json pr create -t -b [--draft] [-d base]\`, parses JSON response for id + url
- **\`GHBackend.create_pr\`** — \`gh pr create --title --body [--draft] [--base]\`, recovers numeric id via \`gh pr view --json\`, falls back to URL-tail parsing if view fails

Persists PR linkage to \`Run.pr_id\` / \`.pr_platform\` / \`.pr_url\` so the existing \`poll-pr\` / \`respond-pr\` commands find it without branch discovery.

## Test plan

- [x] 28 new tests in \`test_pr_draft.py\` — section extraction (h2 / bold / case-insensitive / regex alternation), plan checklist formatting, acceptance formatting, file list (prefer diff stat over agent claim), title derivation (summary → just_did fallback / truncate / no-double-prefix / strip bold), full body render (all sections + omit-when-empty), gather + render_draft from DB, BBBackend + GHBackend create_pr with subprocess mocks
- [x] **Full suite: 309 passed**
- [x] CLI smoke against a seeded synthetic run — title with ticket prefix, checklist marks intact, acceptance block intact, Jira + Figma links populated
- [ ] Real-Bitbucket validation — deferred. Backend tests are mock-based; the actual \`bb pr create\` against your remote needs a worktree with push permissions and you in the loop to clean up if anything goes sideways.

## Notes for review / bugs caught along the way

- **Section extractor regex bug:** the original \`(.*?)\` body group was capturing nothing when callers passed alternation (\`risks( / open questions)?\`) — the inner capture group stole positional index 1. Switched the body group to a named group \`(?P<body>...)\` so it's index-independent.
- **CLI render bug:** Rich's \`console.print\` was eating \`[x]\` checkboxes and \`[unit_test]\` labels as markup. Body is now emitted with \`click.echo\` to preserve markdown verbatim.
- **What's NOT included:** Qase MCP integration. Out of scope for this PR; would require a separate "after open, register Qase cases from acceptance" step we can layer in later.
- **Labs deploy link:** H9 isn't shipped yet, so there's no \`labs_url\` slot in the body. Easy follow-up — one section + one option flag.

Closes #80 (scope as built: draft + open, minus Qase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)