### PR TITLE
H11 v2 mini: hand auto-fires execute on propose approval (#81)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -166,11 +166,18 @@ proposes → parks. While a recently-parked proposal is awaiting your
 review (24h window), the hand idles instead of piling on new work.
 
 After you review a parked proposal:
-- If you want to proceed, run `ranch run max --ticket <key> --brief "<plan>"`
-  using the plan from the dossier — execution wiring lands when the next
-  H-tickets layer in (H8 self-judge, H9 labs handoff, H10 PR draft).
+- If you want to proceed, run `ranch approve <run_id>` — the hand
+  detects this on its next poll cycle and auto-fires the execute step
+  (plan_ready and tests_green checkpoints auto-approve since the plan
+  was already vetted; pre_push remains a real operator gate).
 - If you want to reject, just delete or supersede the parked run; the
   hand will triage past it once it falls outside the 24h window.
+
+When the execute step finishes (or hits its budget), it parks at
+`pre_push`. You review the diff via `ranch dossier <execute_run_id>`,
+then either `ranch approve <execute_run_id>` to push and `ranch pr open`,
+or `ranch reject <execute_run_id> "reason"` to send the agent back to
+fix.
 
 Stop semantics: `ranch hand stop` writes a sentinel file the daemon polls
 for between cycles — clean exit, never kills mid-tool-use.

--- a/ranch/hand.py
+++ b/ranch/hand.py
@@ -29,7 +29,7 @@ from rich.console import Console
 
 from .config import AGENTS, RANCH_HOME, reload_agents
 from .db import db_session
-from .models import Dossier, Run
+from .models import Dossier, Interjection, Run
 
 console = Console()
 
@@ -172,6 +172,140 @@ def _snapshot_run(run: "Run") -> _RunSnapshot:
     return _RunSnapshot(id=run.id, agent=run.agent, ticket=run.ticket, state=run.state)
 
 
+@dataclass
+class _ApprovedPropose:
+    """A parked propose run the operator has just approved — the hand's
+    trigger to fire the execute step."""
+
+    propose_run: _RunSnapshot
+    parked_payload: dict  # the latest dossier payload (plan, acceptance, details, ...)
+
+
+def _find_approved_parked_propose(agent: str) -> _ApprovedPropose | None:
+    """Look for a terminal-state run by this agent whose latest dossier is
+    `parked` AND has an unprocessed `approve` interjection. Consumes (marks
+    processed) the interjection in the same transaction so the same approval
+    can't fire execute twice.
+    """
+    cutoff = datetime.now(timezone.utc) - AWAITING_APPROVAL_WINDOW
+    with db_session() as db:
+        runs = (
+            db.query(Run)
+            .filter(Run.agent == agent)
+            .filter(Run.state.in_(TERMINAL_RUN_STATES))
+            .filter(Run.ended_at >= cutoff)
+            .order_by(Run.ended_at.desc())
+            .all()
+        )
+        for run in runs:
+            latest = (
+                db.query(Dossier)
+                .filter_by(run_id=run.id)
+                .order_by(Dossier.created_at.desc())
+                .first()
+            )
+            if not latest or latest.state != "parked":
+                continue
+            approve_row = (
+                db.query(Interjection)
+                .filter_by(run_id=run.id, kind="approve", processed_at=None)
+                .order_by(Interjection.id)
+                .first()
+            )
+            if not approve_row:
+                continue
+            approve_row.processed_at = datetime.now(timezone.utc)
+            try:
+                payload = json.loads(latest.payload_json)
+            except (json.JSONDecodeError, TypeError):
+                payload = {}
+            return _ApprovedPropose(
+                propose_run=_snapshot_run(run),
+                parked_payload=payload,
+            )
+    return None
+
+
+def _build_execute_brief(ticket: str | None, parked_payload: dict) -> str:
+    """Construct the brief for the execute run.
+
+    Carries forward the propose's Summary + Plan + acceptance contract so
+    the agent doesn't need to re-derive any of it. The acceptance is also
+    pre-seeded onto the new run's dossier (separate step), so the agent
+    can call `run_acceptance` with no args.
+    """
+    import textwrap
+    details = parked_payload.get("details", "") or ""
+    plan_steps = parked_payload.get("plan") or []
+    plan_md = "\n".join(f"{i}. {s.get('step', '')}" for i, s in enumerate(plan_steps, 1)) or "(no plan steps in propose)"
+
+    return textwrap.dedent(f"""\
+        Ticket: {ticket or '(no ticket)'}
+
+        This is the execute step. The proposal phase has been approved by the
+        operator — your job now is to implement the proposed plan, verify
+        with `run_acceptance`, and park at `pre_push` for final approval.
+
+        Workflow:
+        1. PLAN — read the plan below + any relevant code. Call
+           `record_checkpoint(kind="plan_ready", summary=...)` to acknowledge
+           your execution approach (this checkpoint auto-approves since the
+           plan was already vetted at propose).
+        2. DEVELOP (TDD) — write failing tests first, then implementation.
+        3. VERIFY — call `run_acceptance` (no args; your dossier carries the
+           acceptance contract from propose). Iterate until all checks pass.
+        4. PRE-PUSH — `record_checkpoint(kind="pre_push", summary=...)` and
+           STOP.
+
+        ── PROPOSED PLAN ──
+        {plan_md}
+
+        ── FULL PROPOSAL DETAILS ──
+        {details.strip() or '(no details captured)'}
+
+        Begin with the PLAN step.
+    """)
+
+
+def _create_execute_run(
+    *, agent: str, cwd: Path, ticket: str | None,
+    brief: str, parked_payload: dict,
+) -> int:
+    """Insert the execute Run + pre-seed its dossier with the carried-forward
+    acceptance. Returns the new run_id.
+
+    Pre-seeding the dossier means `run_acceptance` (H8) finds the contract
+    on its own without us having to inline the JSON in the brief.
+    """
+    with db_session() as db:
+        run = Run(
+            agent=agent,
+            ticket=ticket,
+            cwd=str(cwd),
+            initial_prompt=brief,
+            state="planning",
+            auto_approve=1,  # plan_ready was already approved at propose
+        )
+        db.add(run)
+        db.flush()
+        new_id = run.id
+
+        carried_payload = {
+            "plan": parked_payload.get("plan", []),
+            "just_did": "Execute step initiated by ranch hand after operator approval of the proposal.",
+            "state": "planning",
+            "acceptance": parked_payload.get("acceptance", []),
+            "details": parked_payload.get("details", ""),
+        }
+        db.add(Dossier(
+            run_id=new_id,
+            state="planning",
+            payload_json=json.dumps(carried_payload),
+        ))
+
+    return new_id
+
+
 # ─── The hand itself ───────────────────────────────────────────────
 
 
@@ -186,21 +320,25 @@ class RanchHand:
         poll_seconds: float = 30.0,
         idle_log_freq_minutes: float = 30.0,
         jira_project: str | None = None,
+        execute_budget_seconds: float = 600.0,
         triage_fn: Optional[Callable[[str | None], list[str]]] = None,
         scope_fn: Optional[Callable[[str], None]] = None,
         propose_fn: Optional[Callable[[str], Awaitable[None]]] = None,
+        execute_fn: Optional[Callable[[_ApprovedPropose], Awaitable[None]]] = None,
     ):
         self.name = name
         self.cwd = cwd
         self.poll_seconds = poll_seconds
         self.idle_log_freq_minutes = idle_log_freq_minutes
         self.jira_project = jira_project
+        self.execute_budget_seconds = execute_budget_seconds
 
         # Injection seams for tests + offline mode. Default impls hit Jira /
         # invoke H5+H6; the validation harness injects synthetic versions.
         self.triage_fn = triage_fn or self._default_triage
         self.scope_fn = scope_fn or self._default_scope
         self.propose_fn = propose_fn or self._default_propose
+        self.execute_fn = execute_fn or self._default_execute
 
         self.stop_requested = False
         self._last_idle_log = datetime.now(timezone.utc) - timedelta(days=1)
@@ -234,6 +372,36 @@ class RanchHand:
         with JiraClient(JiraConfig.load()) as client:
             scope = build_scope(ticket_key, jira=client, cwd=self.cwd)
         save_scope(scope)
+
+    async def _default_execute(self, approved: "_ApprovedPropose") -> None:
+        """Run the structured-workflow orchestrator against the approved plan.
+
+        Carries the propose dossier's plan + acceptance forward onto a brand-new
+        execute Run, so H8's `run_acceptance` finds the contract on its own.
+        """
+        from .runner.orchestrator import Orchestrator
+
+        brief = _build_execute_brief(approved.propose_run.ticket, approved.parked_payload)
+        new_run_id = _create_execute_run(
+            agent=self.name,
+            cwd=self.cwd,
+            ticket=approved.propose_run.ticket,
+            brief=brief,
+            parked_payload=approved.parked_payload,
+        )
+
+        orch = Orchestrator(
+            agent=self.name,
+            cwd=self.cwd,
+            ticket=approved.propose_run.ticket,
+            brief=brief,
+            free=False,                                    # structured workflow
+            auto_approve=False,                            # pre_push is a REAL human gate
+            auto_approve_kinds={"plan_ready", "tests_green"},  # already vetted at propose
+            budget_seconds=self.execute_budget_seconds,
+        )
+        orch.run_id = new_run_id  # piggyback on the pre-created run + pre-seeded dossier
+        await orch.run()
 
     async def _default_propose(self, ticket_key: str) -> None:
         """Run a propose session via H6 against this hand's worktree."""
@@ -303,7 +471,23 @@ class RanchHand:
                     await asyncio.sleep(self.poll_seconds)
                     continue
 
-                # 2. Recently parked & still within the operator-review window?
+                # 2. An approved parked propose? → fire execute (H11 v2).
+                #    Consumes the approve interjection in the same transaction
+                #    so the same approval cannot re-fire execute.
+                approved = _find_approved_parked_propose(self.name)
+                if approved:
+                    console.print(
+                        f"[bold green]{self.name}: approval received for "
+                        f"{approved.propose_run.ticket} — firing execute[/bold green]"
+                    )
+                    try:
+                        await self.execute_fn(approved)
+                    except Exception as e:
+                        console.print(f"[red]{self.name}: execute failed — {e}[/red]")
+                    await asyncio.sleep(self.poll_seconds)
+                    continue
+
+                # 3. Recently parked & still within the operator-review window?
                 parked = _last_parked_run_for(self.name)
                 if parked:
                     self._maybe_log_idle(

--- a/ranch/runner/orchestrator.py
+++ b/ranch/runner/orchestrator.py
@@ -61,6 +61,7 @@ class Orchestrator:
         allowed_tools_override: list[str] | None = None,
         budget_seconds: float | None = None,
         append_system_prompt_override: str | None = None,
+        auto_approve_kinds: set[str] | None = None,
     ):
         self.agent = agent
         self.cwd = cwd
@@ -68,6 +69,11 @@ class Orchestrator:
         self.brief = brief
         self.free = free
         self.auto_approve = auto_approve
+        # Per-kind override: when set, ONLY these checkpoint kinds auto-approve.
+        # auto_approve=True is the "all kinds" shorthand. Lets the ranch hand
+        # auto-approve plan_ready (already vetted at propose) while leaving
+        # pre_push as a real human gate.
+        self.auto_approve_kinds = auto_approve_kinds
         self.allowed_tools_override = allowed_tools_override
         self.budget_seconds = budget_seconds
         self.append_system_prompt_override = append_system_prompt_override
@@ -102,12 +108,16 @@ class Orchestrator:
         console.print(summary)
         if kind in APPROVAL_REQUIRED:
             self._awaiting_approval = True
-            if self.auto_approve:
-                console.print("[dim](auto-approve mode — firing approval immediately)[/dim]")
+            # Auto-approve precedence: explicit per-kind list wins; else the
+            # blanket `auto_approve` flag covers all kinds.
+            kind_auto = self.auto_approve_kinds is not None and kind in self.auto_approve_kinds
+            blanket_auto = self.auto_approve_kinds is None and self.auto_approve
+            if kind_auto or blanket_auto:
+                console.print(f"[dim](auto-approve fired for {kind})[/dim]")
                 self._approval_result = "approved"
                 self._approval_ready.set()
             else:
-                console.print("[dim]Waiting for: !approve  |  !reject <reason>  |  !stop[/dim]")
+                console.print(f"[dim]Waiting for: !approve  |  !reject <reason>  |  !stop  (gate: {kind})[/dim]")
 
     def requires_approval(self, kind: str) -> bool:
         return kind in APPROVAL_REQUIRED

--- a/tests/test_hand.py
+++ b/tests/test_hand.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -20,6 +20,10 @@ from ranch.hand import (
     HANDS_DIR,
     RanchHand,
     _active_run_for,
+    _ApprovedPropose,
+    _build_execute_brief,
+    _create_execute_run,
+    _find_approved_parked_propose,
     _last_parked_run_for,
     _pid_file,
     _read_pid,
@@ -28,7 +32,7 @@ from ranch.hand import (
     list_all_hand_statuses,
     request_stop,
 )
-from ranch.models import Dossier, Run
+from ranch.models import Dossier, Interjection, Run
 
 
 # ─── Fixture: isolate the hands dir per test ──────────────────────
@@ -310,3 +314,237 @@ def test_status_when_pid_stale_returns_missing(isolated_hands_dir):
     (isolated_hands_dir / "max.pid").write_text("999999")
     s = get_hand_status("max")
     assert s.state == "missing"
+
+
+# ─── H11 v2: approval detection + auto-execute ───────────────────
+
+
+def _add_approve(run_id: int):
+    init_db()
+    with db_session() as db:
+        db.add(Interjection(run_id=run_id, kind="approve", content=""))
+
+
+def test_find_approved_returns_none_with_no_runs():
+    init_db()
+    assert _find_approved_parked_propose("max") is None
+
+
+def test_find_approved_returns_none_when_parked_but_no_approval():
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "parked", blocker="x")
+    assert _find_approved_parked_propose("max") is None
+
+
+def test_find_approved_returns_none_when_approval_but_not_parked():
+    """An approve interjection on a run that never parked shouldn't fire execute."""
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "coding")
+    _add_approve(rid)
+    assert _find_approved_parked_propose("max") is None
+
+
+def test_find_approved_returns_run_and_payload_when_both_present():
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "parked", blocker="x", just_did="ready",
+                  plan=[{"step": "do it", "status": "done"}])
+    _add_approve(rid)
+    approved = _find_approved_parked_propose("max")
+    assert approved is not None
+    assert approved.propose_run.id == rid
+    assert approved.parked_payload["plan"][0]["step"] == "do it"
+
+
+def test_find_approved_marks_interjection_processed():
+    """Same approval cannot fire execute twice."""
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "parked", blocker="x")
+    _add_approve(rid)
+
+    first = _find_approved_parked_propose("max")
+    second = _find_approved_parked_propose("max")
+    assert first is not None
+    assert second is None
+
+
+def test_find_approved_is_agent_scoped():
+    rid = _make_run("jeffy", "ECD-J", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "parked", blocker="x")
+    _add_approve(rid)
+    assert _find_approved_parked_propose("max") is None
+
+
+def test_find_approved_respects_approval_window():
+    rid = _make_run("max", "ECD-1", state="completed",
+                    ended_at=datetime.now(timezone.utc) - timedelta(hours=30))
+    _add_dossier(rid, "parked", blocker="x")
+    _add_approve(rid)
+    assert _find_approved_parked_propose("max") is None
+
+
+def test_build_execute_brief_inlines_plan_and_details():
+    payload = {
+        "details": "## Summary\n\nDo the thing.",
+        "plan": [
+            {"step": "Step one", "status": "pending"},
+            {"step": "Step two", "status": "pending"},
+        ],
+    }
+    brief = _build_execute_brief("ECD-100", payload)
+    assert "Ticket: ECD-100" in brief
+    assert "Step one" in brief
+    assert "Step two" in brief
+    assert "Do the thing." in brief
+    assert "run_acceptance" in brief
+    assert "pre_push" in brief
+
+
+def test_build_execute_brief_handles_missing_fields():
+    brief = _build_execute_brief(None, {})
+    assert "(no ticket)" in brief
+    assert "(no plan steps in propose)" in brief
+    assert "(no details captured)" in brief
+
+
+def test_create_execute_run_preseeds_acceptance_onto_new_run(tmp_path):
+    """The hand carries the acceptance contract forward so H8's hook can find it."""
+    init_db()
+    payload = {
+        "plan": [{"step": "x", "status": "pending"}],
+        "acceptance": [
+            {"kind": "unit_test", "name": "p", "cmd": "pytest", "pass_pattern": "passed"},
+        ],
+        "details": "## Summary\n\nx",
+    }
+    new_id = _create_execute_run(
+        agent="max", cwd=tmp_path, ticket="ECD-100",
+        brief="x", parked_payload=payload,
+    )
+    with db_session() as db:
+        run = db.query(Run).filter_by(id=new_id).one()
+        assert run.agent == "max"
+        assert run.ticket == "ECD-100"
+        assert run.state == "planning"
+
+        latest = (
+            db.query(Dossier)
+            .filter_by(run_id=new_id)
+            .order_by(Dossier.created_at.desc())
+            .first()
+        )
+        seeded = json.loads(latest.payload_json)
+        assert seeded["acceptance"][0]["name"] == "p"
+        assert "Execute step initiated" in seeded["just_did"]
+
+
+@pytest.mark.asyncio
+async def test_hand_fires_execute_when_approval_detected(tmp_path):
+    """End-to-end loop check: parked + approve → execute_fn invoked."""
+    rid = _make_run("testhand", "ECD-X", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "parked", blocker="x",
+                  plan=[{"step": "do", "status": "pending"}])
+    _add_approve(rid)
+
+    captured = {"executed": None}
+    async def fake_execute(approved):
+        captured["executed"] = approved.propose_run.ticket
+
+    hand = RanchHand(
+        "testhand", tmp_path, poll_seconds=0.01,
+        triage_fn=lambda p: [],
+        scope_fn=lambda k: None,
+        propose_fn=AsyncMock(),
+        execute_fn=fake_execute,
+    )
+
+    async def stop():
+        await asyncio.sleep(0.05)
+        hand.stop_requested = True
+
+    await asyncio.gather(hand.run(), stop())
+    assert captured["executed"] == "ECD-X"
+
+
+@pytest.mark.asyncio
+async def test_hand_skips_triage_when_execute_just_fired(tmp_path):
+    """The cycle that fires execute shouldn't also triage — that would
+    duplicate work for the operator to untangle."""
+    rid = _make_run("testhand", "ECD-X", state="completed",
+                    ended_at=datetime.now(timezone.utc))
+    _add_dossier(rid, "parked", blocker="x")
+    _add_approve(rid)
+
+    triage_calls = {"n": 0}
+    def triage_fn(_p):
+        triage_calls["n"] += 1
+        return []
+
+    async def fake_execute(_approved):
+        pass
+
+    hand = RanchHand(
+        "testhand", tmp_path, poll_seconds=0.01,
+        triage_fn=triage_fn,
+        scope_fn=lambda k: None,
+        propose_fn=AsyncMock(),
+        execute_fn=fake_execute,
+    )
+
+    async def stop():
+        await asyncio.sleep(0.05)
+        hand.stop_requested = True
+
+    await asyncio.gather(hand.run(), stop())
+    # Triage may have been called on subsequent cycles AFTER execute fired
+    # (since execute consumed the parked-with-approval state). But it should
+    # NOT have been called in the SAME cycle as the execute fire — we test
+    # this by checking the approve interjection was consumed exactly once.
+    with db_session() as db:
+        approved = db.query(Interjection).filter_by(run_id=rid, kind="approve").one()
+    assert approved.processed_at is not None
+
+
+# ─── Orchestrator per-kind auto-approve ──────────────────────────
+
+
+def test_orchestrator_auto_approve_kinds_overrides_blanket():
+    """auto_approve_kinds wins over auto_approve flag for the listed kinds."""
+    from ranch.runner.orchestrator import Orchestrator
+    orch = Orchestrator(
+        agent="x", cwd=Path("/tmp"), ticket="t", brief="b",
+        auto_approve=False,
+        auto_approve_kinds={"plan_ready"},
+    )
+    assert orch.auto_approve_kinds == {"plan_ready"}
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_on_checkpoint_only_auto_fires_listed_kinds():
+    from ranch.runner.orchestrator import Orchestrator
+    init_db()
+    with db_session() as db:
+        run = Run(agent="x", ticket="t", cwd="/tmp", initial_prompt="b", state="planning")
+        db.add(run); db.flush()
+        rid = run.id
+
+    orch = Orchestrator(
+        agent="x", cwd=Path("/tmp"), ticket="t", brief="b",
+        auto_approve_kinds={"plan_ready"},
+    )
+    orch.run_id = rid
+
+    # plan_ready: should auto-fire approval
+    await orch.on_checkpoint("plan_ready", "ok", None)
+    assert orch._approval_ready.is_set()
+    orch._approval_ready.clear()
+    orch._approval_result = None
+
+    # pre_push: should NOT auto-fire
+    await orch.on_checkpoint("pre_push", "ok", None)
+    assert not orch._approval_ready.is_set()


### PR DESCRIPTION
## Summary

Closes the last manual seam in the autonomous loop. Hand polls for \`approve\` interjections on parked-completed propose runs; when it finds one, fires a structured execute orchestrator with the carried-forward plan + acceptance contract. \`plan_ready\` and \`tests_green\` auto-approve (already vetted at propose); \`pre_push\` remains a real operator gate.

Stacked on #94 (H10).

## The full loop, now end-to-end

```
hand triage → scope → propose → park
  ↓ (operator: ranch approve <run_id>)
hand detects approval → fires execute (new Run.id, carried acceptance)
  ↓ (auto-approve plan_ready + tests_green)
agent codes + calls run_acceptance + iterates until green
  ↓ (parks at pre_push — REAL operator gate)
operator: ranch approve <execute_run_id> → push → ranch pr open
```

## Architecture decisions

**Existing Interjection table, no new schema.** Approval flows through the primitive ranch already has (\`ranch approve <run_id>\` writes a row). Hand consumes it in-transaction so the same approval cannot double-fire. The 24h window from H11 v1 is what makes parked + approve different from parked alone — older approvals fall outside the window.

**Per-kind auto-approve on Orchestrator.** New \`auto_approve_kinds: set[str] | None\` kwarg gives proper "this gate is human, that one isn't" semantics. \`auto_approve=True\` stays as the blanket "all kinds" shorthand. Default behavior unchanged. Lets us auto-approve plan_ready and tests_green (the plan was already vetted at propose) while preserving pre_push as a real human review.

**Carried-forward contract via pre-seeded dossier.** The execute run is a brand-new \`Run.id\`. To avoid leaking the acceptance JSON into the brief, the hand pre-seeds the new run's first \`Dossier\` row with the propose dossier's plan + acceptance + details. H8's \`run_acceptance\` hook finds the contract on its own without inline data.

**Execute budget.** \`RanchHand.execute_budget_seconds\` (default 600) caps the execute orchestrator so a hung \`pre_push\` doesn't block the daemon forever. Wires into the existing budget watchdog from H6.

## Tier-2 validation ✓

Real auto-execute against a pre-seeded parked propose + approve interjection:

| Check | Result |
|---|---|
| Runs created (propose + execute) | 2 ✓ |
| Approve interjection consumed exactly once | ✓ (processed_at set) |
| Execute run's first dossier carries acceptance | ✓ (3 checks) |
| plan_ready auto-approved | ✓ ("auto-approve fired for plan_ready") |
| Agent wrote file + called run_acceptance | ✓ |
| All 3 acceptance checks green | ✓ |
| pre_push parked with REAL gate | ✓ ("Waiting for: !approve | !reject | !stop (gate: pre_push)") |
| Budget watchdog terminated cleanly | ✓ (180s test cap) |
| Independent acceptance re-run | ✓ PASS 3/3 |

## Test plan

- [x] 14 new tests covering: find-approved variants (no runs / parked-but-no-approval / approval-but-not-parked / both / processed-once / agent-scoped / window), build_brief (full inputs + missing fields), create_execute_run (pre-seeded acceptance + plan + details), full loop fires execute_fn on approval, orchestrator per-kind auto-approve precedence + behavior
- [x] **Full suite: 323 passed**
- [x] **Tier-2 real-agent end-to-end validation** (see above)

## Notes for review

- \`_find_approved_parked_propose\` consumes the interjection in the same transaction as the lookup — atomic, no double-fire race.
- The execute orchestrator runs in **structured workflow** (\`free=False\`), not free mode. The agent gets the full plan_ready → tests_green → pre_push ceremony so the operator sees a complete checkpoint history when reviewing pre_push.
- \`execute_fn\` is an injection seam mirroring \`triage_fn\` / \`scope_fn\` / \`propose_fn\` — tests use a fake; production gets \`_default_execute\`.
- This is **v2 mini**. v2 full adds multi-ticket juggling and webhook-triggered approvals. The current PR is the smallest delta to "loop closes itself" — and it does.

Closes the v2-mini scope of #81. Multi-ticket juggling stays open as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)