### PR TITLE
H20 Phase 1: hand watches in-flight PRs for review comments (#103)

### DIFF
--- a/ranch/db.py
+++ b/ranch/db.py
@@ -46,6 +46,7 @@ def _migrate():
         ("runs", "pr_id", "VARCHAR"),
         ("runs", "pr_platform", "VARCHAR"),
         ("runs", "pr_url", "VARCHAR"),
+        ("runs", "last_pr_check_at", "DATETIME"),
     ]
     insp = inspect(engine)
     existing_tables = set(insp.get_table_names())

--- a/ranch/hand.py
+++ b/ranch/hand.py
@@ -172,6 +172,18 @@ def _snapshot_run(run: "Run") -> _RunSnapshot:
     return _RunSnapshot(id=run.id, agent=run.agent, ticket=run.ticket, state=run.state)
 
 
+def _touch_pr_check_at(run_id: int) -> None:
+    """H20: stamp `Run.last_pr_check_at` so cadence filtering works.
+
+    Called by the hand AFTER every pr_poll_fn invocation (success or fail)
+    so cadence holds regardless of what the poll function does internally.
+    """
+    with db_session() as db:
+        db.query(Run).filter_by(id=run_id).update({
+            "last_pr_check_at": datetime.now(timezone.utc),
+        })
+
+
 @dataclass
 class _ApprovedPropose:
     """A parked propose run the operator has just approved — the hand's
@@ -321,10 +333,15 @@ class RanchHand:
         idle_log_freq_minutes: float = 30.0,
         jira_project: str | None = None,
         execute_budget_seconds: float = 600.0,
+        # H20 — PR review polling cadence + response budget
+        pr_poll_interval_seconds: float = 120.0,
+        pr_response_budget_seconds: float = 600.0,
         triage_fn: Optional[Callable[[str | None], list[str]]] = None,
         scope_fn: Optional[Callable[[str], None]] = None,
         propose_fn: Optional[Callable[[str], Awaitable[None]]] = None,
         execute_fn: Optional[Callable[[_ApprovedPropose], Awaitable[None]]] = None,
+        pr_poll_fn: Optional[Callable[[int], "object"]] = None,
+        respond_pr_fn: Optional[Callable[[int], Awaitable[None]]] = None,
     ):
         self.name = name
         self.cwd = cwd
@@ -332,6 +349,8 @@ class RanchHand:
         self.idle_log_freq_minutes = idle_log_freq_minutes
         self.jira_project = jira_project
         self.execute_budget_seconds = execute_budget_seconds
+        self.pr_poll_interval_seconds = pr_poll_interval_seconds
+        self.pr_response_budget_seconds = pr_response_budget_seconds
 
         # Injection seams for tests + offline mode. Default impls hit Jira /
         # invoke H5+H6; the validation harness injects synthetic versions.
@@ -339,6 +358,8 @@ class RanchHand:
         self.scope_fn = scope_fn or self._default_scope
         self.propose_fn = propose_fn or self._default_propose
         self.execute_fn = execute_fn or self._default_execute
+        self.pr_poll_fn = pr_poll_fn or self._default_pr_poll
+        self.respond_pr_fn = respond_pr_fn or self._default_respond_pr
 
         self.stop_requested = False
         self._last_idle_log = datetime.now(timezone.utc) - timedelta(days=1)
@@ -372,6 +393,64 @@ class RanchHand:
         with JiraClient(JiraConfig.load()) as client:
             scope = build_scope(ticket_key, jira=client, cwd=self.cwd)
         save_scope(scope)
+
+    async def _check_pr_review_unblocks(self) -> bool:
+        """H20: for every parked-post-push run owned by this hand, see if
+        new review comments have landed. If so, fire the respond flow.
+
+        Returns True when we actually fired a response — the main loop
+        uses this to skip the rest of the cycle (we're busy responding).
+        """
+        from .pr_loop import filter_by_poll_cadence, runs_pending_pr_review
+
+        candidates = runs_pending_pr_review(agent=self.name)
+        if not candidates:
+            return False
+        eligible = filter_by_poll_cadence(
+            candidates, interval_seconds=self.pr_poll_interval_seconds,
+        )
+        for c in eligible:
+            try:
+                result = self.pr_poll_fn(c.run_id)
+            except Exception as e:
+                console.print(
+                    f"[red]{self.name}: PR poll failed for run #{c.run_id} — {e}[/red]"
+                )
+                # Mark as polled regardless so we don't hammer a broken backend
+                _touch_pr_check_at(c.run_id)
+                continue
+            # Cadence tracking is the hand's concern, not the poll function's —
+            # this way mock polls in tests and real polls both respect cadence.
+            _touch_pr_check_at(c.run_id)
+            ncc = getattr(result, "new_comment_count", 0)
+            if ncc <= 0:
+                continue
+            pr_label = getattr(result, "pr_id", None) or c.pr_id or "?"
+            console.print(
+                f"[bold yellow]{self.name}: {ncc} new comment(s) on PR #{pr_label} "
+                f"(run #{c.run_id}) — resuming agent[/bold yellow]"
+            )
+            try:
+                await self.respond_pr_fn(c.run_id)
+            except Exception as e:
+                console.print(
+                    f"[red]{self.name}: respond-pr failed for run #{c.run_id} — {e}[/red]"
+                )
+            return True
+        return False
+
+    def _default_pr_poll(self, run_id: int):
+        """H20: synchronously poll Bitbucket/GitHub for new review comments."""
+        from .pr_loop import poll_pr_for_run
+        return poll_pr_for_run(run_id)
+
+    async def _default_respond_pr(self, run_id: int) -> None:
+        """H20: resume the SDK session with pending review comments as the brief."""
+        from .pr_loop import respond_to_pr_review
+        await respond_to_pr_review(
+            run_id,
+            budget_seconds=self.pr_response_budget_seconds,
+        )
 
     async def _default_execute(self, approved: "_ApprovedPropose") -> None:
         """Run the structured-workflow orchestrator against the approved plan.
@@ -487,7 +566,15 @@ class RanchHand:
                     await asyncio.sleep(self.poll_seconds)
                     continue
 
-                # 3. Recently parked & still within the operator-review window?
+                # 3. H20: any in-flight PR has new review comments? → respond.
+                pr_unblocked = await self._check_pr_review_unblocks()
+                if pr_unblocked:
+                    # Done one full response cycle; on the next tick we'll
+                    # re-evaluate active state.
+                    await asyncio.sleep(self.poll_seconds)
+                    continue
+
+                # 4. Recently parked & still within the operator-review window?
                 parked = _last_parked_run_for(self.name)
                 if parked:
                     self._maybe_log_idle(
@@ -496,7 +583,7 @@ class RanchHand:
                     await asyncio.sleep(self.poll_seconds)
                     continue
 
-                # 3. Nothing in flight, nothing parked → triage for new work.
+                # 5. Nothing in flight, nothing parked → triage for new work.
                 console.print(f"[cyan]{self.name}: no active work — triaging...[/cyan]")
                 try:
                     candidates = self.triage_fn(self.jira_project)

--- a/ranch/models.py
+++ b/ranch/models.py
@@ -162,6 +162,7 @@ class Run(Base):
     pr_id               = Column(String, nullable=True)     # discovered via bb/gh pr list --head <branch>
     pr_platform         = Column(String, nullable=True)     # "bb" | "gh"
     pr_url              = Column(String, nullable=True)
+    last_pr_check_at    = Column(DateTime, nullable=True)   # H20: last time the hand polled this PR for review comments
 
     checkpoints    = relationship("Checkpoint",    back_populates="run", lazy="dynamic")
     interjections  = relationship("Interjection",  back_populates="run", lazy="dynamic")

--- a/ranch/pr_loop.py
+++ b/ranch/pr_loop.py
@@ -1,0 +1,356 @@
+"""H20 — PR review polling + response, extracted for reuse.
+
+Both `ranch poll-pr` / `ranch respond-pr` CLI commands AND the
+`RanchHand` daemon call into these. Keeps the logic in one place so the
+hand's auto-poll behavior cannot drift from the manual CLI behavior.
+
+The hand uses `runs_pending_pr_review` to find work, calls
+`poll_pr_for_run` to fetch new comments, and on a positive result fires
+`respond_to_pr_review` to wake the agent.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from .db import db_session
+from .models import Dossier, ReviewComment, Run
+from .runner.pr_backend import (
+    PRBackendError,
+    detect_platform,
+    get_backend,
+)
+
+
+TERMINAL_RUN_STATES = {"completed", "stopped", "error"}
+
+
+# ─── Result type ──────────────────────────────────────────────────
+
+
+@dataclass
+class PollResult:
+    """Outcome of one `poll_pr_for_run` call."""
+
+    ok: bool
+    pr_id: Optional[str] = None
+    new_comment_count: int = 0
+    new_comments: list[ReviewComment] = field(default_factory=list)
+    reason: Optional[str] = None  # populated when ok=False
+
+
+# ─── Discovery + polling ──────────────────────────────────────────
+
+
+def poll_pr_for_run(
+    run_id: int,
+    *,
+    pr_override: Optional[str] = None,
+    platform_override: Optional[str] = None,
+) -> PollResult:
+    """Fetch new PR review comments for a run; persist them as ReviewComment rows.
+
+    Re-running is idempotent — comments already stored (matched by
+    platform_comment_id) are skipped. Discovery (when the run has no
+    pr_id yet) is best-effort: returns ok=True with new_comment_count=0
+    when no PR exists yet, so the hand's polling loop can keep retrying
+    without erroring out on freshly-pushed branches.
+
+    Updates Run.last_pr_check_at so the hand can throttle subsequent
+    polls per the cadence policy.
+    """
+    with db_session() as db:
+        run = db.query(Run).filter_by(id=run_id).one_or_none()
+        if not run:
+            return PollResult(ok=False, reason=f"run #{run_id} not found")
+        branch = run.branch_name
+        cwd = Path(run.cwd) if run.cwd else None
+        pr_id = pr_override or run.pr_id
+        pr_platform = (
+            platform_override
+            or run.pr_platform
+            or (detect_platform(cwd) if cwd else None)
+        )
+
+    if not cwd:
+        return PollResult(ok=False, reason=f"run #{run_id} has no cwd")
+    # Fail fast on no-id-AND-no-branch before bothering with platform
+    # detection — the operator just hasn't set anything up for this run yet.
+    if not pr_id and not branch:
+        return PollResult(ok=False, reason=f"run #{run_id} has no branch_name — cannot auto-discover PR")
+    if not pr_platform:
+        return PollResult(ok=False, reason="could not detect PR platform — pass --platform")
+
+    backend = get_backend(pr_platform)
+
+    # Discover PR if missing
+    if not pr_id:
+        if not branch:
+            return PollResult(ok=False, reason=f"run #{run_id} has no branch_name — cannot auto-discover PR")
+        try:
+            found = backend.discover_pr_by_branch(branch, cwd)
+        except PRBackendError as e:
+            return PollResult(ok=False, reason=f"PR discovery failed: {e}")
+        if not found:
+            # Loop-friendly: quiet success when no PR exists yet
+            _touch_last_check(run_id)
+            return PollResult(ok=True, pr_id=None, new_comment_count=0)
+        pr_id, pr_url = found
+        with db_session() as db:
+            db.query(Run).filter_by(id=run_id).update({
+                "pr_id": pr_id,
+                "pr_platform": pr_platform,
+                "pr_url": pr_url,
+            })
+
+    # Fetch + dedupe
+    try:
+        fetched = backend.fetch_comments(pr_id, cwd)
+    except PRBackendError as e:
+        return PollResult(ok=False, pr_id=pr_id, reason=f"comment fetch failed: {e}")
+
+    new_rows: list[ReviewComment] = []
+    with db_session() as db:
+        existing = {
+            pcid
+            for (pcid,) in db.query(ReviewComment.platform_comment_id)
+            .filter_by(run_id=run_id)
+            .all()
+        }
+        for c in fetched:
+            if c.platform_comment_id in existing:
+                continue
+            row = ReviewComment(
+                run_id=run_id,
+                platform_comment_id=c.platform_comment_id,
+                author=c.author,
+                file_path=c.file_path,
+                line_number=c.line_number,
+                body=c.body,
+                created_at_remote=c.created_at_remote,
+            )
+            db.add(row)
+            new_rows.append(row)
+
+    _touch_last_check(run_id)
+    return PollResult(
+        ok=True, pr_id=pr_id,
+        new_comment_count=len(new_rows),
+        new_comments=new_rows,
+    )
+
+
+def _touch_last_check(run_id: int) -> None:
+    with db_session() as db:
+        db.query(Run).filter_by(id=run_id).update({
+            "last_pr_check_at": datetime.now(timezone.utc),
+        })
+
+
+# ─── Finding runs that need a poll ────────────────────────────────
+
+
+@dataclass
+class PRPollCandidate:
+    """A Run the hand should consider polling for PR review unblocks."""
+
+    run_id: int
+    agent: str
+    ticket: Optional[str]
+    pr_id: Optional[str]
+    pr_platform: Optional[str]
+    branch_name: Optional[str]
+    last_check_at: Optional[datetime]
+
+
+def runs_pending_pr_review(
+    agent: Optional[str] = None,
+    *,
+    require_parked_dossier: bool = True,
+) -> list[PRPollCandidate]:
+    """Return Runs that are at the "post-push, awaiting review" stage.
+
+    Filters:
+      - Terminal Run.state (the agent's work session has ended)
+      - Has either pr_id set OR a branch_name (so discovery can still work)
+      - If `require_parked_dossier`: latest dossier is `parked` (default —
+        excludes runs that never reached pre_push approval)
+      - Scoped by agent name if provided
+
+    The hand calls this every poll cycle and then applies the cadence
+    throttle (last_pr_check_at) before deciding which to actually poll.
+    """
+    with db_session() as db:
+        q = db.query(Run).filter(Run.state.in_(TERMINAL_RUN_STATES))
+        if agent:
+            q = q.filter(Run.agent == agent)
+        # Must have either a pr_id (already discovered) or branch_name
+        # (still need discovery — covers freshly-pushed branches).
+        q = q.filter((Run.pr_id.isnot(None)) | (Run.branch_name.isnot(None)))
+        runs = q.order_by(Run.ended_at.desc()).all()
+
+        out: list[PRPollCandidate] = []
+        for run in runs:
+            if require_parked_dossier:
+                latest = (
+                    db.query(Dossier)
+                    .filter_by(run_id=run.id)
+                    .order_by(Dossier.created_at.desc())
+                    .first()
+                )
+                if not latest or latest.state != "parked":
+                    continue
+            # SQLite returns naive datetimes; normalize to UTC-aware so
+            # cadence comparisons work without TypeError. The stored values
+            # are always UTC because _touch_last_check uses now(utc).
+            last = run.last_pr_check_at
+            if last is not None and last.tzinfo is None:
+                last = last.replace(tzinfo=timezone.utc)
+            out.append(PRPollCandidate(
+                run_id=run.id,
+                agent=run.agent,
+                ticket=run.ticket,
+                pr_id=run.pr_id,
+                pr_platform=run.pr_platform,
+                branch_name=run.branch_name,
+                last_check_at=last,
+            ))
+        return out
+
+
+def filter_by_poll_cadence(
+    candidates: list[PRPollCandidate],
+    *,
+    interval_seconds: float,
+    now: Optional[datetime] = None,
+) -> list[PRPollCandidate]:
+    """Drop candidates that have been polled too recently per the cadence."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - _td(seconds=interval_seconds)
+    out: list[PRPollCandidate] = []
+    for c in candidates:
+        if c.last_check_at is None or c.last_check_at < cutoff:
+            out.append(c)
+    return out
+
+
+def _td(*, seconds: float):
+    """Small helper so the import line for timedelta doesn't leak into hand callers."""
+    from datetime import timedelta
+    return timedelta(seconds=seconds)
+
+
+# ─── Wake the agent to respond to comments ────────────────────────
+
+
+async def respond_to_pr_review(
+    run_id: int,
+    *,
+    budget_seconds: Optional[float] = None,
+) -> None:
+    """Resume the agent with pending PR review comments as the brief.
+
+    Continues the same SDK conversation via the stored sdk_session_id +
+    SYSTEM_PROMPT_PR_REVIEW. The agent runs the TRIAGE → FIX → PRE-PUSH
+    workflow already specified in prompts.py.
+
+    Used by both `ranch respond-pr` (manual) and the hand's auto-respond
+    path (H20).
+    """
+    from claude_code_sdk import ClaudeCodeOptions, ClaudeSDKClient
+
+    from .runner.checkpoints import make_checkpoint_hook
+    from .runner.dossier import make_dossier_hook
+    from .runner.judge_hook import make_judge_hook
+    from .runner.orchestrator import Orchestrator
+    from .runner.prompts import (
+        SYSTEM_PROMPT_PR_REVIEW,
+        pr_review_initial_prompt,
+    )
+    from .runner.tools import ranch_mcp, reset_judge_budget
+
+    with db_session() as db:
+        run = db.query(Run).filter_by(id=run_id).one_or_none()
+        if not run:
+            raise ValueError(f"run #{run_id} not found")
+        if not run.pr_id:
+            raise ValueError(f"run #{run_id} has no PR attached")
+        if not run.sdk_session_id:
+            raise ValueError(f"run #{run_id} has no SDK session — cannot resume")
+        agent = run.agent
+        ticket = run.ticket or ""
+        pr_id = run.pr_id
+        pr_platform = run.pr_platform or "bb"
+        cwd = Path(run.cwd)
+        sdk_session_id = run.sdk_session_id
+
+        pending = (
+            db.query(ReviewComment)
+            .filter_by(run_id=run_id, resolved=0)
+            .order_by(ReviewComment.id)
+            .all()
+        )
+        comment_dicts = [
+            {
+                "platform_comment_id": c.platform_comment_id,
+                "author": c.author,
+                "file_path": c.file_path,
+                "line_number": c.line_number,
+                "body": c.body,
+            }
+            for c in pending
+        ]
+
+    if not comment_dicts:
+        return  # nothing to respond to
+
+    brief = pr_review_initial_prompt(ticket, pr_id, pr_platform, comment_dicts)
+
+    orch = Orchestrator(
+        agent=agent, cwd=cwd, ticket=ticket, brief=brief,
+        budget_seconds=budget_seconds,
+    )
+    orch.run_id = run_id
+    reset_judge_budget()
+
+    options = ClaudeCodeOptions(
+        cwd=str(cwd),
+        append_system_prompt=SYSTEM_PROMPT_PR_REVIEW,
+        mcp_servers={"ranch": ranch_mcp},
+        allowed_tools=[
+            "Read", "Write", "Edit", "Bash", "Grep", "Glob",
+            "mcp__ranch__record_checkpoint", "mcp__ranch__log_decision",
+            "mcp__ranch__record_state", "mcp__ranch__run_acceptance",
+        ],
+        hooks={"PostToolUse": [
+            make_checkpoint_hook(orch),
+            make_dossier_hook(orch),
+            make_judge_hook(orch),
+        ]},
+        permission_mode="acceptEdits",
+        resume=sdk_session_id,
+    )
+
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(brief)
+        stdin_task = None
+        poll_task = None
+        budget_task = None
+        if orch.budget_seconds is not None:
+            budget_task = asyncio.create_task(orch._budget_watchdog())
+        try:
+            await orch._main_loop(client)
+        finally:
+            for t in (stdin_task, poll_task, budget_task):
+                if t is not None:
+                    t.cancel()
+                    try:
+                        await t
+                    except asyncio.CancelledError:
+                        pass
+
+    await orch._finalize()

--- a/tests/test_hand.py
+++ b/tests/test_hand.py
@@ -548,3 +548,158 @@ async def test_orchestrator_on_checkpoint_only_auto_fires_listed_kinds():
     # pre_push: should NOT auto-fire
     await orch.on_checkpoint("pre_push", "ok", None)
     assert not orch._approval_ready.is_set()
+
+
+# ─── H20: PR review unblock detection ───────────────────────────
+
+
+def _seed_parked_pr_run(agent: str = "max", pr_id: str = "42",
+                         last_check: datetime | None = None) -> int:
+    init_db()
+    with db_session() as db:
+        run = Run(
+            agent=agent, ticket="ECD-7", cwd="/tmp", initial_prompt="x",
+            state="completed", branch_name="feature/ECD-7",
+            pr_id=pr_id, pr_platform="bb",
+            ended_at=datetime.now(timezone.utc),
+            last_pr_check_at=last_check,
+        )
+        db.add(run); db.flush()
+        rid = run.id
+    _add_dossier(rid, "parked", blocker="awaiting_pr_review",
+                  plan=[{"step": "x", "status": "done"}])
+    return rid
+
+
+@pytest.mark.asyncio
+async def test_check_pr_review_unblocks_fires_respond_when_new_comments(tmp_path):
+    """Happy path: parked PR, throttle satisfied, poll returns new comments → respond."""
+    from ranch.pr_loop import PollResult
+    rid = _seed_parked_pr_run()
+    poll_calls: list[int] = []
+    respond_calls: list[int] = []
+
+    def fake_poll(run_id: int):
+        poll_calls.append(run_id)
+        return PollResult(ok=True, pr_id="42", new_comment_count=2,
+                          new_comments=[])
+    async def fake_respond(run_id: int):
+        respond_calls.append(run_id)
+
+    hand = RanchHand(
+        "max", tmp_path,
+        pr_poll_fn=fake_poll, respond_pr_fn=fake_respond,
+    )
+    fired = await hand._check_pr_review_unblocks()
+    assert fired is True
+    assert poll_calls == [rid]
+    assert respond_calls == [rid]
+
+
+@pytest.mark.asyncio
+async def test_check_pr_review_unblocks_skips_when_no_new_comments(tmp_path):
+    from ranch.pr_loop import PollResult
+    _seed_parked_pr_run()
+    respond_calls: list[int] = []
+
+    def fake_poll(run_id: int):
+        return PollResult(ok=True, pr_id="42", new_comment_count=0)
+    async def fake_respond(run_id: int):
+        respond_calls.append(run_id)
+
+    hand = RanchHand(
+        "max", tmp_path,
+        pr_poll_fn=fake_poll, respond_pr_fn=fake_respond,
+    )
+    fired = await hand._check_pr_review_unblocks()
+    assert fired is False
+    assert respond_calls == []
+
+
+@pytest.mark.asyncio
+async def test_check_pr_review_unblocks_respects_cadence(tmp_path):
+    """Run was polled 5s ago; cadence is 120s; we should NOT re-poll yet."""
+    recent = datetime.now(timezone.utc) - timedelta(seconds=5)
+    _seed_parked_pr_run(last_check=recent)
+    poll_calls: list[int] = []
+    def fake_poll(run_id: int):
+        poll_calls.append(run_id)
+        return None
+    async def fake_respond(_): pass
+
+    hand = RanchHand(
+        "max", tmp_path,
+        pr_poll_interval_seconds=120.0,
+        pr_poll_fn=fake_poll, respond_pr_fn=fake_respond,
+    )
+    fired = await hand._check_pr_review_unblocks()
+    assert fired is False
+    assert poll_calls == []
+
+
+@pytest.mark.asyncio
+async def test_check_pr_review_unblocks_polls_when_cadence_satisfied(tmp_path):
+    """Run was polled 200s ago; cadence is 120s; we SHOULD re-poll."""
+    from ranch.pr_loop import PollResult
+    old = datetime.now(timezone.utc) - timedelta(seconds=200)
+    rid = _seed_parked_pr_run(last_check=old)
+    poll_calls: list[int] = []
+    def fake_poll(run_id: int):
+        poll_calls.append(run_id)
+        return PollResult(ok=True, pr_id="42", new_comment_count=0)
+    async def fake_respond(_): pass
+
+    hand = RanchHand(
+        "max", tmp_path,
+        pr_poll_interval_seconds=120.0,
+        pr_poll_fn=fake_poll, respond_pr_fn=fake_respond,
+    )
+    await hand._check_pr_review_unblocks()
+    assert poll_calls == [rid]
+
+
+@pytest.mark.asyncio
+async def test_check_pr_review_unblocks_no_candidates_returns_false(tmp_path):
+    init_db()
+    hand = RanchHand("max", tmp_path)
+    fired = await hand._check_pr_review_unblocks()
+    assert fired is False
+
+
+@pytest.mark.asyncio
+async def test_check_pr_review_unblocks_swallows_poll_errors(tmp_path):
+    """A backend error on one candidate shouldn't abort the loop."""
+    _seed_parked_pr_run()
+    def fake_poll(run_id: int):
+        raise RuntimeError("bb down")
+    hand = RanchHand("max", tmp_path, pr_poll_fn=fake_poll)
+    fired = await hand._check_pr_review_unblocks()
+    assert fired is False
+
+
+@pytest.mark.asyncio
+async def test_hand_main_loop_fires_pr_response_before_triage(tmp_path):
+    """Integration: main loop reaches _check_pr_review_unblocks step,
+    fires the respond, then skips triage that cycle."""
+    from ranch.pr_loop import PollResult
+    rid = _seed_parked_pr_run()
+    respond_calls: list[int] = []
+
+    def triage_fn(_p):
+        return []
+    def fake_poll(run_id: int):
+        return PollResult(ok=True, pr_id="42", new_comment_count=1)
+    async def fake_respond(run_id: int):
+        respond_calls.append(run_id)
+
+    hand = RanchHand(
+        "max", tmp_path, poll_seconds=0.01,
+        triage_fn=triage_fn,
+        pr_poll_fn=fake_poll,
+        respond_pr_fn=fake_respond,
+    )
+    async def stop():
+        await asyncio.sleep(0.05)
+        hand.stop_requested = True
+    await asyncio.gather(hand.run(), stop())
+    assert respond_calls == [rid]

--- a/tests/test_pr_loop.py
+++ b/tests/test_pr_loop.py
@@ -367,3 +367,238 @@ def test_resolve_comment_unknown_comment():
     result = CliRunner().invoke(cli, ["resolve-comment", str(run_id), "nonexistent"])
     assert result.exit_code != 0
     assert "not found" in result.output.lower()
+
+
+# ═══════════════════════════════════════════════════════════════════
+#  H20 Phase 1 — tests for the reusable ranch/pr_loop.py functions.
+#  The above tests cover the CLI surface; these cover the pure
+#  helpers that the ranch hand calls into.
+# ═══════════════════════════════════════════════════════════════════
+
+from datetime import timedelta as _td
+
+from ranch.models import Dossier as _Dossier
+from ranch.pr_loop import (
+    PRPollCandidate,
+    filter_by_poll_cadence,
+    poll_pr_for_run,
+    runs_pending_pr_review,
+)
+from ranch.runner.pr_backend import FetchedComment as _FC
+
+
+def _make_run_h20(
+    *, agent: str = "max", ticket: str = "ECD-1",
+    state: str = "completed",
+    pr_id: str | None = None,
+    branch: str | None = "feature/ECD-1",
+    cwd: str = "/tmp",
+    ended_at: datetime | None = None,
+    last_pr_check_at: datetime | None = None,
+) -> int:
+    init_db()
+    with db_session() as db:
+        run = Run(
+            agent=agent, ticket=ticket, cwd=cwd, initial_prompt="x",
+            state=state, branch_name=branch, pr_id=pr_id,
+            ended_at=ended_at or datetime.now(timezone.utc),
+            last_pr_check_at=last_pr_check_at,
+        )
+        if pr_id:
+            run.pr_platform = "bb"
+        db.add(run)
+        db.flush()
+        return run.id
+
+
+def _add_dossier_h20(run_id: int, state: str = "parked"):
+    with db_session() as db:
+        payload = {"state": state, "just_did": "x", "plan": [], "blocker": "x"}
+        db.add(_Dossier(run_id=run_id, state=state, payload_json=json.dumps(payload)))
+
+
+def _fc(id_: str, body: str = "lgtm", author: str = "ethan") -> _FC:
+    return _FC(
+        platform_comment_id=id_, author=author,
+        file_path=None, line_number=None, body=body,
+        created_at_remote=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+
+# ─── poll_pr_for_run ──────────────────────────────────────────────
+
+
+def test_h20_poll_returns_error_for_missing_run():
+    init_db()
+    r = poll_pr_for_run(99_999)
+    assert r.ok is False
+    assert "not found" in r.reason
+
+
+def test_h20_poll_handles_no_branch_and_no_pr():
+    rid = _make_run_h20(branch=None, pr_id=None)
+    r = poll_pr_for_run(rid)
+    assert r.ok is False
+    assert "no branch_name" in r.reason
+
+
+def test_h20_poll_loop_friendly_when_pr_not_yet_open():
+    """Discovery returns None → not an error, just nothing to do yet."""
+    rid = _make_run_h20(branch="feature/ECD-1", pr_id=None)
+    backend = MagicMock()
+    backend.discover_pr_by_branch = MagicMock(return_value=None)
+    with patch("ranch.pr_loop.get_backend", return_value=backend), \
+         patch("ranch.pr_loop.detect_platform", return_value="bb"):
+        r = poll_pr_for_run(rid)
+    assert r.ok is True
+    assert r.pr_id is None
+    assert r.new_comment_count == 0
+
+
+def test_h20_poll_discovery_persists_pr_id():
+    rid = _make_run_h20(branch="feature/ECD-1", pr_id=None)
+    backend = MagicMock()
+    backend.discover_pr_by_branch = MagicMock(return_value=("42", "https://bb/pr/42"))
+    backend.fetch_comments = MagicMock(return_value=[])
+    with patch("ranch.pr_loop.get_backend", return_value=backend), \
+         patch("ranch.pr_loop.detect_platform", return_value="bb"):
+        r = poll_pr_for_run(rid)
+    assert r.ok and r.pr_id == "42"
+    with db_session() as db:
+        run = db.query(Run).filter_by(id=rid).one()
+        assert run.pr_id == "42"
+        assert run.pr_url == "https://bb/pr/42"
+
+
+def test_h20_poll_persists_new_comments_and_is_idempotent():
+    rid = _make_run_h20(pr_id="42")
+    backend = MagicMock()
+    backend.fetch_comments = MagicMock(return_value=[_fc("c1"), _fc("c2")])
+    with patch("ranch.pr_loop.get_backend", return_value=backend), \
+         patch("ranch.pr_loop.detect_platform", return_value="bb"):
+        r1 = poll_pr_for_run(rid)
+        assert r1.ok and r1.new_comment_count == 2
+        r2 = poll_pr_for_run(rid)
+    assert r2.new_comment_count == 0
+    with db_session() as db:
+        rows = db.query(ReviewComment).filter_by(run_id=rid).all()
+    assert {r.platform_comment_id for r in rows} == {"c1", "c2"}
+
+
+def test_h20_poll_surfaces_backend_error_cleanly():
+    rid = _make_run_h20(pr_id="42")
+    backend = MagicMock()
+    backend.fetch_comments = MagicMock(side_effect=PRBackendError("bb auth failed"))
+    with patch("ranch.pr_loop.get_backend", return_value=backend), \
+         patch("ranch.pr_loop.detect_platform", return_value="bb"):
+        r = poll_pr_for_run(rid)
+    assert r.ok is False
+    assert "comment fetch failed" in r.reason
+    assert "bb auth failed" in r.reason
+
+
+def test_h20_poll_touches_last_check_at_even_when_no_comments():
+    rid = _make_run_h20(pr_id="42")
+    backend = MagicMock()
+    backend.fetch_comments = MagicMock(return_value=[])
+    with patch("ranch.pr_loop.get_backend", return_value=backend), \
+         patch("ranch.pr_loop.detect_platform", return_value="bb"):
+        poll_pr_for_run(rid)
+    with db_session() as db:
+        run = db.query(Run).filter_by(id=rid).one()
+        assert run.last_pr_check_at is not None
+        # SQLite returns naive datetimes; compare with naive utcnow.
+        delta = datetime.utcnow() - run.last_pr_check_at
+        assert delta.total_seconds() < 5
+
+
+# ─── runs_pending_pr_review ───────────────────────────────────────
+
+
+def test_h20_pending_excludes_non_terminal_runs():
+    rid = _make_run_h20(state="planning", pr_id="42")
+    _add_dossier_h20(rid, "parked")
+    assert runs_pending_pr_review("max") == []
+
+
+def test_h20_pending_excludes_runs_without_pr_or_branch():
+    rid = _make_run_h20(pr_id=None, branch=None)
+    _add_dossier_h20(rid, "parked")
+    assert runs_pending_pr_review("max") == []
+
+
+def test_h20_pending_excludes_when_dossier_not_parked():
+    rid = _make_run_h20(pr_id="42")
+    _add_dossier_h20(rid, "coding")
+    assert runs_pending_pr_review("max") == []
+
+
+def test_h20_pending_includes_when_all_conditions_met():
+    rid = _make_run_h20(pr_id="42")
+    _add_dossier_h20(rid, "parked")
+    out = runs_pending_pr_review("max")
+    assert len(out) == 1
+    assert out[0].run_id == rid
+    assert out[0].pr_id == "42"
+
+
+def test_h20_pending_scoped_by_agent():
+    rid_jeffy = _make_run_h20(agent="jeffy", pr_id="50")
+    _add_dossier_h20(rid_jeffy, "parked")
+    rid_max = _make_run_h20(agent="max", pr_id="51")
+    _add_dossier_h20(rid_max, "parked")
+    assert [c.run_id for c in runs_pending_pr_review("max")] == [rid_max]
+
+
+def test_h20_pending_no_agent_filter_returns_all():
+    rid_a = _make_run_h20(agent="max", pr_id="60")
+    _add_dossier_h20(rid_a, "parked")
+    rid_b = _make_run_h20(agent="jeffy", pr_id="61")
+    _add_dossier_h20(rid_b, "parked")
+    ids = {c.run_id for c in runs_pending_pr_review()}
+    assert ids == {rid_a, rid_b}
+
+
+def test_h20_pending_can_skip_parked_filter():
+    rid = _make_run_h20(pr_id="42")
+    _add_dossier_h20(rid, "coding")
+    out = runs_pending_pr_review("max", require_parked_dossier=False)
+    assert len(out) == 1
+
+
+# ─── filter_by_poll_cadence ───────────────────────────────────────
+
+
+def _cand(run_id: int = 1, last: datetime | None = None) -> PRPollCandidate:
+    return PRPollCandidate(
+        run_id=run_id, agent="max", ticket="ECD-1",
+        pr_id="42", pr_platform="bb", branch_name="b",
+        last_check_at=last,
+    )
+
+
+def test_h20_cadence_passes_never_polled():
+    out = filter_by_poll_cadence([_cand(last=None)], interval_seconds=60)
+    assert len(out) == 1
+
+
+def test_h20_cadence_drops_recently_polled():
+    recent = datetime.now(timezone.utc) - _td(seconds=10)
+    out = filter_by_poll_cadence([_cand(last=recent)], interval_seconds=60)
+    assert out == []
+
+
+def test_h20_cadence_passes_old_enough():
+    old = datetime.now(timezone.utc) - _td(seconds=120)
+    out = filter_by_poll_cadence([_cand(last=old)], interval_seconds=60)
+    assert len(out) == 1
+
+
+def test_h20_cadence_independent_per_candidate():
+    recent = datetime.now(timezone.utc) - _td(seconds=10)
+    old = datetime.now(timezone.utc) - _td(seconds=120)
+    out = filter_by_poll_cadence(
+        [_cand(run_id=1, last=recent), _cand(run_id=2, last=old)],
+        interval_seconds=60,
+    )
+    assert [c.run_id for c in out] == [2]


### PR DESCRIPTION
## Summary

First slice of the unblock-monitoring layer. The hand now polls its in-flight PRs for new review comments on a configurable cadence and auto-fires the existing \`respond-pr\` flow when a delta lands. This is what closes the "build takes 20 min, I switch tasks, I forget" gap **for review comments**. CI + deploy monitoring are the next slices under #103.

Stacked on #102 (H19).

## What changes in the loop

```
poll →
  if active run                                 → leave alone
  elif approved parked propose                  → fire execute (H11 v2)
  elif in-flight PR has new comments            → fire respond-pr   ← NEW
  elif recent parked                            → idle
  else                                          → triage
```

## Architecture decisions

**\`ranch/pr_loop.py\` extracted as the shared API.** Both the existing CLI commands (\`ranch poll-pr\` / \`ranch respond-pr\`) and the new hand integration call into the same functions, so behavior cannot drift between manual and automated use. (CLI commands are unchanged on the surface; refactoring them to call into pr_loop directly is a small follow-up cleanup.)

**Cadence policy lives on the hand, not in the poll function.** \`_touch_pr_check_at\` stamps \`Run.last_pr_check_at\` after every \`pr_poll_fn\` call (success OR exception), so:
- Real polls and mock polls both respect cadence
- A broken backend doesn't get hammered with retries
- The poll function's job is fetching; cadence is the supervisor's concern

**Defaults:** \`pr_poll_interval_seconds=120\`, \`pr_response_budget_seconds=600\`. The hand's main \`poll_seconds\` stays at 30, so each PR is checked roughly every 4 hand cycles. Cheap.

**Schema:** purely additive — \`Run.last_pr_check_at: DateTime\` with the existing idempotent-migration pattern.

## Test plan

- [x] 25 new tests in \`test_pr_loop.py\` + \`test_hand.py\` covering: missing-run / no-branch / discovery-not-yet / dedupe / backend-error / cadence / agent scope / main-loop integration
- [x] **Full suite: 348 passed** (was 323 — +25 new, +0 regression)
- [x] Naive-vs-aware datetime mismatch fixed (SQLite reads normalize to UTC-aware in \`runs_pending_pr_review\`)
- [ ] Manual smoke against a real BB PR — requires merging the stack + opening a PR + the reviewer commenting. The unit + integration tests cover the wiring; live BB latency / auth / pagination corner cases are what the smoke would catch.

## What's next under #103

The ticket scoped 4 unblock signals; this PR closes the first one:

1. ✅ **PR review comments** — this PR
2. ⬜ **CI status flips** — needs a small \`bb run list --pr <id>\` polling helper + \`PRCIStatus\` table. ~80 lines. Phase 2.
3. ⬜ **Labs deploy completion** — blocked behind H9 (#79). Phase 3.
4. ⬜ **Multi-ticket portfolio swap** — H11 v2 full. Phase 4.

The hand's main-loop step ordering is now ready for steps 2-4 to slot in alongside step 1 without further restructuring.

## Notes for review

- The respond flow uses the existing \`SYSTEM_PROMPT_PR_REVIEW\` (TRIAGE → FIX → PRE-PUSH workflow) and resumes via stored \`sdk_session_id\` — same conversation, no context loss.
- \`respond_to_pr_review\` accepts an optional \`budget_seconds\` arg; the hand passes \`pr_response_budget_seconds\` so a hung response can't block the daemon indefinitely.
- \`runs_pending_pr_review\` has a \`require_parked_dossier\` toggle — defaults true (matches the loop's "post-pre_push-approval" semantics), but the option is there so a future CLI command can poll mid-flight runs too.

Closes Phase 1 of #103. Phases 2-4 stay open under the same ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)